### PR TITLE
Use environment variable for backend URL

### DIFF
--- a/src/common/components/user/UsersList.tsx
+++ b/src/common/components/user/UsersList.tsx
@@ -57,7 +57,7 @@ export default function UsersList() {
     const fetchUsers = async () => {
       try {
         const token = localStorage.getItem('authToken');
-        const baseUrl = 'http://localhost:5050'; // Base URL for development
+        const baseUrl = import.meta.env.VITE_APP_BACKEND_URL;
         const response = await fetch(
           `${baseUrl}/auth/users`,
           {

--- a/src/common/hooks/clients/useClients.ts
+++ b/src/common/hooks/clients/useClients.ts
@@ -1,7 +1,7 @@
 // src/common/hooks/clients/useClients.ts
 import {
-  getSessionExpirationMessage,
-  isSessionExpiredError,
+    getSessionExpirationMessage,
+    isSessionExpiredError,
 } from '@/common/utils/sessionUtils';
 import type { Client } from '@/features/pipeline/data/schema';
 import { useCallback, useState } from 'react';
@@ -16,7 +16,7 @@ export function useClients() {
     setError(null);
 
     try {
-      const BASE = 'http://localhost:5050'; // Base URL for development
+      const BASE = import.meta.env.VITE_APP_BACKEND_URL;
       const token = localStorage.getItem('authToken');
 
       const res = await fetch(`${BASE}/clients`, {
@@ -93,7 +93,7 @@ export function useClients() {
     setError(null);
 
     try {
-      const BASE = 'http://localhost:5050'; // Base URL for development
+      const BASE = import.meta.env.VITE_APP_BACKEND_URL;
       const response = await fetch(
         `${BASE}/clients/${id}?detailed=${detailed}`,
         {

--- a/src/common/hooks/user/useSaveUser.ts
+++ b/src/common/hooks/user/useSaveUser.ts
@@ -7,7 +7,7 @@ export default async function useSaveUser(userData: User) {
   );
   try {
     const token = localStorage.getItem('authToken');
-    const baseUrl = 'http://localhost:5050'; // Base URL for development
+    const baseUrl = import.meta.env.VITE_APP_BACKEND_URL;
     const response = await fetch(
       `${baseUrl}/users/update`,
       {

--- a/src/features/contracts/components/pdf/PdfPreview.tsx
+++ b/src/features/contracts/components/pdf/PdfPreview.tsx
@@ -25,7 +25,7 @@ export function PdfPreview() {
         console.log(selectedTemplateName);
         const token = localStorage.getItem('authToken');
         const res = await fetch(
-          `http://localhost:5050/contracts/templates/generate`,
+          `${import.meta.env.VITE_APP_BACKEND_URL}/contracts/templates/generate`,
           {
             method: 'POST',
             headers: {


### PR DESCRIPTION
Replaced hardcoded 'http://localhost:5050' backend URLs with import.meta.env.VITE_APP_BACKEND_URL in user, client, and PDF preview components and hooks. This change improves configuration flexibility for different environments.

<!-- Describe your changes in detail -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published
