### PR TITLE
Add client deletion logic and improve dialogs

### DIFF
--- a/src/common/utils/deleteClient.test.ts
+++ b/src/common/utils/deleteClient.test.ts
@@ -1,0 +1,69 @@
+import { vi } from 'vitest';
+import deleteClient from './deleteClient';
+
+global.fetch = vi.fn();
+
+const mockLocalStorage = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+  removeItem: vi.fn(),
+};
+Object.defineProperty(window, 'localStorage', {
+  value: mockLocalStorage,
+});
+
+describe('deleteClient', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLocalStorage.getItem.mockReturnValue('mock-token');
+  });
+
+  it('should call DELETE /clients/delete with client ID in body and return success on 204', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      status: 204,
+      ok: true,
+      text: async () => '',
+    });
+    const result = await deleteClient('123');
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining('/clients/delete'),
+      expect.objectContaining({
+        method: 'DELETE',
+        headers: expect.objectContaining({
+          Authorization: 'Bearer mock-token',
+          'Content-Type': 'application/json',
+        }),
+        body: JSON.stringify({ id: '123' }),
+      })
+    );
+    expect(result).toEqual({ success: true });
+  });
+
+  it('should call DELETE /clients/delete and return success on 200 OK', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      status: 200,
+      ok: true,
+      text: async () => '',
+    });
+    const result = await deleteClient('456');
+    expect(result).toEqual({ success: true });
+  });
+
+  it('should handle error response', async () => {
+    (global.fetch as any).mockResolvedValueOnce({
+      status: 400,
+      ok: false,
+      text: async () => 'Bad Request',
+    });
+    const result = await deleteClient('789');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('400');
+  });
+
+  it('should handle network error', async () => {
+    (global.fetch as any).mockRejectedValueOnce(new Error('Network error'));
+    const result = await deleteClient('999');
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Network error');
+  });
+}); 

--- a/src/common/utils/deleteClient.ts
+++ b/src/common/utils/deleteClient.ts
@@ -1,0 +1,61 @@
+import {
+  getSessionExpirationMessage,
+  isSessionExpiredError,
+} from './sessionUtils';
+
+export default async function deleteClient(
+  clientId: string
+): Promise<{ success: boolean; error?: string }> {
+  const token = localStorage.getItem('authToken');
+
+  // Debug logging
+  console.log('🚨 DEBUG START - Client Delete');
+  console.log('🚨 Client ID:', clientId);
+  console.log('🚨 Client ID type:', typeof clientId);
+  console.log('🚨 Auth Token:', token ? 'Present' : 'Missing');
+  console.log(
+    '🚨 Full request URL:',
+    `${import.meta.env.VITE_APP_BACKEND_URL}/clients/delete`
+  );
+
+  try {
+    const baseUrl =
+      import.meta.env.VITE_APP_BACKEND_URL || '';
+    const cleanBaseUrl = baseUrl.replace(/\/+$/, ''); // Remove trailing slashes
+    const url = `${cleanBaseUrl}/clients/delete`;
+    const response = await fetch(url, {
+      method: 'DELETE',
+      credentials: 'include',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ id: clientId }),
+    });
+
+    if (response.status === 204 || response.ok) {
+      // Success: No Content or OK
+      console.log('✅ Client deleted successfully');
+      return { success: true };
+    }
+
+    // Handle errors
+    const errorText = await response.text();
+    console.error('❌ Client delete failed:', response.status, errorText);
+
+    // Check for authentication/session expiration errors
+    if (isSessionExpiredError(response.status, errorText)) {
+      throw new Error(getSessionExpirationMessage());
+    }
+
+    throw new Error(
+      `Failed to delete client: ${response.status} - ${errorText}`
+    );
+  } catch (err) {
+    console.error("❌ Couldn't delete client: ", err);
+    return {
+      success: false,
+      error: err instanceof Error ? err.message : 'Unknown error',
+    };
+  }
+} 

--- a/src/features/clients/components/dialog/TableDialogs.tsx
+++ b/src/features/clients/components/dialog/TableDialogs.tsx
@@ -1,3 +1,4 @@
+import { useClientsContext } from '@/features/clients/contexts/ClientsContext';
 import { useTable } from '@/features/clients/contexts/TableContext';
 import { ArchiveClientDialog } from './ArchiveClientDialog';
 import { ContractCreationDialog } from './ContractCreationDialog';
@@ -5,6 +6,8 @@ import { DeleteClientDialog } from './DeleteClientDialog';
 
 export function TableDialogs() {
   const { open, setOpen, currentRow, setCurrentRow } = useTable();
+  const { refreshClients } = useClientsContext();
+
   return (
     <>
       <ContractCreationDialog
@@ -18,6 +21,7 @@ export function TableDialogs() {
         open={open === 'delete'}
         onOpenChange={(state) => setOpen(state ? 'delete' : '')}
         client={currentRow}
+        onDeleteSuccess={refreshClients}
       />
 
       <ArchiveClientDialog

--- a/src/features/clients/components/users-delete-dialog.tsx
+++ b/src/features/clients/components/users-delete-dialog.tsx
@@ -7,36 +7,76 @@ import {
 import { ConfirmDialog } from '@/common/components/ui/confirm-dialog';
 import { Input } from '@/common/components/ui/input';
 import { Label } from '@/common/components/ui/label';
-import { toast } from '@/common/hooks/toast/use-toast';
+import deleteClient from '@/common/utils/deleteClient';
 import { User } from '@/features/clients/data/schema';
 import { TriangleAlert } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
+import { toast } from 'sonner';
 
 interface Props {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   currentRow: User;
+  onDeleteSuccess?: () => void;
 }
 
-export function UsersDeleteDialog({ open, onOpenChange, currentRow }: Props) {
-  const [value, setValue] = useState('');
+export function UsersDeleteDialog({ open, onOpenChange, currentRow, onDeleteSuccess }: Props) {
+  const [confirmValue, setConfirmValue] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
 
-  const handleDelete = () => {
-    const { firstname, lastname } = currentRow;
-    const fullName = `${firstname} ${lastname}`;
-    if (value.trim() !== fullName) return;
+  // Reset state when dialog opens/closes
+  useEffect(() => {
+    if (!open) {
+      setConfirmValue('');
+      setErrorMessage('');
+      setIsLoading(false);
+    }
+  }, [open]);
 
-    onOpenChange(false);
-    toast({
-      title: 'The following user has been deleted:',
-      description: (
-        <pre className='mt-2 w-[340px] rounded-md bg-slate-950 p-4'>
-          <code className='text-white'>
-            {JSON.stringify(currentRow, null, 2)}
-          </code>
-        </pre>
-      ),
-    });
+  // Check if confirm value matches (case-insensitive)
+  const isConfirmValid = confirmValue.trim().toLowerCase() === 'confirm';
+
+  const handleDelete = async () => {
+    if (!isConfirmValid) {
+      setErrorMessage('Please type \'confirm\' to proceed.');
+      return;
+    }
+
+    setIsLoading(true);
+    setErrorMessage('');
+
+    try {
+      const result = await deleteClient(currentRow.id);
+
+      if (result.success) {
+        onOpenChange(false);
+        setTimeout(() => {
+          toast.success(
+            `${currentRow.firstname} ${currentRow.lastname} was successfully deleted.`
+          );
+        }, 150);
+        // Refresh the client list
+        if (onDeleteSuccess) {
+          onDeleteSuccess();
+        }
+      } else {
+        setErrorMessage(result.error || 'Failed to delete client. Please try again.');
+      }
+    } catch (error) {
+      console.error('Error deleting client:', error);
+      setErrorMessage('An unexpected error occurred. Please try again.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setConfirmValue(e.target.value);
+    // Clear error message when user starts typing
+    if (errorMessage) {
+      setErrorMessage('');
+    }
   };
 
   return (
@@ -44,6 +84,8 @@ export function UsersDeleteDialog({ open, onOpenChange, currentRow }: Props) {
       open={open}
       onOpenChange={onOpenChange}
       handleConfirm={handleDelete}
+      disabled={!isConfirmValid || isLoading}
+      isLoading={isLoading}
       className='max-w-sm'
       title={
         <span className='text-destructive'>
@@ -57,24 +99,32 @@ export function UsersDeleteDialog({ open, onOpenChange, currentRow }: Props) {
       desc={
         <div className='space-y-4'>
           <p className='mb-2'>
-            Are you sure you want to delete <br />
-            This action will permanently remove the user with the role of from
-            the system. This cannot be undone.
+            Are you sure you want to delete{' '}
+            <strong>{currentRow.firstname} {currentRow.lastname}</strong>?<br />
+            This action will permanently remove the user from the system. This cannot be undone.
           </p>
 
-          <Label className='my-2'>
-            Username:
-            <Input
-              value={value}
-              onChange={(e) => setValue(e.target.value)}
-              placeholder='Enter username to confirm deletion.'
-            />
-          </Label>
+          <div className='space-y-2'>
+            <Label>
+              Type 'confirm' to proceed:
+              <Input
+                value={confirmValue}
+                onChange={handleInputChange}
+                placeholder="Type 'confirm' to proceed"
+                className='mt-1'
+                disabled={isLoading}
+              />
+            </Label>
+
+            {errorMessage && (
+              <p className='text-sm text-red-500'>{errorMessage}</p>
+            )}
+          </div>
 
           <Alert variant='destructive'>
             <AlertTitle>Warning!</AlertTitle>
             <AlertDescription>
-              Please be carefull, this operation can not be rolled back.
+              Please be careful, this operation cannot be rolled back.
             </AlertDescription>
           </Alert>
         </div>

--- a/src/features/clients/components/users-dialogs.tsx
+++ b/src/features/clients/components/users-dialogs.tsx
@@ -45,6 +45,7 @@ export function UsersDialogs() {
               }, 500);
             }}
             currentRow={currentRow}
+            onDeleteSuccess={refreshClients}
           />
         </>
       )}


### PR DESCRIPTION
Introduces a new deleteClient utility with backend integration and error handling, along with unit tests. Updates DeleteClientDialog and UsersDeleteDialog to use the new logic, add loading and error states, and require typing 'confirm' for deletion. Dialogs now refresh client lists after deletion for improved UX.

<!-- Describe your changes in detail -->

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published
