### PR TITLE
[codex] quickbooks payment methods

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -4,6 +4,7 @@ import ClientLogin from '@/features/auth/ClientLogin';
 import SetPassword from '@/features/auth/SetPassword';
 import ClientRoutes from '@/features/clients/ClientRoutes';
 import Home from '@/features/dashboard-home/Home';
+import ClientDashboard from '@/features/client-dashboard/ClientDashboard';
 import NotFound from '@/features/not-found/NotFound';
 import PipelineRoutes from '@/features/pipeline/PipelineRoutes';
 import RequestRoutes from '@/features/request/RequestRoutes';
@@ -55,6 +56,8 @@ const AppRoutes = () => (
       <Route element={<DashboardLayout />}>
         <Route element={<PrivateRoute />}>
           <Route index element={<Home />} />
+          <Route path='/profile' element={<ClientDashboard view='profile' />} />
+          <Route path='/billing' element={<ClientDashboard view='billing' />} />
           {ContractRoutes()}
           {PipelineRoutes()}
           {ClientRoutes()}

--- a/src/api/clients/clientDocuments.ts
+++ b/src/api/clients/clientDocuments.ts
@@ -11,6 +11,7 @@ export type ClientDocument = {
 };
 
 type RequestMode = 'client-self' | 'staff';
+export type InsuranceCardSide = 'front' | 'back';
 
 export const CLIENT_DOCUMENT_ENDPOINTS = {
   clientList: '/api/clients/me/documents',
@@ -27,9 +28,28 @@ export const CLIENT_DOCUMENT_ENDPOINTS = {
 
 const INSURANCE_CARD_DOCUMENT_TYPES = new Set([
   'insurance_card',
+  'insurance_card_front',
+  'insurance_card_back',
   'insurance-card',
   'insuranceCard',
+  'insuranceCardFront',
+  'insuranceCardBack',
 ]);
+
+export function getInsuranceCardSide(
+  documentType: string,
+  fileName?: string
+): InsuranceCardSide | null {
+  const normalized = documentType.trim().toLowerCase().replace(/[-\s]+/g, '_');
+  if (normalized === 'insurance_card_front') return 'front';
+  if (normalized === 'insurance_card_back') return 'back';
+  const normalizedFileName = String(fileName ?? '').trim().toLowerCase();
+  if (normalizedFileName) {
+    if (/(?:^|[-_.\s])front(?:$|[-_.\s])/.test(normalizedFileName)) return 'front';
+    if (/(?:^|[-_.\s])back(?:$|[-_.\s])/.test(normalizedFileName)) return 'back';
+  }
+  return null;
+}
 
 function parseErrorMessage(parsed: unknown, fallback: string): string {
   if (typeof parsed === 'string' && parsed.trim()) {
@@ -119,7 +139,10 @@ export function isInsuranceCardDocument(document: ClientDocument): boolean {
   return INSURANCE_CARD_DOCUMENT_TYPES.has(document.documentType);
 }
 
-export function getClientDocumentLabel(documentType: string): string {
+export function getClientDocumentLabel(documentType: string, fileName?: string): string {
+  const side = getInsuranceCardSide(documentType, fileName);
+  if (side === 'front') return 'Insurance Card Front';
+  if (side === 'back') return 'Insurance Card Back';
   if (INSURANCE_CARD_DOCUMENT_TYPES.has(documentType)) return 'Insurance Card';
   return documentType
     .replace(/[_-]+/g, ' ')
@@ -159,11 +182,23 @@ export async function listClientDocuments(
   }
 }
 
-export async function uploadInsuranceCard(file: File): Promise<ClientDocument> {
+export async function uploadInsuranceCard(
+  file: File,
+  side: InsuranceCardSide = 'front'
+): Promise<ClientDocument> {
   const formData = new FormData();
-  formData.append('file', file);
-  formData.append('documentType', 'insurance_card');
-  formData.append('document_type', 'insurance_card');
+  const documentType = 'insurance_card';
+  const extensionMatch = file.name.match(/\.[^.]+$/);
+  const extension = extensionMatch?.[0] || '';
+  const prefixedName =
+    side === 'back' ? `insurance-card-back${extension}` : `insurance-card-front${extension}`;
+  const uploadFile =
+    typeof File !== 'undefined'
+      ? new File([file], prefixedName, { type: file.type, lastModified: file.lastModified })
+      : file;
+  formData.append('file', uploadFile);
+  formData.append('documentType', documentType);
+  formData.append('document_type', documentType);
   formData.append('category', 'billing');
 
   const response = await requestClientDocuments(CLIENT_DOCUMENT_ENDPOINTS.clientUpload, {
@@ -187,8 +222,8 @@ export async function uploadInsuranceCard(file: File): Promise<ClientDocument> {
   if (!document) {
     return {
       id: crypto.randomUUID(),
-      documentType: 'insurance_card',
-      fileName: file.name,
+      documentType,
+      fileName: uploadFile.name,
       uploadedAt: new Date().toISOString(),
       status: 'uploaded',
       contentType: file.type,

--- a/src/api/services/__tests__/clients.service.test.ts
+++ b/src/api/services/__tests__/clients.service.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockPut } = vi.hoisted(() => ({
+  mockPut: vi.fn(),
+}));
+
+vi.mock('../../http', () => ({
+  get: vi.fn(),
+  put: mockPut,
+}));
+
+vi.mock('../../config', () => ({
+  API_CONFIG: {
+    useLegacyApi: false,
+    baseUrl: 'http://localhost:5050',
+    isProd: false,
+  },
+}));
+
+import { updateClientPhi } from '@/api/services/clients.service';
+
+describe('updateClientPhi', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('normalizes numeric zip_code values to strings before sending', async () => {
+    mockPut.mockResolvedValueOnce({ success: true });
+
+    await updateClientPhi('client-1', {
+      zip_code: 60601,
+      first_name: 'Jane',
+    });
+
+    expect(mockPut).toHaveBeenCalledWith(
+      '/clients/client-1/phi',
+      expect.objectContaining({
+        zip_code: '60601',
+        first_name: 'Jane',
+      })
+    );
+  });
+
+  it('preserves a trimmed ZIP string unchanged', async () => {
+    mockPut.mockResolvedValueOnce({ success: true });
+
+    await updateClientPhi('client-1', {
+      zip_code: ' 01234 ',
+    });
+
+    expect(mockPut).toHaveBeenCalledWith(
+      '/clients/client-1/phi',
+      expect.objectContaining({
+        zip_code: '01234',
+      })
+    );
+  });
+});

--- a/src/api/services/clients.service.ts
+++ b/src/api/services/clients.service.ts
@@ -4,6 +4,7 @@ import { ApiError } from '../errors';
 import { extractClientList, mapClient, mapClientDetail } from '../mappers/client.mapper';
 import type { ClientListItemDTO, ClientDetailDTO } from '../dto/client.dto';
 import type { Client, ClientDetail } from '@/domain/client';
+import { normalizeZipCode } from '@/common/utils/zipCode';
 
 /**
  * Normalize API response to an array of client list DTOs.
@@ -152,7 +153,11 @@ export async function updateClientPhi(
   }
 
   try {
-    const response = await put<PhiUpdateResponse>(`/clients/${clientId}/phi`, phiData);
+    const normalizedPhiData =
+      Object.prototype.hasOwnProperty.call(phiData, 'zip_code')
+        ? { ...phiData, zip_code: normalizeZipCode(phiData.zip_code) }
+        : phiData;
+    const response = await put<PhiUpdateResponse>(`/clients/${clientId}/phi`, normalizedPhiData);
     return response;
   } catch (error: unknown) {
     let message = 'Failed to update PHI fields';

--- a/src/common/components/ui/sidebar.tsx
+++ b/src/common/components/ui/sidebar.tsx
@@ -122,7 +122,7 @@ function SidebarProvider({
             } as React.CSSProperties
           }
           className={cn(
-            'group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full',
+            'group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full overflow-x-hidden',
             className
           )}
           {...props}

--- a/src/common/data/sidebar-data.ts
+++ b/src/common/data/sidebar-data.ts
@@ -8,6 +8,7 @@ import {
   LucideLink,
   LucideUsers,
   Search,
+  User,
   UserPlus,
   Scale,
 } from 'lucide-react';
@@ -40,7 +41,13 @@ export const sidebarSections = [
   {
     label: 'Client Portal',
     items: [
-      { title: 'My profile', url: '/', icon: Home, clientOnly: true },
+      { title: 'Profile Information', url: '/profile', icon: User, clientOnly: true },
+      {
+        title: 'Billing Information',
+        url: '/billing',
+        icon: LucideCreditCard,
+        clientOnly: true,
+      },
     ],
   },
   {

--- a/src/common/layouts/DashboardLayout.tsx
+++ b/src/common/layouts/DashboardLayout.tsx
@@ -7,11 +7,11 @@ export default function DashboardLayout() {
   return (
     <SearchProvider>
       <SidebarProvider>
-        <div className='flex h-screen w-screen overflow-hidden'>
+        <div className='flex w-screen overflow-x-hidden'>
           <aside className='w-64 shrink-0 border-r bg-muted p-4'>
             <AppSidebar />
           </aside>
-          <main className='flex-1 h-full w-full'>
+          <main className='flex-1 w-full'>
             <Outlet />
           </main>
         </div>

--- a/src/common/layouts/Main.tsx
+++ b/src/common/layouts/Main.tsx
@@ -12,7 +12,7 @@ export const Main = ({ fixed, ...props }: MainProps) => {
       className={cn(
         'peer-[.header-fixed]/header:mt-16',
         'w-full max-w-screen h-full max-h-screen overflow-x-hidden px-4 py-6',
-        fixed && 'fixed-main flex flex-grow flex-col'
+        fixed && 'fixed-main flex h-full flex-grow min-h-0 flex-col overflow-hidden'
       )}
       {...props}
     />

--- a/src/common/utils/User.tsx
+++ b/src/common/utils/User.tsx
@@ -13,7 +13,7 @@ export interface User {
   city?: string;
   state?: (typeof STATES)[0];
   country?: string;
-  zip_code?: number;
+  zip_code?: string | number;
   profile_picture?: string;
   account_status?: ACCOUNT_STATUS;
   business?: string;

--- a/src/common/utils/__tests__/zipCode.test.ts
+++ b/src/common/utils/__tests__/zipCode.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeZipCode } from '@/common/utils/zipCode';
+
+describe('normalizeZipCode', () => {
+  it('returns a trimmed string for numeric ZIP values', () => {
+    expect(normalizeZipCode(60601)).toBe('60601');
+  });
+
+  it('preserves leading zeros in string ZIP values', () => {
+    expect(normalizeZipCode(' 01234 ')).toBe('01234');
+  });
+
+  it('returns an empty string for nullish ZIP values', () => {
+    expect(normalizeZipCode(null)).toBe('');
+    expect(normalizeZipCode(undefined)).toBe('');
+  });
+});

--- a/src/common/utils/updateClient.ts
+++ b/src/common/utils/updateClient.ts
@@ -3,6 +3,7 @@ import {
   isSessionExpiredError,
 } from './sessionUtils';
 import { PHI_KEYS } from '@/config/phi';
+import { normalizeZipCode } from './zipCode';
 
 /**
  * Columns that cannot be updated via PUT /clients/:id to Supabase client_info table.
@@ -41,6 +42,10 @@ export default async function updateClient(
   const payload = stripUnsupportedColumns(
     typeof updateData === 'object' && updateData !== null ? updateData : {}
   );
+
+  if (Object.prototype.hasOwnProperty.call(payload, 'zip_code')) {
+    payload.zip_code = normalizeZipCode(payload.zip_code);
+  }
 
   // Debug logging
   console.log('🚨 DEBUG START - Client Update');

--- a/src/common/utils/zipCode.ts
+++ b/src/common/utils/zipCode.ts
@@ -1,0 +1,12 @@
+export function normalizeZipCode(value: unknown): string {
+  if (value === null || value === undefined) {
+    return '';
+  }
+
+  const normalized = String(value).trim();
+  if (normalized === '-1') {
+    return '';
+  }
+
+  return normalized;
+}

--- a/src/features/billing/components/QuickBooksCardOnFileForm.test.tsx
+++ b/src/features/billing/components/QuickBooksCardOnFileForm.test.tsx
@@ -1,0 +1,125 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import QuickBooksCardOnFileForm from './QuickBooksCardOnFileForm';
+
+const { tokenizeIntuitCard, savePaymentMethod, getPaymentMethod } = vi.hoisted(() => ({
+  tokenizeIntuitCard: vi.fn(),
+  savePaymentMethod: vi.fn(),
+  getPaymentMethod: vi.fn(),
+}));
+
+vi.mock('./quickbooksPayments', async () => {
+  const actual = await vi.importActual<typeof import('./quickbooksPayments')>('./quickbooksPayments');
+  return {
+    ...actual,
+    tokenizeIntuitCard,
+    savePaymentMethod,
+    getPaymentMethod,
+  };
+});
+
+describe('QuickBooksCardOnFileForm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getPaymentMethod.mockResolvedValue(null);
+  });
+
+  it('tokenizes card details and saves only the token with the client id', async () => {
+    tokenizeIntuitCard.mockResolvedValue('tok_123');
+    savePaymentMethod.mockResolvedValue({
+      client_id: 'client_123',
+      quickbooks_customer_id: 'qb_456',
+      provider_payment_method_reference: 'pm_789',
+      card_brand: 'Visa',
+      last4: '1111',
+      exp_month: '07',
+      exp_year: '2025',
+      status: 'saved',
+      created_at: '2026-04-23T10:00:00Z',
+      updated_at: '2026-04-23T10:00:00Z',
+    });
+
+    const onSuccess = vi.fn();
+    const user = userEvent.setup();
+
+    render(<QuickBooksCardOnFileForm clientId='client_123' onSuccess={onSuccess} />);
+
+    await waitFor(() => expect(getPaymentMethod).toHaveBeenCalledTimes(1));
+    await user.type(screen.getByLabelText(/name on card/i), 'Jane Doe');
+    await user.type(screen.getByLabelText(/card number/i), '4111111111111111');
+    await user.type(screen.getByLabelText(/expiration/i), '07/25');
+    await user.type(screen.getByLabelText(/security code/i), '123');
+    await user.type(screen.getByLabelText(/^billing address$/i), '123 Main St');
+    await user.type(screen.getByLabelText(/apartment, suite, or unit/i), 'Apt 4B');
+    await user.type(screen.getByLabelText(/^city$/i), 'Boston');
+    await user.type(screen.getByLabelText(/^state$/i), 'MA');
+    await user.type(screen.getByLabelText(/postal code/i), '02118');
+
+    await user.click(screen.getByRole('button', { name: /save card/i }));
+
+    await waitFor(() => expect(tokenizeIntuitCard).toHaveBeenCalledTimes(1));
+    expect(tokenizeIntuitCard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: 'client_123',
+        cardNumber: '4111111111111111',
+        expiration: '07/25',
+        cvc: '123',
+        cardholderName: 'Jane Doe',
+        billingAddress1: '123 Main St',
+        billingAddress2: 'Apt 4B',
+        billingCity: 'Boston',
+        billingState: 'MA',
+        billingPostalCode: '02118',
+        billingCountry: 'US',
+      }),
+      expect.any(Object)
+    );
+
+    await waitFor(() => expect(savePaymentMethod).toHaveBeenCalledTimes(1));
+    expect(savePaymentMethod).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client_id: 'client_123',
+        intuit_token: 'tok_123',
+        request_id: expect.any(String),
+      }),
+      expect.objectContaining({
+        endpoints: expect.arrayContaining([
+          '/api/payment-methods',
+          '/api/quickbooks/payment-methods',
+          '/quickbooks/payment-methods',
+        ]),
+      })
+    );
+    expect(onSuccess).toHaveBeenCalledWith(
+      expect.objectContaining({
+        client_id: 'client_123',
+        quickbooks_customer_id: 'qb_456',
+        provider_payment_method_reference: 'pm_789',
+        card_brand: 'Visa',
+        last4: '1111',
+      })
+    );
+    expect(screen.getByText(/card saved/i)).toBeInTheDocument();
+    expect(screen.getByText(/visa ending in 1111/i)).toBeInTheDocument();
+  });
+
+  it('prefills a disposable test card for QA', async () => {
+    const user = userEvent.setup();
+
+    render(<QuickBooksCardOnFileForm clientId='client_123' />);
+
+    await user.click(screen.getByRole('button', { name: /prefill test card/i }));
+
+    expect(screen.getByLabelText(/name on card/i)).toHaveValue('Test Cardholder');
+    expect(screen.getByLabelText(/card number/i)).toHaveValue('4111111111111111');
+    expect(screen.getByLabelText(/expiration/i)).toHaveValue('07/25');
+    expect(screen.getByLabelText(/security code/i)).toHaveValue('123');
+    expect(screen.getByLabelText(/^billing address$/i)).toHaveValue('123 Main St');
+    expect(screen.getByLabelText(/apartment, suite, or unit/i)).toHaveValue('Apt 4B');
+    expect(screen.getByLabelText(/^city$/i)).toHaveValue('Boston');
+    expect(screen.getByLabelText(/^state$/i)).toHaveValue('MA');
+    expect(screen.getByLabelText(/postal code/i)).toHaveValue('02118');
+  });
+});

--- a/src/features/billing/components/QuickBooksCardOnFileForm.tsx
+++ b/src/features/billing/components/QuickBooksCardOnFileForm.tsx
@@ -1,0 +1,746 @@
+import { useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
+import { AlertCircle, CheckCircle2, CreditCard, Loader2, ShieldCheck, X } from 'lucide-react';
+
+import { Alert, AlertDescription, AlertTitle } from '@/common/components/ui/alert';
+import { Button } from '@/common/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/common/components/ui/card';
+import { Input } from '@/common/components/ui/input';
+import { Label } from '@/common/components/ui/label';
+import { cn } from '@/lib/utils';
+
+import {
+  createPaymentMethodRequestId,
+  getPaymentMethod,
+  parseExpiration,
+  savePaymentMethod,
+  tokenizeIntuitCard,
+  PaymentMethodApiError,
+  type QuickBooksCardTokenizationInput,
+  type PaymentMethodMetadata,
+} from './quickbooksPayments';
+
+type FormFieldKey =
+  | 'cardholderName'
+  | 'cardNumber'
+  | 'expiration'
+  | 'cvc'
+  | 'billingAddress1'
+  | 'billingAddress2'
+  | 'billingCity'
+  | 'billingState'
+  | 'billingPostalCode'
+  | 'billingCountry';
+
+type FormValues = Record<FormFieldKey, string>;
+type FormErrors = Partial<Record<FormFieldKey, string>> & { form?: string };
+
+export type QuickBooksCardOnFileFormStatus = 'idle' | 'submitting' | 'tokenizing' | 'saving' | 'success' | 'error';
+export type QuickBooksCardOnFileFormDisplayMode = 'full' | 'compact';
+
+export interface QuickBooksCardOnFileFormProps {
+  clientId: string;
+  onSuccess?: (metadata: PaymentMethodMetadata) => void;
+  onError?: (message: string) => void;
+  onCancel?: () => void;
+  initialDisplayMode?: QuickBooksCardOnFileFormDisplayMode;
+  className?: string;
+  tokenEndpoint?: string;
+  saveEndpoint?: string;
+  showTestCardButton?: boolean;
+}
+
+const DEFAULT_VALUES: FormValues = {
+  cardholderName: '',
+  cardNumber: '',
+  expiration: '',
+  cvc: '',
+  billingAddress1: '',
+  billingAddress2: '',
+  billingCity: '',
+  billingState: '',
+  billingPostalCode: '',
+  billingCountry: 'US',
+};
+
+const TEST_CARD_VALUES: FormValues = {
+  cardholderName: 'Test Cardholder',
+  cardNumber: '4111111111111111',
+  expiration: '07/25',
+  cvc: '123',
+  billingAddress1: '123 Main St',
+  billingAddress2: 'Apt 4B',
+  billingCity: 'Boston',
+  billingState: 'MA',
+  billingPostalCode: '02118',
+  billingCountry: 'US',
+};
+
+function digitsOnly(value: string): string {
+  return value.replace(/\D/g, '');
+}
+
+function validateValues(values: FormValues): FormErrors {
+  const errors: FormErrors = {};
+
+  if (!values.cardholderName.trim()) errors.cardholderName = 'Enter the name on the card.';
+  if (digitsOnly(values.cardNumber).length < 13) {
+    errors.cardNumber = 'Enter the full card number.';
+  }
+  if (!parseExpiration(values.expiration)) errors.expiration = 'Enter the expiration as MM/YY.';
+  if (digitsOnly(values.cvc).length < 3) errors.cvc = 'Enter the 3-digit or 4-digit security code.';
+  if (!values.billingAddress1.trim()) errors.billingAddress1 = 'Enter the billing street address.';
+  if (!values.billingCity.trim()) errors.billingCity = 'Enter the billing city.';
+  if (!values.billingState.trim()) errors.billingState = 'Enter the billing state.';
+  if (!values.billingPostalCode.trim()) errors.billingPostalCode = 'Enter the billing postal code.';
+  if (!values.billingCountry.trim()) errors.billingCountry = 'Enter the billing country.';
+
+  return errors;
+}
+
+function toFriendlyErrorMessage(error: unknown): string {
+  const code = getErrorCode(error);
+  switch (code) {
+    case 'validation_error':
+      return 'Please fix the highlighted fields and try again.';
+    case 'unauthorized':
+    case 'forbidden':
+      return 'Please sign in again or reconnect your account.';
+    case 'client_not_found':
+      return 'We could not find this client. Please refresh and try again.';
+    case 'quickbooks_not_connected':
+      return 'QuickBooks is not connected right now.';
+    case 'provider_timeout':
+      return 'The payment service took too long to respond. Please try again.';
+    case 'provider_save_failure':
+    case 'database_persistence_failure':
+      return 'We could not save this card. Please try again.';
+    case 'invalid_token':
+    case 'expired_token':
+      return 'The payment token expired. Please try again.';
+    case 'duplicate_request':
+      return 'This request was already processed. Refreshing your saved card.';
+    default:
+      return 'We could not save this card. Please try again.';
+  }
+}
+
+function buildTokenizationInput(clientId: string, values: FormValues): QuickBooksCardTokenizationInput {
+  return {
+    clientId,
+    cardholderName: values.cardholderName.trim(),
+    cardNumber: digitsOnly(values.cardNumber),
+    expiration: values.expiration.trim(),
+    cvc: digitsOnly(values.cvc),
+    billingAddress1: values.billingAddress1.trim(),
+    billingAddress2: values.billingAddress2.trim() || undefined,
+    billingCity: values.billingCity.trim(),
+    billingState: values.billingState.trim(),
+    billingPostalCode: values.billingPostalCode.trim(),
+    billingCountry: values.billingCountry.trim() || 'US',
+  };
+}
+
+function makeInitialValues(initialDisplayMode: QuickBooksCardOnFileFormDisplayMode | undefined): FormValues {
+  if (initialDisplayMode === 'compact') {
+    return { ...DEFAULT_VALUES };
+  }
+  return { ...DEFAULT_VALUES };
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  if (error instanceof PaymentMethodApiError) return error.code;
+  if (error instanceof Error && 'code' in error && typeof (error as { code?: unknown }).code === 'string') {
+    return (error as { code?: string }).code;
+  }
+  return undefined;
+}
+
+function getErrorDetails(error: unknown): Record<string, unknown> | undefined {
+  if (error instanceof PaymentMethodApiError && error.details) return error.details;
+  if (error instanceof Error && 'details' in error && typeof (error as { details?: unknown }).details === 'object') {
+    return (error as { details?: Record<string, unknown> }).details;
+  }
+  return undefined;
+}
+
+function extractFieldErrors(error: unknown): FormErrors {
+  const details = getErrorDetails(error);
+  if (!details) return {};
+  const fields =
+    (details.fieldErrors as Record<string, string | string[] | undefined> | undefined) ??
+    (details.fields as Record<string, string | string[] | undefined> | undefined) ??
+    (details.errors as Record<string, string | string[] | undefined> | undefined);
+  if (!fields) return {};
+
+  const nextErrors: FormErrors = {};
+  Object.entries(fields).forEach(([key, value]) => {
+    const message = Array.isArray(value) ? value[0] : value;
+    if (typeof message !== 'string' || !message.trim()) return;
+    if (key in DEFAULT_VALUES) {
+      nextErrors[key as FormFieldKey] = message;
+    } else {
+      nextErrors.form = message;
+    }
+  });
+  return nextErrors;
+}
+
+export default function QuickBooksCardOnFileForm({
+  clientId,
+  onSuccess,
+  onError,
+  onCancel,
+  initialDisplayMode = 'full',
+  className,
+  tokenEndpoint = import.meta.env.VITE_QUICKBOOKS_PAYMENTS_TOKEN_ENDPOINT || '',
+  saveEndpoint = import.meta.env.VITE_QUICKBOOKS_PAYMENTS_SAVE_ENDPOINT || '/api/quickbooks/payments/cards',
+  showTestCardButton = import.meta.env.DEV,
+}: QuickBooksCardOnFileFormProps) {
+  const [values, setValues] = useState<FormValues>(() => makeInitialValues(initialDisplayMode));
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [status, setStatus] = useState<QuickBooksCardOnFileFormStatus>('idle');
+  const [statusMessage, setStatusMessage] = useState<string>(
+    'Your card is securely stored for future billing use.'
+  );
+  const [currentPaymentMethod, setCurrentPaymentMethod] = useState<PaymentMethodMetadata | null>(null);
+  const [loadingCurrentPaymentMethod, setLoadingCurrentPaymentMethod] = useState(false);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  const isBusy = status === 'submitting' || status === 'tokenizing' || status === 'saving';
+
+  const maskedSummary = useMemo(() => {
+    if (!currentPaymentMethod?.last4) return '';
+    const brand = currentPaymentMethod.card_brand ? currentPaymentMethod.card_brand : 'Card';
+    return `${brand} ending in ${currentPaymentMethod.last4}`;
+  }, [currentPaymentMethod]);
+
+  useEffect(() => {
+    if (!clientId.trim()) return;
+
+    let active = true;
+    setLoadingCurrentPaymentMethod(true);
+    void (async () => {
+      try {
+        const paymentMethod = await getPaymentMethod({ clientId });
+        if (!active || !mountedRef.current) return;
+        setCurrentPaymentMethod(paymentMethod);
+      } catch {
+        if (!active || !mountedRef.current) return;
+        setCurrentPaymentMethod(null);
+      } finally {
+        if (active && mountedRef.current) {
+          setLoadingCurrentPaymentMethod(false);
+        }
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [clientId]);
+
+  function resetSensitiveState() {
+    setValues({ ...DEFAULT_VALUES });
+  }
+
+  function updateField(field: FormFieldKey, value: string) {
+    setValues((current) => ({ ...current, [field]: value }));
+    setErrors((current) => ({ ...current, [field]: undefined, form: undefined }));
+    if (status === 'error') {
+      setStatus('idle');
+      setStatusMessage('Your card is securely stored for future billing use.');
+    }
+  }
+
+  function applyTestCard() {
+    setValues({ ...TEST_CARD_VALUES });
+    setErrors({});
+    setStatus('idle');
+    setStatusMessage('Test card details are prefilled. Review them before saving.');
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setStatus('submitting');
+    setErrors({});
+    setStatusMessage('Checking the card details.');
+
+    if (!clientId.trim()) {
+      const message = 'We could not save this card. Please try again.';
+      setStatus('error');
+      setStatusMessage(message);
+      setErrors({ form: message });
+      onError?.(message);
+      resetSensitiveState();
+      return;
+    }
+
+    const submittedValues = { ...values };
+    const validationErrors = validateValues(submittedValues);
+    if (Object.keys(validationErrors).length > 0) {
+      setStatus('error');
+      setErrors(validationErrors);
+      setStatusMessage('Please fix the highlighted fields and try again.');
+      onError?.('Please fix the highlighted fields and try again.');
+      resetSensitiveState();
+      return;
+    }
+
+    try {
+      setStatus('tokenizing');
+      setStatusMessage('Sending the card details to Intuit securely.');
+
+      const token = await tokenizeIntuitCard(buildTokenizationInput(clientId, submittedValues), {
+        endpoint: tokenEndpoint,
+      });
+
+      if (!mountedRef.current) return;
+
+      resetSensitiveState();
+      setStatus('saving');
+      setStatusMessage('Saving the token with QuickBooks.');
+
+      let metadata: PaymentMethodMetadata | null = null;
+      let retriedTokenization = false;
+      let retriedSaveTimeout = false;
+      let currentToken = token;
+      const requestId = createPaymentMethodRequestId();
+
+      while (mountedRef.current && metadata === null) {
+        try {
+          metadata = await savePaymentMethod(
+            {
+              client_id: clientId,
+              intuit_token: currentToken,
+              request_id: requestId,
+            },
+            {
+              endpoints: [
+                saveEndpoint,
+                '/api/payment-methods',
+                '/api/quickbooks/payment-methods',
+                '/quickbooks/payment-methods',
+              ],
+            }
+          );
+          break;
+        } catch (error) {
+          const code = getErrorCode(error);
+
+          if ((code === 'invalid_token' || code === 'expired_token') && !retriedTokenization) {
+            retriedTokenization = true;
+            setStatus('tokenizing');
+            setStatusMessage('Reconnecting to Intuit and trying again.');
+            currentToken = await tokenizeIntuitCard(buildTokenizationInput(clientId, submittedValues), {
+              endpoint: tokenEndpoint,
+            });
+            resetSensitiveState();
+            setStatus('saving');
+            setStatusMessage('Saving the token with QuickBooks.');
+            continue;
+          }
+
+          if (code === 'provider_timeout' && !retriedSaveTimeout) {
+            retriedSaveTimeout = true;
+            setStatus('saving');
+            setStatusMessage('Saving the card...');
+            continue;
+          }
+
+          if (code === 'duplicate_request') {
+            metadata = (await getPaymentMethod({ clientId })) ?? currentPaymentMethod;
+            if (!metadata) {
+              throw error;
+            }
+            break;
+          }
+
+          throw error;
+        }
+      }
+
+      if (!mountedRef.current) return;
+
+      if (!metadata) {
+        metadata = await getPaymentMethod({ clientId });
+      }
+
+      if (!metadata) {
+        throw new PaymentMethodApiError('The card was saved, but no metadata was returned.', 502);
+      }
+
+      setCurrentPaymentMethod(metadata);
+      setStatus('success');
+      setStatusMessage('The card was saved successfully.');
+      onSuccess?.(metadata);
+    } catch (error) {
+      if (!mountedRef.current) return;
+      const safeMessage = toFriendlyErrorMessage(error);
+      setStatus('error');
+      setStatusMessage(safeMessage);
+      const fieldErrors = extractFieldErrors(error);
+      setErrors((current) => ({
+        ...current,
+        ...fieldErrors,
+        form: safeMessage,
+      }));
+      onError?.(safeMessage);
+    } finally {
+      if (mountedRef.current) {
+        resetSensitiveState();
+      }
+    }
+  }
+
+  function handleCancel() {
+    resetSensitiveState();
+    setErrors({});
+    setStatus('idle');
+    setStatusMessage('Your card is securely stored for future billing use.');
+    onCancel?.();
+  }
+
+  return (
+    <Card className={cn('w-full overflow-hidden', className)}>
+      <CardHeader className={cn(initialDisplayMode === 'compact' ? 'px-4 pb-0 pt-4' : undefined)}>
+        <div className='flex items-start justify-between gap-3'>
+          <div className='space-y-1.5'>
+            <CardTitle className='flex items-center gap-2 text-xl'>
+              <CreditCard className='h-5 w-5' />
+              Save a card for future billing
+            </CardTitle>
+            <CardDescription>
+              Securely store a customer card in QuickBooks Payments without sending card details to your server.
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+
+      <CardContent className={cn('space-y-6', initialDisplayMode === 'compact' ? 'px-4 pb-4' : undefined)}>
+        <div className='flex items-start gap-3 rounded-lg border border-dashed bg-muted/30 p-4 text-sm text-muted-foreground'>
+          <ShieldCheck className='mt-0.5 h-4 w-4 shrink-0 text-primary' />
+          <p>
+            Card details are entered in the browser, tokenized with Intuit, and stored securely by QuickBooks.
+          </p>
+        </div>
+
+        <div className='rounded-lg border bg-muted/20 p-4 space-y-2'>
+          <div className='text-sm font-medium'>QuickBooks card on file</div>
+          {loadingCurrentPaymentMethod ? (
+            <p className='text-sm text-muted-foreground'>Loading saved card details...</p>
+          ) : currentPaymentMethod ? (
+            <div className='grid gap-2 text-sm sm:grid-cols-2'>
+              <MetadataLine label='Brand' value={currentPaymentMethod.card_brand || 'Card'} />
+              <MetadataLine label='Last 4' value={currentPaymentMethod.last4 || '—'} />
+              <MetadataLine label='Expires' value={formatExpiry(currentPaymentMethod.exp_month, currentPaymentMethod.exp_year)} />
+              <MetadataLine label='Status' value={currentPaymentMethod.status || 'Saved'} />
+            </div>
+          ) : (
+            <p className='text-sm text-muted-foreground'>No card is stored with QuickBooks yet.</p>
+          )}
+        </div>
+
+        <div aria-live='polite' className='space-y-3'>
+          <div className='flex items-center gap-2 text-sm font-medium'>
+            <span className={cn(
+              'inline-flex h-2.5 w-2.5 rounded-full',
+              status === 'success'
+                ? 'bg-emerald-500'
+                : status === 'error'
+                  ? 'bg-destructive'
+                  : status === 'tokenizing' || status === 'saving'
+                    ? 'bg-amber-500'
+                    : 'bg-muted-foreground'
+            )} />
+            <span>{statusMessage}</span>
+          </div>
+
+          {status === 'error' && errors.form ? (
+            <Alert variant='destructive'>
+              <AlertCircle className='h-4 w-4' />
+              <AlertTitle>We could not save this card</AlertTitle>
+              <AlertDescription>{errors.form}</AlertDescription>
+            </Alert>
+          ) : null}
+
+          {status === 'success' && currentPaymentMethod ? (
+            <Alert className='border-emerald-200 bg-emerald-50 text-emerald-950 dark:border-emerald-900 dark:bg-emerald-950/40 dark:text-emerald-100'>
+              <CheckCircle2 className='h-4 w-4' />
+              <AlertTitle>Card saved</AlertTitle>
+              <AlertDescription>
+                <div className='mt-3 grid gap-2 text-sm sm:grid-cols-2'>
+                  <MetadataLine label='Client ID' value={currentPaymentMethod.client_id} />
+                  <MetadataLine label='Status' value={currentPaymentMethod.status || 'Saved'} />
+                  <MetadataLine label='Card' value={maskedSummary || 'Saved card'} />
+                  <MetadataLine label='Last 4' value={currentPaymentMethod.last4 || '—'} />
+                  <MetadataLine label='Expires' value={formatExpiry(currentPaymentMethod.exp_month, currentPaymentMethod.exp_year)} />
+                  <MetadataLine label='QuickBooks customer' value={currentPaymentMethod.quickbooks_customer_id || '—'} />
+                </div>
+              </AlertDescription>
+            </Alert>
+          ) : null}
+        </div>
+
+        <form className='space-y-5' onSubmit={handleSubmit} autoComplete='off'>
+          <div className='grid gap-4 md:grid-cols-2'>
+            <Field
+              htmlFor='qb-cardholder-name'
+              label='Name on card'
+              error={errors.cardholderName}
+              input={
+                <Input
+                  id='qb-cardholder-name'
+                  value={values.cardholderName}
+                  onChange={(event) => updateField('cardholderName', event.target.value)}
+                  placeholder='Jane Doe'
+                  autoComplete='off'
+                  disabled={isBusy}
+                />
+              }
+            />
+
+            <Field
+              htmlFor='qb-card-number'
+              label='Card number'
+              error={errors.cardNumber}
+              input={
+                <Input
+                  id='qb-card-number'
+                  value={values.cardNumber}
+                  onChange={(event) => updateField('cardNumber', digitsOnly(event.target.value))}
+                  placeholder='1234 1234 1234 1234'
+                  inputMode='numeric'
+                  autoComplete='off'
+                  disabled={isBusy}
+                  maxLength={19}
+                />
+              }
+            />
+          </div>
+
+          <div className='grid gap-4 md:grid-cols-3'>
+            <Field
+              htmlFor='qb-expiration'
+              label='Expiration'
+              error={errors.expiration}
+              helper='Use MM/YY'
+              input={
+                <Input
+                  id='qb-expiration'
+                  value={values.expiration}
+                  onChange={(event) => updateField('expiration', event.target.value)}
+                  placeholder='MM/YY'
+                  inputMode='numeric'
+                  autoComplete='off'
+                  disabled={isBusy}
+                  maxLength={7}
+                />
+              }
+            />
+
+            <Field
+              htmlFor='qb-cvc'
+              label='Security code'
+              error={errors.cvc}
+              helper='3 or 4 digits'
+              input={
+                <Input
+                  id='qb-cvc'
+                  value={values.cvc}
+                  onChange={(event) => updateField('cvc', digitsOnly(event.target.value))}
+                  placeholder='123'
+                  inputMode='numeric'
+                  autoComplete='off'
+                  disabled={isBusy}
+                  maxLength={4}
+                />
+              }
+            />
+
+            <Field
+              htmlFor='qb-billing-country'
+              label='Country'
+              error={errors.billingCountry}
+              input={
+                <Input
+                  id='qb-billing-country'
+                  value={values.billingCountry}
+                  onChange={(event) => updateField('billingCountry', event.target.value)}
+                  placeholder='US'
+                  autoComplete='off'
+                  disabled={isBusy}
+                />
+              }
+            />
+          </div>
+
+          <div className='space-y-4'>
+            <Field
+              htmlFor='qb-billing-address-1'
+              label='Billing address'
+              error={errors.billingAddress1}
+              input={
+                <Input
+                  id='qb-billing-address-1'
+                  value={values.billingAddress1}
+                  onChange={(event) => updateField('billingAddress1', event.target.value)}
+                  placeholder='123 Main St'
+                  autoComplete='off'
+                  disabled={isBusy}
+                />
+              }
+            />
+
+            <Field
+              htmlFor='qb-billing-address-2'
+              label='Apartment, suite, or unit'
+              error={errors.billingAddress2}
+              input={
+                <Input
+                  id='qb-billing-address-2'
+                  value={values.billingAddress2}
+                  onChange={(event) => updateField('billingAddress2', event.target.value)}
+                  placeholder='Apt 4B'
+                  autoComplete='off'
+                  disabled={isBusy}
+                />
+              }
+            />
+          </div>
+
+          <div className='grid gap-4 md:grid-cols-3'>
+            <Field
+              htmlFor='qb-billing-city'
+              label='City'
+              error={errors.billingCity}
+              input={
+                <Input
+                  id='qb-billing-city'
+                  value={values.billingCity}
+                  onChange={(event) => updateField('billingCity', event.target.value)}
+                  placeholder='Boston'
+                  autoComplete='off'
+                  disabled={isBusy}
+                />
+              }
+            />
+
+            <Field
+              htmlFor='qb-billing-state'
+              label='State'
+              error={errors.billingState}
+              input={
+                <Input
+                  id='qb-billing-state'
+                  value={values.billingState}
+                  onChange={(event) => updateField('billingState', event.target.value)}
+                  placeholder='MA'
+                  autoComplete='off'
+                  disabled={isBusy}
+                />
+              }
+            />
+
+            <Field
+              htmlFor='qb-billing-postal-code'
+              label='Postal code'
+              error={errors.billingPostalCode}
+              input={
+                <Input
+                  id='qb-billing-postal-code'
+                  value={values.billingPostalCode}
+                  onChange={(event) => updateField('billingPostalCode', event.target.value)}
+                  placeholder='02118'
+                  inputMode='numeric'
+                  autoComplete='off'
+                  disabled={isBusy}
+                />
+              }
+            />
+          </div>
+
+          <div className='flex flex-col gap-3 sm:flex-row sm:justify-between'>
+            <div className='flex flex-col gap-2'>
+              <div className='text-xs text-muted-foreground'>
+                Card values are cleared after each submit attempt. No raw payment data is stored in app state.
+              </div>
+              {showTestCardButton ? (
+                <Button type='button' variant='outline' onClick={applyTestCard} disabled={isBusy}>
+                  Prefill test card
+                </Button>
+              ) : null}
+            </div>
+            <div className='flex gap-2 sm:justify-end'>
+              {onCancel ? (
+                <Button type='button' variant='outline' onClick={handleCancel} disabled={isBusy}>
+                  <X className='h-4 w-4' />
+                  Cancel
+                </Button>
+              ) : null}
+              <Button type='submit' disabled={isBusy}>
+                {status === 'submitting' || status === 'tokenizing' || status === 'saving' ? (
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                ) : null}
+                {status === 'submitting'
+                  ? 'Checking details...'
+                  : status === 'tokenizing'
+                    ? 'Tokenizing...'
+                    : status === 'saving'
+                      ? 'Saving card...'
+                      : 'Save card'}
+              </Button>
+            </div>
+          </div>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}
+
+function Field({
+  htmlFor,
+  label,
+  error,
+  helper,
+  input,
+}: {
+  htmlFor: string;
+  label: string;
+  error?: string;
+  helper?: string;
+  input: ReactNode;
+}) {
+  return (
+    <div className='space-y-1.5'>
+      <Label htmlFor={htmlFor} className='text-sm font-medium'>
+        {label}
+      </Label>
+      {input}
+      {helper ? <p className='text-xs text-muted-foreground'>{helper}</p> : null}
+      {error ? <p className='text-xs text-destructive'>{error}</p> : null}
+    </div>
+  );
+}
+
+function MetadataLine({ label, value }: { label: string; value: string }) {
+  return (
+    <div className='rounded-md border bg-background/70 px-3 py-2'>
+      <div className='text-xs font-medium text-muted-foreground'>{label}</div>
+      <div className='text-sm'>{value}</div>
+    </div>
+  );
+}
+
+function formatExpiry(month?: number | string | null, year?: number | string | null): string {
+  if (!month || !year) return '—';
+  const monthPart = String(month).padStart(2, '0');
+  const yearPart = String(year).slice(-2);
+  return `${monthPart}/${yearPart}`;
+}

--- a/src/features/billing/components/quickbooksPayments.test.ts
+++ b/src/features/billing/components/quickbooksPayments.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  createPaymentMethodRequestId,
+  getPaymentMethod,
+  parseExpiration,
+  savePaymentMethod,
+  tokenizeIntuitCard,
+} from './quickbooksPayments';
+
+describe('quickbooksPayments helpers', () => {
+  it('parses and normalizes expiration dates', () => {
+    expect(parseExpiration('07/25')).toEqual({ exp_month: '07', exp_year: '2025' });
+    expect(parseExpiration('7/25')).toEqual({ exp_month: '07', exp_year: '2025' });
+    expect(parseExpiration('13/25')).toBeNull();
+  });
+
+  it('tokenizes card data without sending it to the backend save helper', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () => JSON.stringify({ token: 'tok_123' }),
+    } as Response);
+
+    const token = await tokenizeIntuitCard(
+      {
+        clientId: 'client_123',
+        cardNumber: '4111111111111111',
+        expiration: '07/25',
+        cvc: '123',
+        cardholderName: 'Jane Doe',
+        billingAddress1: '123 Main St',
+        billingAddress2: 'Apt 4B',
+        billingCity: 'Boston',
+        billingState: 'MA',
+        billingPostalCode: '02118',
+        billingCountry: 'US',
+      },
+      { endpoint: 'https://example.com/tokenize', fetchImpl: fetchImpl as typeof fetch }
+    );
+
+    expect(token).toBe('tok_123');
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+
+    const [, init] = fetchImpl.mock.calls[0];
+    expect(init?.body).toBeDefined();
+
+    const body = JSON.parse(String(init?.body));
+    expect(body).toEqual({
+      client_id: 'client_123',
+      cardholder_name: 'Jane Doe',
+      card_number: '4111111111111111',
+      cvc: '123',
+      exp_month: '07',
+      exp_year: '2025',
+      billing_address: {
+        line1: '123 Main St',
+        line2: 'Apt 4B',
+        city: 'Boston',
+        state: 'MA',
+        postal_code: '02118',
+        country: 'US',
+      },
+    });
+  });
+
+  it('sends only client_id, intuit_token, and request_id when saving the card', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: true,
+      text: async () =>
+        JSON.stringify({
+          success: true,
+          data: {
+            client_id: 'client_123',
+            quickbooks_customer_id: 'qb_456',
+            provider_payment_method_reference: 'pm_789',
+            card_brand: 'Visa',
+            last4: '1111',
+            exp_month: '07',
+            exp_year: '2025',
+            status: 'saved',
+            created_at: '2026-04-23T10:00:00Z',
+            updated_at: '2026-04-23T10:00:00Z',
+          },
+        }),
+    } as Response);
+
+    const requestId = createPaymentMethodRequestId();
+    const saved = await savePaymentMethod(
+      { client_id: 'client_123', intuit_token: 'tok_123', request_id: requestId },
+      { endpoints: ['https://example.com/save'], requestImpl: fetchImpl as typeof fetch }
+    );
+
+    expect(saved).toEqual({
+      client_id: 'client_123',
+      quickbooks_customer_id: 'qb_456',
+      provider_payment_method_reference: 'pm_789',
+      card_brand: 'Visa',
+      last4: '1111',
+      exp_month: 7,
+      exp_year: 2025,
+      status: 'saved',
+      created_at: '2026-04-23T10:00:00Z',
+      updated_at: '2026-04-23T10:00:00Z',
+    });
+
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+    const [, init] = fetchImpl.mock.calls[0];
+    expect(JSON.parse(String(init?.body))).toEqual({
+      client_id: 'client_123',
+      intuit_token: 'tok_123',
+      request_id: requestId,
+    });
+  });
+
+  it('returns null when the backend says no payment method exists', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 404,
+      statusText: 'Not Found',
+      text: async () =>
+        JSON.stringify({
+          success: false,
+          error: 'Payment method not found',
+          code: 'payment_method_not_found',
+        }),
+    } as Response);
+
+    await expect(
+      getPaymentMethod({ clientId: 'client_123' }, { endpoints: ['https://example.com/save/123'], requestImpl: fetchImpl as typeof fetch })
+    ).resolves.toBeNull();
+  });
+});

--- a/src/features/billing/components/quickbooksPayments.ts
+++ b/src/features/billing/components/quickbooksPayments.ts
@@ -1,0 +1,428 @@
+import { buildUrl, fetchWithAuth } from '@/api/http';
+
+export interface IntuitTokenizationInput {
+  clientId: string;
+  cardNumber: string;
+  expiration: string;
+  cvc: string;
+  cardholderName: string;
+  billingAddress1: string;
+  billingAddress2?: string;
+  billingCity: string;
+  billingState: string;
+  billingPostalCode: string;
+  billingCountry: string;
+}
+
+export interface PaymentMethodMetadata {
+  client_id: string;
+  quickbooks_customer_id?: string | null;
+  provider_payment_method_reference?: string | null;
+  card_brand?: string | null;
+  last4?: string | null;
+  exp_month?: number | null;
+  exp_year?: number | null;
+  status?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export type PaymentMethodRequestId = string;
+
+export interface PaymentMethodSaveRequest {
+  client_id: string;
+  intuit_token: string;
+  request_id: PaymentMethodRequestId;
+  ui_metadata?: Record<string, string | number | boolean | null | undefined>;
+}
+
+export interface PaymentMethodQueryRequest {
+  clientId: string;
+}
+
+export interface TokenizationOptions {
+  endpoint: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface PaymentMethodRequestOptions {
+  endpoints?: string[];
+  requestImpl?: typeof fetchWithAuth;
+}
+
+export interface PaymentMethodApiErrorDetails {
+  fieldErrors?: Record<string, string | string[] | undefined>;
+  fields?: Record<string, string | string[] | undefined>;
+  errors?: Record<string, string | string[] | undefined>;
+  [key: string]: unknown;
+}
+
+export type PaymentMethodErrorCode =
+  | 'validation_error'
+  | 'unauthorized'
+  | 'forbidden'
+  | 'client_not_found'
+  | 'quickbooks_not_connected'
+  | 'invalid_token'
+  | 'expired_token'
+  | 'duplicate_request'
+  | 'provider_timeout'
+  | 'provider_save_failure'
+  | 'database_persistence_failure'
+  | 'payment_method_not_found'
+  | string;
+
+export class PaymentMethodApiError extends Error {
+  status: number;
+  code?: PaymentMethodErrorCode;
+  details?: PaymentMethodApiErrorDetails;
+
+  constructor(message: string, status: number, code?: PaymentMethodErrorCode, details?: PaymentMethodApiErrorDetails) {
+    super(message);
+    this.name = 'PaymentMethodApiError';
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+type ApiEnvelope<T> = {
+  success?: boolean;
+  data?: T;
+  error?: string;
+  code?: PaymentMethodErrorCode;
+  details?: PaymentMethodApiErrorDetails;
+  fieldErrors?: Record<string, string | string[] | undefined>;
+  fields?: Record<string, string | string[] | undefined>;
+  errors?: Record<string, string | string[] | undefined>;
+};
+
+const PAYMENT_METHOD_ENDPOINTS = [
+  '/api/payment-methods',
+  '/api/quickbooks/payment-methods',
+  '/quickbooks/payment-methods',
+];
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === 'object' && !Array.isArray(value);
+}
+
+export function createPaymentMethodRequestId(): string {
+  const cryptoObj = globalThis.crypto as Crypto | undefined;
+  if (cryptoObj?.randomUUID) return cryptoObj.randomUUID();
+  return `req_${Date.now()}_${Math.random().toString(16).slice(2)}`;
+}
+
+export function parseExpiration(expiration: string): { exp_month: string; exp_year: string } | null {
+  const trimmed = expiration.trim();
+  const match = trimmed.match(/^(\d{1,2})\s*\/\s*(\d{2}|\d{4})$/);
+  if (!match) return null;
+
+  const month = Number(match[1]);
+  const yearValue = match[2];
+  const year = Number(yearValue.length === 2 ? `20${yearValue}` : yearValue);
+
+  if (!Number.isFinite(month) || month < 1 || month > 12) return null;
+  if (!Number.isFinite(year) || year < 2000) return null;
+
+  return {
+    exp_month: String(month).padStart(2, '0'),
+    exp_year: String(year),
+  };
+}
+
+async function parseResponse<T>(response: Response): Promise<T> {
+  const text = await response.text();
+  if (!text) return null as T;
+
+  try {
+    return JSON.parse(text) as T;
+  } catch {
+    return text as T;
+  }
+}
+
+function normalizeErrorDetails(parsed: unknown): PaymentMethodApiErrorDetails | undefined {
+  if (!isRecord(parsed)) return undefined;
+  const details =
+    (isRecord(parsed.details) ? (parsed.details as PaymentMethodApiErrorDetails) : undefined) ??
+    (isRecord(parsed.fieldErrors)
+      ? ({ fieldErrors: parsed.fieldErrors } as PaymentMethodApiErrorDetails)
+      : undefined) ??
+    (isRecord(parsed.fields) ? ({ fields: parsed.fields } as PaymentMethodApiErrorDetails) : undefined) ??
+    (isRecord(parsed.errors) ? ({ errors: parsed.errors } as PaymentMethodApiErrorDetails) : undefined);
+  return details;
+}
+
+function normalizeError(
+  response: Response,
+  parsed: unknown
+): PaymentMethodApiError {
+  const message =
+    isRecord(parsed) && isNonEmptyString(parsed.error)
+      ? parsed.error
+      : isRecord(parsed) && isNonEmptyString(parsed.message)
+        ? parsed.message
+        : response.statusText || 'Request failed';
+  const code =
+    isRecord(parsed) && typeof parsed.code === 'string' ? (parsed.code as PaymentMethodErrorCode) : undefined;
+  const details = normalizeErrorDetails(parsed);
+  return new PaymentMethodApiError(String(message), response.status, code, details);
+}
+
+function coerceNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+function normalizePaymentMethodMetadata(value: unknown): PaymentMethodMetadata | null {
+  if (!isRecord(value)) return null;
+
+  const clientId = value.client_id;
+  if (!isNonEmptyString(clientId)) return null;
+
+  return {
+    client_id: clientId,
+    quickbooks_customer_id: isNonEmptyString(value.quickbooks_customer_id) ? value.quickbooks_customer_id : null,
+    provider_payment_method_reference: isNonEmptyString(value.provider_payment_method_reference)
+      ? value.provider_payment_method_reference
+      : null,
+    card_brand: isNonEmptyString(value.card_brand) ? value.card_brand : null,
+    last4: isNonEmptyString(value.last4) ? value.last4 : null,
+    exp_month: coerceNumber(value.exp_month),
+    exp_year: coerceNumber(value.exp_year),
+    status: isNonEmptyString(value.status) ? value.status : null,
+    created_at: isNonEmptyString(value.created_at) ? value.created_at : null,
+    updated_at: isNonEmptyString(value.updated_at) ? value.updated_at : null,
+  };
+}
+
+function shouldFallbackToAlias(error: PaymentMethodApiError): boolean {
+  return error.status === 404 || error.status === 405;
+}
+
+function extractData<T>(parsed: unknown): T | null {
+  if (!isRecord(parsed)) return null;
+  if ('data' in parsed && parsed.data !== undefined) {
+    return parsed.data as T;
+  }
+  if (parsed.success === false) return null;
+  return parsed as T;
+}
+
+async function requestJson<T>(
+  path: string,
+  init: RequestInit,
+  requestImpl: typeof fetchWithAuth = fetchWithAuth
+): Promise<T> {
+  const response = await requestImpl(buildUrl(path), init);
+  const parsed = await parseResponse<ApiEnvelope<T> | T | string>(response);
+
+  if (!response.ok) {
+    throw normalizeError(response, parsed);
+  }
+
+  const data = extractData<T>(parsed);
+  if (data === null) {
+    throw new PaymentMethodApiError('Invalid payment method response format', response.status);
+  }
+  return data;
+}
+
+async function requestWithFallback<T>(
+  paths: string[],
+  initFactory: (path: string) => RequestInit,
+  requestImpl: typeof fetchWithAuth = fetchWithAuth
+): Promise<T> {
+  let lastError: PaymentMethodApiError | null = null;
+
+  for (const path of paths) {
+    try {
+      return await requestJson<T>(path, initFactory(path), requestImpl);
+    } catch (error) {
+      const apiError = error instanceof PaymentMethodApiError ? error : new PaymentMethodApiError(String(error), 0);
+      lastError = apiError;
+      if (!shouldFallbackToAlias(apiError)) {
+        throw apiError;
+      }
+    }
+  }
+
+  throw lastError ?? new PaymentMethodApiError('Payment method request failed', 0);
+}
+
+export async function tokenizeIntuitCard(
+  input: IntuitTokenizationInput,
+  options: TokenizationOptions
+): Promise<string> {
+  if (!options.endpoint) {
+    throw new PaymentMethodApiError('Missing Intuit tokenization endpoint.', 0);
+  }
+
+  const parsedExpiration = parseExpiration(input.expiration);
+  if (!parsedExpiration) {
+    throw new PaymentMethodApiError('Invalid expiration date.', 400, 'validation_error');
+  }
+
+  const response = await (options.fetchImpl ?? fetch)(options.endpoint, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    credentials: 'omit',
+    body: JSON.stringify({
+      client_id: input.clientId,
+      cardholder_name: input.cardholderName,
+      card_number: input.cardNumber,
+      cvc: input.cvc,
+      exp_month: parsedExpiration.exp_month,
+      exp_year: parsedExpiration.exp_year,
+      billing_address: {
+        line1: input.billingAddress1,
+        line2: input.billingAddress2 || undefined,
+        city: input.billingCity,
+        state: input.billingState,
+        postal_code: input.billingPostalCode,
+        country: input.billingCountry,
+      },
+    }),
+  });
+
+  const parsed = await parseResponse<{ token?: unknown; data?: { token?: unknown } } | string>(response);
+  if (!response.ok) {
+    const message =
+      response.status >= 500 ? 'The payment service is temporarily unavailable. Please try again.' : 'We could not complete the request. Please try again.';
+    throw new PaymentMethodApiError(message, response.status);
+  }
+
+  const token =
+    isRecord(parsed) && typeof parsed.token === 'string'
+      ? parsed.token
+      : isRecord(parsed) && isRecord(parsed.data) && typeof parsed.data.token === 'string'
+        ? parsed.data.token
+        : null;
+
+  if (!token) {
+    throw new PaymentMethodApiError('The payment service did not return a token.', 502);
+  }
+
+  return token;
+}
+
+export async function savePaymentMethod(
+  input: PaymentMethodSaveRequest,
+  options?: PaymentMethodRequestOptions
+): Promise<PaymentMethodMetadata> {
+  const requestImpl = options?.requestImpl ?? fetchWithAuth;
+  const endpoints = options?.endpoints?.length ? options.endpoints : PAYMENT_METHOD_ENDPOINTS;
+
+  const data = await requestWithFallback<unknown>(
+    endpoints,
+    (path) => ({
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      credentials: 'include',
+      body: JSON.stringify(input),
+    }),
+    requestImpl
+  );
+
+  const normalized = normalizePaymentMethodMetadata(data);
+  if (!normalized) {
+    throw new PaymentMethodApiError('The card was saved, but the response format was not recognized.', 502);
+  }
+
+  return normalized;
+}
+
+export async function getPaymentMethod(
+  input: PaymentMethodQueryRequest,
+  options?: PaymentMethodRequestOptions
+): Promise<PaymentMethodMetadata | null> {
+  const requestImpl = options?.requestImpl ?? fetchWithAuth;
+  const endpoints = options?.endpoints?.length
+    ? options.endpoints
+    : PAYMENT_METHOD_ENDPOINTS.map((path) => `${path}/${encodeURIComponent(input.clientId)}`);
+
+  let lastError: PaymentMethodApiError | null = null;
+
+  for (const path of endpoints) {
+    try {
+      const data = await requestJson<unknown>(
+        path,
+        {
+          method: 'GET',
+          credentials: 'include',
+          headers: {
+            Accept: 'application/json',
+          },
+        },
+        requestImpl
+      );
+      const normalized = normalizePaymentMethodMetadata(data);
+      if (!normalized) {
+        throw new PaymentMethodApiError('The payment method response format was not recognized.', 502);
+      }
+      return normalized;
+    } catch (error) {
+      const apiError = error instanceof PaymentMethodApiError ? error : new PaymentMethodApiError(String(error), 0);
+      if (apiError.code === 'payment_method_not_found' || apiError.status === 404) {
+        // If the backend explicitly says no payment method exists, do not hide it behind alias fallback.
+        if (apiError.code === 'payment_method_not_found') return null;
+      }
+      lastError = apiError;
+      if (!shouldFallbackToAlias(apiError)) {
+        throw apiError;
+      }
+    }
+  }
+
+  if (lastError && lastError.code === 'payment_method_not_found') {
+    return null;
+  }
+
+  throw lastError ?? new PaymentMethodApiError('Payment method request failed', 0);
+}
+
+// Backwards-compatible aliases for existing imports/tests.
+export type QuickBooksCardTokenizationInput = IntuitTokenizationInput;
+export type QuickBooksSavedCardMetadata = PaymentMethodMetadata;
+export type QuickBooksTokenizationOptions = TokenizationOptions;
+export type QuickBooksSaveOptions = PaymentMethodRequestOptions;
+
+export async function tokenizeQuickBooksCard(
+  input: QuickBooksCardTokenizationInput,
+  options: QuickBooksTokenizationOptions
+): Promise<string> {
+  return tokenizeIntuitCard(input, options);
+}
+
+export async function saveQuickBooksCard(
+  input: { clientId: string; token: string },
+  options: QuickBooksSaveOptions
+): Promise<QuickBooksSavedCardMetadata> {
+  return savePaymentMethod(
+    {
+      client_id: input.clientId,
+      intuit_token: input.token,
+      request_id: createPaymentMethodRequestId(),
+    },
+    options
+  );
+}
+
+export function parsePaymentMethodMetadata(value: unknown): PaymentMethodMetadata | null {
+  return normalizePaymentMethodMetadata(value);
+}

--- a/src/features/client-dashboard/ClientDashboard.tsx
+++ b/src/features/client-dashboard/ClientDashboard.tsx
@@ -1,5 +1,3 @@
-import { Header } from '@/common/layouts/Header';
-import { Main } from '@/common/layouts/Main';
 import ClientProfileTab from './components/ClientProfileTab';
 import { useClientAuth } from '@/common/hooks/auth/useClientAuth';
 import { useIsClientPortalUser } from '@/common/hooks/auth/useIsClientPortalUser';
@@ -11,8 +9,14 @@ const serviceOutcomesUrl = (
   import.meta.env.VITE_CLIENT_PORTAL_SERVICE_OUTCOMES_URL as string | undefined
 )?.trim();
 
+type ClientDashboardView = 'profile' | 'billing' | 'all';
+
+interface ClientDashboardProps {
+  view?: ClientDashboardView;
+}
+
 /** Client-facing area: profile only (no org metrics or staff CRM). */
-export default function ClientDashboard() {
+export default function ClientDashboard({ view = 'profile' }: ClientDashboardProps) {
   const { client, isLoading: clientAuthLoading } = useClientAuth();
   const { isClientPortalUser, isLoading: portalLoading } = useIsClientPortalUser();
   const { user } = useUser();
@@ -22,16 +26,13 @@ export default function ClientDashboard() {
   if (isLoading) {
     return (
       <>
-        <Header fixed>
-          <div className='ml-auto flex items-center space-x-4'></div>
-        </Header>
-        <Main>
-          <div className='flex-1 overflow-auto p-6'>
+        <main className='w-full max-w-screen overflow-x-hidden px-4 py-6'>
+          <div className='p-6'>
             <div className='flex items-center justify-center h-64'>
               <div className='animate-spin rounded-full h-8 w-8 border-b-2 border-gray-900'></div>
             </div>
           </div>
-        </Main>
+        </main>
       </>
     );
   }
@@ -39,11 +40,8 @@ export default function ClientDashboard() {
   if (!isClientPortalUser) {
     return (
       <>
-        <Header fixed>
-          <div className='ml-auto flex items-center space-x-4'></div>
-        </Header>
-        <Main>
-          <div className='flex-1 overflow-auto p-6'>
+        <main className='w-full max-w-screen overflow-x-hidden px-4 py-6'>
+          <div className='p-6'>
             <Alert variant='destructive'>
               <AlertCircle className='h-4 w-4' />
               <AlertDescription>
@@ -55,7 +53,7 @@ export default function ClientDashboard() {
               </AlertDescription>
             </Alert>
           </div>
-        </Main>
+        </main>
       </>
     );
   }
@@ -69,19 +67,20 @@ export default function ClientDashboard() {
 
   return (
     <>
-      <Header fixed>
-        <div className='ml-auto flex items-center space-x-4'></div>
-      </Header>
-
-      <Main>
-        <div className='flex-1 overflow-auto p-6'>
+      <main className='w-full max-w-screen overflow-x-hidden px-4 py-6'>
+        <div className='p-6'>
           <div className='mb-6'>
-            <h1 className='text-3xl font-bold text-gray-900'>Your profile</h1>
-            <p className='text-gray-600 mt-1'>
-              Welcome, {welcomeName}. Update your details below.
+            <h1 className='text-3xl font-bold text-gray-900'>
+              {view === 'billing' ? 'Billing information' : 'Profile information'}
+            </h1>
+            <p className='mt-1 text-gray-600'>
+              Welcome, {welcomeName}.{' '}
+              {view === 'billing'
+                ? 'Update your billing details below.'
+                : 'Update your details below.'}
             </p>
             {serviceOutcomesUrl ? (
-              <p className='text-gray-600 mt-2'>
+              <p className='mt-2 text-gray-600'>
                 <a
                   href={serviceOutcomesUrl}
                   target='_blank'
@@ -90,14 +89,14 @@ export default function ClientDashboard() {
                 >
                   Service Outcomes
                 </a>
-                <span className='text-gray-500 text-sm ml-2'>(opens in a new tab)</span>
+                <span className='ml-2 text-sm text-gray-500'>(opens in a new tab)</span>
               </p>
             ) : null}
           </div>
 
-          <ClientProfileTab />
+          <ClientProfileTab view={view} />
         </div>
-      </Main>
+      </main>
     </>
   );
 }

--- a/src/features/client-dashboard/components/ClientProfileTab.tsx
+++ b/src/features/client-dashboard/components/ClientProfileTab.tsx
@@ -31,32 +31,111 @@ import { Badge } from '@/common/components/ui/badge';
 import { format, isValid, parseISO } from 'date-fns';
 import { Download, ExternalLink, FileImage, Loader2, MessageSquare, Trash2, Upload } from 'lucide-react';
 import { buildUrl, fetchWithAuth } from '@/api/http';
+import QuickBooksCardOnFileForm from '@/features/billing/components/QuickBooksCardOnFileForm';
 import {
   compareClientDocumentsByUploadedAtDesc,
   deleteClientDocument,
   getClientDocumentLabel,
   getClientDocumentUrl,
+  getInsuranceCardSide,
   isInsuranceCardDocument,
   listClientDocuments,
   uploadInsuranceCard,
+  type InsuranceCardSide,
   type ClientDocument,
 } from '@/api/clients/clientDocuments';
+import { normalizeZipCode } from '@/common/utils/zipCode';
+
+type ClientDashboardView = 'all' | 'profile' | 'billing';
 
 const BILLING_PAYMENT_METHOD_OPTIONS = [
   'Self-Pay',
   'Commercial Insurance',
   'Private Insurance',
   'Medicaid',
-  'Other',
 ] as const;
+
+function normalizeBillingPaymentMethod(method: unknown): string {
+  const raw = String(method ?? '').trim();
+  if (!raw) return '';
+
+  const normalized = raw.toLowerCase().replace(/_/g, ' ').replace(/\s+/g, ' ');
+
+  if (normalized === 'self-pay' || normalized === 'self pay' || normalized === 'selfpay') {
+    return 'Self-Pay';
+  }
+  if (normalized === 'commercial insurance') {
+    return 'Commercial Insurance';
+  }
+  if (normalized === 'private insurance') {
+    return 'Private Insurance';
+  }
+  if (normalized === 'medicaid') {
+    return 'Medicaid';
+  }
+
+  return raw;
+}
+
+function isBillingPaymentMethodOption(value: string): boolean {
+  return BILLING_PAYMENT_METHOD_OPTIONS.includes(value as (typeof BILLING_PAYMENT_METHOD_OPTIONS)[number]);
+}
 
 function isSelfPayMethod(method: string): boolean {
   const normalized = method.trim().toLowerCase();
   return normalized === 'self-pay' || normalized === 'self pay' || normalized === 'selfpay';
 }
 
+function hasInsuranceBilling(method: string): boolean {
+  const normalized = method.trim();
+  return normalized.length > 0 && !isSelfPayMethod(normalized);
+}
+
+function isImageDocument(document: ClientDocument): boolean {
+  const contentType = document.contentType?.toLowerCase() || '';
+  if (contentType.startsWith('image/')) return true;
+  return /\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(document.fileName);
+}
+
 function isEndpointUnavailableStatus(status: number): boolean {
   return status === 404 || status === 405 || status === 501;
+}
+
+function getInsuranceCardDocumentForSide(
+  documents: ClientDocument[],
+  side: InsuranceCardSide
+): ClientDocument | null {
+  const explicit = documents.find(
+    (document) => getInsuranceCardSide(document.documentType, document.fileName) === side
+  );
+  if (explicit) return explicit;
+  if (side === 'front') {
+    return documents.find((document) => document.documentType === 'insurance_card') ?? null;
+  }
+  return null;
+}
+
+export function buildClientProfileUpdatePayload(formData: {
+  firstname: string;
+  lastname: string;
+  phone: string;
+  address: string;
+  city: string;
+  state: string;
+  zip_code: string | number | null | undefined;
+  bio: string;
+}) {
+  return {
+    firstname: formData.firstname,
+    lastname: formData.lastname,
+    phone: formData.phone,
+    phone_number: formData.phone,
+    address: formData.address,
+    city: formData.city,
+    state: formData.state,
+    zip_code: normalizeZipCode(formData.zip_code),
+    bio: formData.bio,
+  };
 }
 
 function extractBillingPayload(payload: unknown): Record<string, unknown> {
@@ -68,7 +147,11 @@ function extractBillingPayload(payload: unknown): Record<string, unknown> {
   return obj;
 }
 
-export default function ClientProfileTab() {
+interface ClientProfileTabProps {
+  view?: ClientDashboardView;
+}
+
+export default function ClientProfileTab({ view = 'all' }: ClientProfileTabProps) {
   const { client } = useClientAuth();
   const { user } = useUser();
   const userRecord = user as Record<string, unknown> | null;
@@ -85,9 +168,30 @@ export default function ClientProfileTab() {
   const [sharedNotesLoading, setSharedNotesLoading] = useState(false);
   const [clientDocuments, setClientDocuments] = useState<ClientDocument[]>([]);
   const [documentsLoading, setDocumentsLoading] = useState(false);
-  const [uploadingInsuranceCard, setUploadingInsuranceCard] = useState(false);
+  const [uploadingInsuranceCardSide, setUploadingInsuranceCardSide] =
+    useState<InsuranceCardSide | null>(null);
   const [deletingInsuranceCardId, setDeletingInsuranceCardId] = useState<string | null>(null);
   const [activeDocumentId, setActiveDocumentId] = useState<string | null>(null);
+  const [documentPreviewUrls, setDocumentPreviewUrls] = useState<Record<string, string>>({});
+  const [isProfileEditing, setIsProfileEditing] = useState(false);
+  const [profileSnapshot, setProfileSnapshot] = useState({
+    firstname: '',
+    lastname: '',
+    phone: '',
+    address: '',
+    city: '',
+    state: '',
+    zip_code: '',
+    bio: '',
+  });
+  const [billingPaymentMethodDisplay, setBillingPaymentMethodDisplay] = useState('');
+  const [isBillingEditing, setIsBillingEditing] = useState(false);
+  const [billingSnapshot, setBillingSnapshot] = useState({
+    payment_method: '',
+    insurance_provider: '',
+    insurance_member_id: '',
+    policy_number: '',
+  });
   const [formData, setFormData] = useState({
     firstname: '',
     lastname: '',
@@ -102,7 +206,6 @@ export default function ClientProfileTab() {
     insurance_provider: '',
     insurance_member_id: '',
     policy_number: '',
-    self_pay_card_info: '',
   });
 
   const getClientApiBase = () =>
@@ -267,17 +370,13 @@ export default function ClientProfileTab() {
         profile = payload?.success && payload?.data ? payload.data : payload;
       }
 
-      setFormData({
-        firstname: profile?.firstname || profile?.first_name || effectiveClientFirstName,
-        lastname: profile?.lastname || profile?.last_name || effectiveClientLastName,
-        email: profile?.email || effectiveClientEmail,
-        phone: profile?.phone || profile?.phone_number || '',
-        address: profile?.address || profile?.address_line1 || '',
-        city: profile?.city || '',
-        state: profile?.state || '',
-        zip_code: profile?.zip_code || profile?.zipCode || '',
-        bio: profile?.bio || '',
-        payment_method: profile?.payment_method || profile?.paymentMethod || '',
+      const profilePaymentMethod = normalizeBillingPaymentMethod(
+        profile?.payment_method ?? profile?.paymentMethod ?? ''
+      );
+      const profileBillingState = {
+        payment_method: isBillingPaymentMethodOption(profilePaymentMethod)
+          ? profilePaymentMethod
+          : '',
         insurance_provider:
           profile?.insurance_provider ||
           profile?.insuranceProvider ||
@@ -286,9 +385,34 @@ export default function ClientProfileTab() {
         insurance_member_id:
           profile?.insurance_member_id || profile?.insuranceMemberId || '',
         policy_number: profile?.policy_number || profile?.policyNumber || '',
-        self_pay_card_info:
-          profile?.self_pay_card_info || profile?.selfPayCardInfo || '',
+      };
+
+      setFormData({
+        firstname: profile?.firstname || profile?.first_name || effectiveClientFirstName,
+        lastname: profile?.lastname || profile?.last_name || effectiveClientLastName,
+        email: profile?.email || effectiveClientEmail,
+        phone: profile?.phone || profile?.phone_number || '',
+        address: profile?.address || profile?.address_line1 || '',
+        city: profile?.city || '',
+        state: profile?.state || '',
+        zip_code: normalizeZipCode(profile?.zip_code ?? profile?.zipCode),
+        bio: profile?.bio || '',
+        ...profileBillingState,
       });
+      setProfileSnapshot({
+        firstname: profile?.firstname || profile?.first_name || effectiveClientFirstName,
+        lastname: profile?.lastname || profile?.last_name || effectiveClientLastName,
+        phone: profile?.phone || profile?.phone_number || '',
+        address: profile?.address || profile?.address_line1 || '',
+        city: profile?.city || '',
+        state: profile?.state || '',
+        zip_code: normalizeZipCode(profile?.zip_code ?? profile?.zipCode),
+        bio: profile?.bio || '',
+      });
+      setIsProfileEditing(false);
+      setBillingPaymentMethodDisplay(profilePaymentMethod);
+      setBillingSnapshot(profileBillingState);
+      setIsBillingEditing(false);
 
       // Prefer dedicated billing endpoint when available; keep profile values as fallback.
       try {
@@ -298,45 +422,57 @@ export default function ClientProfileTab() {
         if (billingResponse.ok) {
           const billingRaw = await billingResponse.json().catch(() => ({}));
           const billing = extractBillingPayload(billingRaw);
-          setFormData((prev) => ({
-            ...prev,
-            payment_method:
-              String(
-                billing.payment_method ??
-                  billing.paymentMethod ??
-                  prev.payment_method ??
-                  ''
-              ) || '',
+          const loadedPaymentMethod = normalizeBillingPaymentMethod(
+            billing.payment_method ??
+              billing.paymentMethod ??
+              profilePaymentMethod ??
+              ''
+          );
+          const loadedBillingState = {
+            payment_method: isBillingPaymentMethodOption(loadedPaymentMethod)
+              ? loadedPaymentMethod
+              : '',
             insurance_provider:
               String(
                 billing.insurance_provider ??
                   billing.insuranceProvider ??
                   billing.insurance ??
-                  prev.insurance_provider ??
+                  profileBillingState.insurance_provider ??
                   ''
               ) || '',
             insurance_member_id:
               String(
                 billing.insurance_member_id ??
                   billing.insuranceMemberId ??
-                  prev.insurance_member_id ??
+                  profileBillingState.insurance_member_id ??
                   ''
               ) || '',
             policy_number:
               String(
                 billing.policy_number ??
                   billing.policyNumber ??
-                  prev.policy_number ??
+                  profileBillingState.policy_number ??
                   ''
               ) || '',
-            self_pay_card_info:
-              String(
-                billing.self_pay_card_info ??
-                  billing.selfPayCardInfo ??
-                  prev.self_pay_card_info ??
-                  ''
-              ) || '',
+          };
+          setFormData((prev) => ({
+            ...prev,
+            ...loadedBillingState,
           }));
+          setProfileSnapshot((prev) => ({
+            ...prev,
+            firstname: profile?.firstname || profile?.first_name || effectiveClientFirstName,
+            lastname: profile?.lastname || profile?.last_name || effectiveClientLastName,
+            phone: profile?.phone || profile?.phone_number || '',
+            address: profile?.address || profile?.address_line1 || '',
+            city: profile?.city || '',
+            state: profile?.state || '',
+            zip_code: normalizeZipCode(profile?.zip_code ?? profile?.zipCode),
+            bio: profile?.bio || '',
+          }));
+          setBillingPaymentMethodDisplay(loadedPaymentMethod);
+          setBillingSnapshot(loadedBillingState);
+          setIsBillingEditing(false);
         }
       } catch {
         // Keep backward compatibility: ignore if endpoint is unavailable or unreachable.
@@ -358,8 +494,8 @@ export default function ClientProfileTab() {
         insurance_provider: '',
         insurance_member_id: '',
         policy_number: '',
-        self_pay_card_info: '',
       });
+      setBillingPaymentMethodDisplay('');
     } finally {
       setIsLoading(false);
     }
@@ -384,11 +520,54 @@ export default function ClientProfileTab() {
   }, []);
 
   useEffect(() => {
+    let cancelled = false;
+
+    const populatePreviewUrls = async () => {
+      const imageDocs = clientDocuments.filter(isInsuranceCardDocument).filter(isImageDocument);
+      const missingDocs = imageDocs.filter((doc) => !documentPreviewUrls[doc.id]);
+
+      if (missingDocs.length === 0) return;
+
+      const entries = await Promise.all(
+        missingDocs.map(async (doc) => {
+          try {
+            const url = doc.url || (await getClientDocumentUrl('client-self', doc.id));
+            return [doc.id, url] as const;
+          } catch {
+            return null;
+          }
+        })
+      );
+
+      if (cancelled) return;
+
+      setDocumentPreviewUrls((prev) => {
+        const next = { ...prev };
+        entries.forEach((entry) => {
+          if (entry) {
+            next[entry[0]] = entry[1];
+          }
+        });
+        return next;
+      });
+    };
+
+    void populatePreviewUrls();
+    return () => {
+      cancelled = true;
+    };
+  }, [clientDocuments, documentPreviewUrls]);
+
+  useEffect(() => {
     if (effectiveClientId) {
       fetchProfile();
-      fetchClientAssignedDoulas();
-      fetchSharedNotesFromDoula();
-      fetchClientDocuments();
+      if (view !== 'billing') {
+        fetchClientAssignedDoulas();
+        fetchSharedNotesFromDoula();
+      }
+      if (view !== 'profile') {
+        fetchClientDocuments();
+      }
     } else {
       setIsLoading(false);
     }
@@ -398,6 +577,7 @@ export default function ClientProfileTab() {
     fetchClientAssignedDoulas,
     fetchSharedNotesFromDoula,
     fetchClientDocuments,
+    view,
   ]);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
@@ -406,25 +586,6 @@ export default function ClientProfileTab() {
 
     setIsSaving(true);
     try {
-      const selectedPaymentMethod = formData.payment_method.trim();
-      const isSelfPay = isSelfPayMethod(selectedPaymentMethod);
-
-      if (!selectedPaymentMethod) {
-        toast.error('Please select a payment method.');
-        setIsSaving(false);
-        return;
-      }
-      if (isSelfPay && !formData.self_pay_card_info.trim()) {
-        toast.error('Please enter credit card information for self-pay.');
-        setIsSaving(false);
-        return;
-      }
-      if (!isSelfPay && !formData.insurance_provider.trim()) {
-        toast.error('Please enter an insurance provider for insurance billing.');
-        setIsSaving(false);
-        return;
-      }
-
       let token: string | undefined;
       try {
         const {
@@ -435,23 +596,179 @@ export default function ClientProfileTab() {
         token = undefined;
       }
 
+      if (view === 'profile') {
+        const response = await fetch(
+          `${getClientApiBase()}/clients/${effectiveClientId}`,
+          {
+            method: 'PUT',
+            credentials: 'include',
+            headers: getClientAuthHeaders(token),
+            body: JSON.stringify(
+              buildClientProfileUpdatePayload({
+                firstname: formData.firstname,
+                lastname: formData.lastname,
+                phone: formData.phone,
+                address: formData.address,
+                city: formData.city,
+                state: formData.state,
+                zip_code: formData.zip_code,
+                bio: formData.bio,
+              })
+            ),
+          }
+        );
+
+        if (!response.ok) {
+          const errorText = await response.text().catch(() => '');
+          throw new Error(
+            `Failed to update profile (${response.status}) ${errorText}`.trim()
+          );
+        }
+
+        if (client) {
+          await supabase.auth.updateUser({
+            data: {
+              firstname: formData.firstname,
+              lastname: formData.lastname,
+              phone: formData.phone,
+            },
+          });
+        }
+
+        toast.success('Profile updated successfully');
+        setProfileSnapshot({
+          firstname: formData.firstname,
+          lastname: formData.lastname,
+          phone: formData.phone,
+          address: formData.address,
+          city: formData.city,
+          state: formData.state,
+          zip_code: formData.zip_code,
+          bio: formData.bio,
+        });
+        setIsProfileEditing(false);
+        return;
+      }
+
+      if (view === 'billing') {
+        const selectedPaymentMethod = formData.payment_method.trim();
+        const isSelfPay = isSelfPayMethod(selectedPaymentMethod);
+
+        if (!selectedPaymentMethod) {
+          toast.error('Please select a payment method.');
+          setIsSaving(false);
+          return;
+        }
+        if (!isSelfPay && !formData.insurance_provider.trim()) {
+          toast.error('Please enter an insurance provider for insurance billing.');
+          setIsSaving(false);
+          return;
+        }
+        if (!isSelfPay && !formData.insurance_member_id.trim()) {
+          toast.error('Please enter an insurance member ID for insurance billing.');
+          setIsSaving(false);
+          return;
+        }
+        if (!isSelfPay && !formData.policy_number.trim()) {
+          toast.error('Please enter a policy number for insurance billing.');
+          setIsSaving(false);
+          return;
+        }
+        if (!isSelfPay && (!frontInsuranceCard || !backInsuranceCard)) {
+          toast.error('Please upload both the front and back insurance cards before saving insurance billing.');
+          setIsSaving(false);
+          return;
+        }
+
+        const billingPayload = {
+          payment_method: selectedPaymentMethod,
+          insurance_provider: isSelfPay ? '' : formData.insurance_provider,
+          insurance_member_id: isSelfPay ? '' : formData.insurance_member_id,
+          policy_number: isSelfPay ? '' : formData.policy_number,
+          insurance: isSelfPay ? '' : formData.insurance_provider,
+        };
+
+        const billingResponse = await fetchWithAuth(buildUrl('/api/clients/me/billing'), {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(billingPayload),
+        });
+
+        if (!billingResponse.ok) {
+          if (isEndpointUnavailableStatus(billingResponse.status)) {
+            const legacyBillingResponse = await fetch(
+              `${getClientApiBase()}/clients/${effectiveClientId}`,
+              {
+                method: 'PUT',
+                credentials: 'include',
+                headers: getClientAuthHeaders(token),
+                body: JSON.stringify(billingPayload),
+              }
+            );
+            if (!legacyBillingResponse.ok) {
+              const legacyErrorText = await legacyBillingResponse.text().catch(() => '');
+              throw new Error(
+                `Failed to update billing (${legacyBillingResponse.status}) ${legacyErrorText}`.trim()
+              );
+            }
+          } else {
+            const billingErrorText = await billingResponse.text().catch(() => '');
+            throw new Error(
+              `Failed to update billing (${billingResponse.status}) ${billingErrorText}`.trim()
+            );
+          }
+        }
+
+        toast.success('Billing updated successfully');
+        setBillingPaymentMethodDisplay(selectedPaymentMethod);
+        setBillingSnapshot({
+          payment_method: isSelfPay ? 'Self-Pay' : selectedPaymentMethod,
+          insurance_provider: isSelfPay ? '' : formData.insurance_provider,
+          insurance_member_id: isSelfPay ? '' : formData.insurance_member_id,
+          policy_number: isSelfPay ? '' : formData.policy_number,
+        });
+        setIsBillingEditing(false);
+        return;
+      }
+
+      const selectedPaymentMethod = formData.payment_method.trim();
+      const isSelfPay = isSelfPayMethod(selectedPaymentMethod);
+
+      if (!selectedPaymentMethod) {
+        toast.error('Please select a payment method.');
+        setIsSaving(false);
+        return;
+      }
+      if (!isSelfPay && !formData.insurance_provider.trim()) {
+        toast.error('Please enter an insurance provider for insurance billing.');
+        setIsSaving(false);
+        return;
+      }
+      if (!isSelfPay && !formData.insurance_member_id.trim()) {
+        toast.error('Please enter an insurance member ID for insurance billing.');
+        setIsSaving(false);
+        return;
+      }
+      if (!isSelfPay && !formData.policy_number.trim()) {
+        toast.error('Please enter a policy number for insurance billing.');
+        setIsSaving(false);
+        return;
+      }
+      if (!isSelfPay && (!frontInsuranceCard || !backInsuranceCard)) {
+        toast.error('Please upload both the front and back insurance cards before saving insurance billing.');
+        setIsSaving(false);
+        return;
+      }
+
       const response = await fetch(
         `${getClientApiBase()}/clients/${effectiveClientId}`,
         {
           method: 'PUT',
           credentials: 'include',
           headers: getClientAuthHeaders(token),
-          body: JSON.stringify({
-            firstname: formData.firstname,
-            lastname: formData.lastname,
-            phone: formData.phone,
-            phone_number: formData.phone,
-            address: formData.address,
-            city: formData.city,
-            state: formData.state,
-            zip_code: formData.zip_code,
-            bio: formData.bio,
-          }),
+          body: JSON.stringify(buildClientProfileUpdatePayload(formData)),
         }
       );
 
@@ -467,7 +784,6 @@ export default function ClientProfileTab() {
         insurance_provider: isSelfPay ? '' : formData.insurance_provider,
         insurance_member_id: isSelfPay ? '' : formData.insurance_member_id,
         policy_number: isSelfPay ? '' : formData.policy_number,
-        self_pay_card_info: isSelfPay ? formData.self_pay_card_info : '',
         // Keep legacy insurance field in sync where backend still uses it.
         insurance: isSelfPay ? '' : formData.insurance_provider,
       };
@@ -520,6 +836,14 @@ export default function ClientProfileTab() {
       }
 
       toast.success('Profile updated successfully');
+      setBillingPaymentMethodDisplay(selectedPaymentMethod);
+      setBillingSnapshot({
+        payment_method: isSelfPay ? 'Self-Pay' : selectedPaymentMethod,
+        insurance_provider: isSelfPay ? '' : formData.insurance_provider,
+        insurance_member_id: isSelfPay ? '' : formData.insurance_member_id,
+        policy_number: isSelfPay ? '' : formData.policy_number,
+      });
+      setIsBillingEditing(false);
     } catch (error: any) {
       console.error('Error updating profile:', error);
       toast.error(error.message || 'Failed to update profile');
@@ -528,12 +852,70 @@ export default function ClientProfileTab() {
     }
   };
 
-  const activeInsuranceCard =
-    clientDocuments
-      .filter(isInsuranceCardDocument)
-      .sort(compareClientDocumentsByUploadedAtDesc)[0] ?? null;
+  const insuranceCardDocuments = clientDocuments
+    .filter(isInsuranceCardDocument)
+    .sort(compareClientDocumentsByUploadedAtDesc);
+  const frontInsuranceCard = getInsuranceCardDocumentForSide(insuranceCardDocuments, 'front');
+  const backInsuranceCard = getInsuranceCardDocumentForSide(insuranceCardDocuments, 'back');
+  const isProfileFormDisabled = isSaving || !isProfileEditing;
+  const requiresInsuranceCard = !isSelfPayMethod(formData.payment_method);
+  const isBillingFormDisabled = isSaving || !isBillingEditing;
+  const isBillingSaveDisabled =
+    isSaving || (requiresInsuranceCard && (!frontInsuranceCard || !backInsuranceCard));
+
+  const handleStartProfileEdit = () => {
+    setProfileSnapshot({
+      firstname: formData.firstname,
+      lastname: formData.lastname,
+      phone: formData.phone,
+      address: formData.address,
+      city: formData.city,
+      state: formData.state,
+      zip_code: formData.zip_code,
+      bio: formData.bio,
+    });
+    setIsProfileEditing(true);
+  };
+
+  const handleCancelProfileEdit = () => {
+    setFormData((prev) => ({
+      ...prev,
+      firstname: profileSnapshot.firstname,
+      lastname: profileSnapshot.lastname,
+      phone: profileSnapshot.phone,
+      address: profileSnapshot.address,
+      city: profileSnapshot.city,
+      state: profileSnapshot.state,
+      zip_code: profileSnapshot.zip_code,
+      bio: profileSnapshot.bio,
+    }));
+    setIsProfileEditing(false);
+  };
+
+  const handleStartBillingEdit = () => {
+    setBillingSnapshot({
+      payment_method: formData.payment_method,
+      insurance_provider: formData.insurance_provider,
+      insurance_member_id: formData.insurance_member_id,
+      policy_number: formData.policy_number,
+    });
+    setIsBillingEditing(true);
+  };
+
+  const handleCancelBillingEdit = () => {
+    setFormData((prev) => ({
+      ...prev,
+      payment_method: billingSnapshot.payment_method,
+      insurance_provider: billingSnapshot.insurance_provider,
+      insurance_member_id: billingSnapshot.insurance_member_id,
+      policy_number: billingSnapshot.policy_number,
+    }));
+    setBillingPaymentMethodDisplay(billingSnapshot.payment_method);
+    setIsBillingEditing(false);
+  };
 
   const handleInsuranceCardSelected = async (
+    side: InsuranceCardSide,
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
     const file = e.target.files?.[0];
@@ -559,15 +941,15 @@ export default function ClientProfileTab() {
       return;
     }
 
-    setUploadingInsuranceCard(true);
+    setUploadingInsuranceCardSide(side);
     try {
-      await uploadInsuranceCard(file);
-      toast.success('Insurance card uploaded successfully');
+      await uploadInsuranceCard(file, side);
+      toast.success(`Insurance card ${side} uploaded successfully`);
       await fetchClientDocuments();
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to upload insurance card');
+      toast.error(error instanceof Error ? error.message : `Failed to upload insurance card ${side}`);
     } finally {
-      setUploadingInsuranceCard(false);
+      setUploadingInsuranceCardSide((current) => (current === side ? null : current));
     }
   };
 
@@ -631,259 +1013,212 @@ export default function ClientProfileTab() {
     }
   };
 
+  const renderInsuranceCardDocument = (documentItem: ClientDocument) => {
+    const parsed = documentItem.uploadedAt ? parseISO(documentItem.uploadedAt) : null;
+    const uploadedAt =
+      parsed && isValid(parsed) ? format(parsed, 'MMM d, yyyy') : documentItem.uploadedAt || '';
+    const isBusy =
+      activeDocumentId === documentItem.id ||
+      deletingInsuranceCardId === documentItem.id ||
+      uploadingInsuranceCardSide !== null;
+    const previewUrl = documentPreviewUrls[documentItem.id] || documentItem.url || '';
+    const showPreview = isImageDocument(documentItem) && previewUrl;
+
+    return (
+      <div
+        key={documentItem.id}
+        className='flex flex-col gap-3 rounded-lg border p-3 md:flex-row md:items-start md:justify-between'
+      >
+        <div className='min-w-0 flex-1'>
+          <div className='flex items-center gap-2'>
+            <FileImage className='h-4 w-4 text-primary' />
+            <p className='truncate text-sm font-medium'>{documentItem.fileName}</p>
+            <Badge variant='secondary'>
+              {getClientDocumentLabel(documentItem.documentType, documentItem.fileName)}
+            </Badge>
+          </div>
+          <p className='mt-1 text-xs text-muted-foreground'>
+            {uploadedAt ? `Uploaded ${uploadedAt}` : 'Upload date unavailable'}
+          </p>
+          {showPreview ? (
+            <img
+              src={previewUrl}
+              alt={documentItem.fileName}
+              className='mt-3 max-h-56 rounded-md border object-contain'
+            />
+          ) : null}
+        </div>
+        <div className='flex flex-wrap items-center gap-2'>
+          <Button
+            type='button'
+            variant='outline'
+            size='sm'
+            onClick={() => void handleOpenDocument(documentItem)}
+            disabled={isBusy}
+          >
+            <ExternalLink className='mr-1 h-4 w-4' />
+            {activeDocumentId === documentItem.id ? 'Opening...' : 'View'}
+          </Button>
+          <Button
+            type='button'
+            variant='outline'
+            size='sm'
+            onClick={() => void handleDownloadDocument(documentItem)}
+            disabled={isBusy}
+          >
+            <Download className='mr-1 h-4 w-4' />
+            {activeDocumentId === documentItem.id ? 'Working...' : 'Download'}
+          </Button>
+          <Button
+            type='button'
+            variant='outline'
+            size='sm'
+            onClick={() => void handleDeleteInsuranceCard(documentItem)}
+            disabled={isBusy || isBillingFormDisabled}
+          >
+            <Trash2 className='mr-1 h-4 w-4' />
+            {deletingInsuranceCardId === documentItem.id
+              ? 'Removing...'
+              : 'Remove Insurance Card'}
+          </Button>
+        </div>
+      </div>
+    );
+  };
+
   if (isLoading) {
     return <LoadingOverlay isLoading={isLoading} />;
   }
 
   return (
-    <div className='space-y-6'>
-      <Card>
-        <CardHeader>
-          <CardTitle>
-            Your Assigned Doula{assignedDoulas.length !== 1 ? 's' : ''}
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {isLoadingAssignedDoulas ? (
-            <div className='flex items-center gap-2 text-sm text-muted-foreground'>
-              <Loader2 className='h-4 w-4 animate-spin' />
-              Loading assigned doulas...
-            </div>
-          ) : assignedDoulasError ? (
-            <div className='space-y-2'>
-              <p className='text-sm text-destructive'>{assignedDoulasError}</p>
-              <Button
-                variant='outline'
-                size='sm'
-                onClick={fetchClientAssignedDoulas}
-              >
-                Retry
-              </Button>
-            </div>
-          ) : assignedDoulas.length === 0 ? (
-            <p className='text-sm text-muted-foreground'>
-              You do not have an assigned doula yet.
-            </p>
-          ) : (
-            <div className='space-y-3'>
-              {assignedDoulas.map((assignment) => {
-                const doula = assignment.doula;
-                const fullName =
-                  `${doula.firstname || ''} ${doula.lastname || ''}`.trim() ||
-                  doula.email;
-                const role = normalizeAssignmentRole(
-                  assignment.role ?? assignment.category
-                );
-                const roleLabel = role
-                  ? ASSIGNMENT_ROLE_OPTIONS.find((option) => option.value === role)
-                      ?.label || 'Unspecified'
-                  : 'Unspecified';
-                return (
-                  <div
-                    key={assignment.id}
-                    className='flex items-center justify-between rounded-lg border p-3'
+    <div className='space-y-4'>
+      {view !== 'billing' ? (
+        <>
+          <Card>
+            <CardHeader>
+              <CardTitle>
+                Your Assigned Doula{assignedDoulas.length !== 1 ? 's' : ''}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {isLoadingAssignedDoulas ? (
+                <div className='flex items-center gap-2 text-sm text-muted-foreground'>
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                  Loading assigned doulas...
+                </div>
+              ) : assignedDoulasError ? (
+                <div className='space-y-2'>
+                  <p className='text-sm text-destructive'>{assignedDoulasError}</p>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    onClick={fetchClientAssignedDoulas}
                   >
-                    <div className='flex items-center gap-3'>
-                      <UserAvatar fullName={fullName} />
-                      <div>
-                        <p className='font-medium'>{fullName}</p>
-                        <p className='text-sm text-muted-foreground'>
-                          {doula.email}
-                        </p>
-                      </div>
-                    </div>
-                    <div className='flex items-center gap-2'>
-                      <Badge variant='secondary'>{roleLabel}</Badge>
-                      <Badge variant='outline'>{assignment.status}</Badge>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle className='flex items-center gap-2'>
-            <MessageSquare className='h-5 w-5' />
-            Updates from your care team
-          </CardTitle>
-        </CardHeader>
-        <CardContent>
-          {sharedNotesLoading ? (
-            <div className='flex items-center gap-2 text-sm text-muted-foreground'>
-              <Loader2 className='h-4 w-4 animate-spin' />
-              Loading…
-            </div>
-          ) : sharedNotes.length === 0 ? (
-            <p className='text-sm text-muted-foreground'>
-              When your doula shares a note with you, it will appear here.
-            </p>
-          ) : (
-            <ul className='space-y-4'>
-              {sharedNotes.map((note) => {
-                const parsed = note.created_at ? parseISO(note.created_at) : null;
-                const when =
-                  parsed && isValid(parsed)
-                    ? format(parsed, 'MMM d, yyyy · h:mm a')
-                    : note.created_at || '';
-                return (
-                  <li
-                    key={note.id}
-                    className='rounded-lg border border-border p-3 text-sm'
-                  >
-                    <div className='mb-1 flex flex-wrap items-center gap-2'>
-                      <Badge variant='secondary' className='text-xs capitalize'>
-                        {note.activity_type}
-                      </Badge>
-                      {when ? (
-                        <span className='text-xs text-muted-foreground'>{when}</span>
-                      ) : null}
-                    </div>
-                    <p className='whitespace-pre-wrap text-foreground'>{note.content}</p>
-                  </li>
-                );
-              })}
-            </ul>
-          )}
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle>Billing</CardTitle>
-        </CardHeader>
-        <CardContent className='space-y-4'>
-          <div className='rounded-lg border border-dashed p-4'>
-            <div className='flex flex-col gap-3 md:flex-row md:items-center md:justify-between'>
-              <div className='space-y-1'>
-                <p className='font-medium'>Insurance card</p>
+                    Retry
+                  </Button>
+                </div>
+              ) : assignedDoulas.length === 0 ? (
                 <p className='text-sm text-muted-foreground'>
-                  Upload a JPG, PNG, or PDF of your insurance card. Staff will be able to
-                  view and download it from your client profile.
+                  You do not have an assigned doula yet.
                 </p>
-              </div>
-              <div>
-                <input
-                  id='insurance-card-upload'
-                  type='file'
-                  accept='.jpg,.jpeg,.png,.pdf,image/jpeg,image/png,application/pdf'
-                  className='hidden'
-                  onChange={handleInsuranceCardSelected}
-                  disabled={uploadingInsuranceCard || Boolean(deletingInsuranceCardId)}
-                />
-                <Button
-                  type='button'
-                  onClick={() =>
-                    document.getElementById('insurance-card-upload')?.click()
-                  }
-                  disabled={uploadingInsuranceCard || Boolean(deletingInsuranceCardId)}
-                >
-                  <Upload className='mr-2 h-4 w-4' />
-                  {uploadingInsuranceCard
-                    ? 'Uploading...'
-                    : activeInsuranceCard
-                      ? 'Upload Another'
-                      : 'Upload Insurance Card'}
-                </Button>
-              </div>
-            </div>
-          </div>
-
-          {documentsLoading ? (
-            <div className='flex items-center gap-2 text-sm text-muted-foreground'>
-              <Loader2 className='h-4 w-4 animate-spin' />
-              Loading uploaded documents...
-            </div>
-          ) : !activeInsuranceCard ? (
-            <p className='text-sm text-muted-foreground'>
-              No insurance card uploaded yet.
-            </p>
-          ) : (
-            <div className='space-y-3'>
-              {[activeInsuranceCard].map((documentItem) => {
-                const parsed = documentItem.uploadedAt
-                  ? parseISO(documentItem.uploadedAt)
-                  : null;
-                const uploadedAt =
-                  parsed && isValid(parsed)
-                    ? format(parsed, 'MMM d, yyyy')
-                    : documentItem.uploadedAt || '';
-                const isBusy =
-                  activeDocumentId === documentItem.id ||
-                  deletingInsuranceCardId === documentItem.id ||
-                  uploadingInsuranceCard;
-
-                return (
-                  <div
-                    key={documentItem.id}
-                    className='flex flex-col gap-3 rounded-lg border p-3 md:flex-row md:items-center md:justify-between'
-                  >
-                    <div className='min-w-0'>
-                      <div className='flex items-center gap-2'>
-                        <FileImage className='h-4 w-4 text-primary' />
-                        <p className='truncate text-sm font-medium'>
-                          {documentItem.fileName}
-                        </p>
-                        <Badge variant='secondary'>
-                          {getClientDocumentLabel(documentItem.documentType)}
-                        </Badge>
+              ) : (
+                <div className='space-y-3'>
+                  {assignedDoulas.map((assignment) => {
+                    const doula = assignment.doula;
+                    const fullName =
+                      `${doula.firstname || ''} ${doula.lastname || ''}`.trim() ||
+                      doula.email;
+                    const role = normalizeAssignmentRole(
+                      assignment.role ?? assignment.category
+                    );
+                    const roleLabel = role
+                      ? ASSIGNMENT_ROLE_OPTIONS.find((option) => option.value === role)
+                          ?.label || 'Unspecified'
+                      : 'Unspecified';
+                    return (
+                      <div
+                        key={assignment.id}
+                        className='flex items-center justify-between rounded-lg border p-3'
+                      >
+                        <div className='flex items-center gap-3'>
+                          <UserAvatar fullName={fullName} />
+                          <div>
+                            <p className='font-medium'>{fullName}</p>
+                            <p className='text-sm text-muted-foreground'>
+                              {doula.email}
+                            </p>
+                          </div>
+                        </div>
+                        <div className='flex items-center gap-2'>
+                          <Badge variant='secondary'>{roleLabel}</Badge>
+                          <Badge variant='outline'>{assignment.status}</Badge>
+                        </div>
                       </div>
-                      <p className='mt-1 text-xs text-muted-foreground'>
-                        {uploadedAt ? `Uploaded ${uploadedAt}` : 'Upload date unavailable'}
-                      </p>
-                    </div>
-                    <div className='flex items-center gap-2'>
-                      <Button
-                        type='button'
-                        variant='outline'
-                        size='sm'
-                        onClick={() => void handleOpenDocument(documentItem)}
-                        disabled={isBusy}
-                      >
-                        <ExternalLink className='mr-1 h-4 w-4' />
-                        {activeDocumentId === documentItem.id ? 'Opening...' : 'View'}
-                      </Button>
-                      <Button
-                        type='button'
-                        variant='outline'
-                        size='sm'
-                        onClick={() => void handleDownloadDocument(documentItem)}
-                        disabled={isBusy}
-                      >
-                        <Download className='mr-1 h-4 w-4' />
-                        {activeDocumentId === documentItem.id ? 'Working...' : 'Download'}
-                      </Button>
-                      <Button
-                        type='button'
-                        variant='outline'
-                        size='sm'
-                        onClick={() => void handleDeleteInsuranceCard(documentItem)}
-                        disabled={isBusy}
-                      >
-                        <Trash2 className='mr-1 h-4 w-4' />
-                        {deletingInsuranceCardId === documentItem.id
-                          ? 'Removing...'
-                          : 'Remove Insurance Card'}
-                      </Button>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+                    );
+                  })}
+                </div>
+              )}
+            </CardContent>
+          </Card>
 
+          <Card>
+            <CardHeader>
+              <CardTitle className='flex items-center gap-2'>
+                <MessageSquare className='h-5 w-5' />
+                Updates from your care team
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              {sharedNotesLoading ? (
+                <div className='flex items-center gap-2 text-sm text-muted-foreground'>
+                  <Loader2 className='h-4 w-4 animate-spin' />
+                  Loading…
+                </div>
+              ) : sharedNotes.length === 0 ? (
+                <p className='text-sm text-muted-foreground'>
+                  When your doula shares a note with you, it will appear here.
+                </p>
+              ) : (
+                <ul className='space-y-4'>
+                  {sharedNotes.map((note) => {
+                    const parsed = note.created_at ? parseISO(note.created_at) : null;
+                    const when =
+                      parsed && isValid(parsed)
+                        ? format(parsed, 'MMM d, yyyy · h:mm a')
+                        : note.created_at || '';
+                    return (
+                      <li
+                        key={note.id}
+                        className='rounded-lg border border-border p-3 text-sm'
+                      >
+                        <div className='mb-1 flex flex-wrap items-center gap-2'>
+                          <Badge variant='secondary' className='text-xs capitalize'>
+                            {note.activity_type}
+                          </Badge>
+                          {when ? (
+                            <span className='text-xs text-muted-foreground'>{when}</span>
+                          ) : null}
+                        </div>
+                        <p className='whitespace-pre-wrap text-foreground'>{note.content}</p>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </CardContent>
+          </Card>
+        </>
+      ) : null}
+
+      {view !== 'billing' ? (
       <Card>
         <CardHeader>
           <CardTitle>Profile Information</CardTitle>
         </CardHeader>
         <CardContent>
-          <form onSubmit={handleSubmit} className='space-y-6'>
-            <div className='flex items-center gap-6 mb-6'>
+          <form onSubmit={handleSubmit} className='space-y-4'>
+            <div className='mb-4 flex items-center justify-between gap-4'>
+              <div className='flex items-center gap-4'>
               <UserAvatar
                 fullName={
                   `${formData.firstname || ''} ${formData.lastname || ''}`.trim() ||
@@ -900,9 +1235,30 @@ export default function ClientProfileTab() {
                   {formData.email}
                 </p>
               </div>
+              </div>
+              <div className='flex flex-wrap gap-2'>
+                {isProfileEditing ? (
+                  <Button
+                    type='button'
+                    variant='outline'
+                    onClick={handleCancelProfileEdit}
+                    disabled={isSaving}
+                  >
+                    Cancel
+                  </Button>
+                ) : null}
+                <Button
+                  type='button'
+                  variant={isProfileEditing ? 'secondary' : 'outline'}
+                  onClick={handleStartProfileEdit}
+                  disabled={isSaving || isProfileEditing}
+                >
+                  {isProfileEditing ? 'Editing Profile' : 'Edit Profile'}
+                </Button>
+              </div>
             </div>
 
-            <div className='grid grid-cols-2 gap-4'>
+            <div className='grid grid-cols-2 gap-3'>
               <div className='space-y-2'>
                 <Label htmlFor='firstname'>First Name</Label>
                 <Input
@@ -911,7 +1267,7 @@ export default function ClientProfileTab() {
                   onChange={(e) =>
                     setFormData({ ...formData, firstname: e.target.value })
                   }
-                  disabled={isSaving}
+                  disabled={isProfileFormDisabled}
                 />
               </div>
 
@@ -923,7 +1279,7 @@ export default function ClientProfileTab() {
                   onChange={(e) =>
                     setFormData({ ...formData, lastname: e.target.value })
                   }
-                  disabled={isSaving}
+                  disabled={isProfileFormDisabled}
                 />
               </div>
             </div>
@@ -952,7 +1308,7 @@ export default function ClientProfileTab() {
                 onChange={(e) =>
                   setFormData({ ...formData, phone: e.target.value })
                 }
-                disabled={isSaving}
+                disabled={isProfileFormDisabled}
               />
             </div>
 
@@ -964,11 +1320,11 @@ export default function ClientProfileTab() {
                 onChange={(e) =>
                   setFormData({ ...formData, address: e.target.value })
                 }
-                disabled={isSaving}
+                disabled={isProfileFormDisabled}
               />
             </div>
 
-            <div className='grid grid-cols-3 gap-4'>
+            <div className='grid grid-cols-3 gap-3'>
               <div className='space-y-2'>
                 <Label htmlFor='city'>City</Label>
                 <Input
@@ -977,7 +1333,7 @@ export default function ClientProfileTab() {
                   onChange={(e) =>
                     setFormData({ ...formData, city: e.target.value })
                   }
-                  disabled={isSaving}
+                  disabled={isProfileFormDisabled}
                 />
               </div>
 
@@ -989,7 +1345,7 @@ export default function ClientProfileTab() {
                   onChange={(e) =>
                     setFormData({ ...formData, state: e.target.value })
                   }
-                  disabled={isSaving}
+                  disabled={isProfileFormDisabled}
                 />
               </div>
 
@@ -1001,7 +1357,7 @@ export default function ClientProfileTab() {
                   onChange={(e) =>
                     setFormData({ ...formData, zip_code: e.target.value })
                   }
-                  disabled={isSaving}
+                  disabled={isProfileFormDisabled}
                 />
               </div>
             </div>
@@ -1014,110 +1370,259 @@ export default function ClientProfileTab() {
                 onChange={(e) =>
                   setFormData({ ...formData, bio: e.target.value })
                 }
-                disabled={isSaving}
+                disabled={isProfileFormDisabled}
                 rows={4}
                 placeholder='Tell us about yourself...'
               />
             </div>
-
-            <div className='rounded-lg border p-4 space-y-4'>
-              <h4 className='text-base font-semibold'>Billing Information</h4>
-
-              <div className='space-y-2'>
-                <Label>Payment Method</Label>
-                <Select
-                  value={formData.payment_method || undefined}
-                  onValueChange={(value) => {
-                    const selfPaySelected = isSelfPayMethod(value);
-                    setFormData((prev) => ({
-                      ...prev,
-                      payment_method: value,
-                      insurance_provider: selfPaySelected ? '' : prev.insurance_provider,
-                      insurance_member_id: selfPaySelected ? '' : prev.insurance_member_id,
-                      policy_number: selfPaySelected ? '' : prev.policy_number,
-                      self_pay_card_info: selfPaySelected ? prev.self_pay_card_info : '',
-                    }));
-                  }}
-                  disabled={isSaving}
-                >
-                  <SelectTrigger>
-                    <SelectValue placeholder='Select payment method' />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {BILLING_PAYMENT_METHOD_OPTIONS.map((option) => (
-                      <SelectItem key={option} value={option}>
-                        {option}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-
-              {isSelfPayMethod(formData.payment_method) ? (
-                <div className='space-y-2'>
-                  <Label htmlFor='self_pay_card_info'>Credit Card Information</Label>
-                  <Textarea
-                    id='self_pay_card_info'
-                    value={formData.self_pay_card_info}
-                    onChange={(e) =>
-                      setFormData({ ...formData, self_pay_card_info: e.target.value })
-                    }
-                    disabled={isSaving}
-                    rows={3}
-                    placeholder='Cardholder name, card brand, and last 4 digits'
-                  />
-                </div>
-              ) : (
-                <>
-                  <div className='space-y-2'>
-                    <Label htmlFor='insurance_provider'>Insurance Provider</Label>
-                    <Input
-                      id='insurance_provider'
-                      value={formData.insurance_provider}
-                      onChange={(e) =>
-                        setFormData({ ...formData, insurance_provider: e.target.value })
-                      }
-                      disabled={isSaving}
-                    />
-                  </div>
-
-                  <div className='grid grid-cols-2 gap-4'>
-                    <div className='space-y-2'>
-                      <Label htmlFor='insurance_member_id'>Insurance Member ID</Label>
-                      <Input
-                        id='insurance_member_id'
-                        value={formData.insurance_member_id}
-                        onChange={(e) =>
-                          setFormData({ ...formData, insurance_member_id: e.target.value })
-                        }
-                        disabled={isSaving}
-                      />
-                    </div>
-
-                    <div className='space-y-2'>
-                      <Label htmlFor='policy_number'>Policy Number</Label>
-                      <Input
-                        id='policy_number'
-                        value={formData.policy_number}
-                        onChange={(e) =>
-                          setFormData({ ...formData, policy_number: e.target.value })
-                        }
-                        disabled={isSaving}
-                      />
-                    </div>
-                  </div>
-                </>
-              )}
-            </div>
-
             <div className='flex justify-end'>
-              <Button type='submit' disabled={isSaving}>
-                {isSaving ? 'Saving...' : 'Save Changes'}
+              <Button type='submit' disabled={isProfileFormDisabled}>
+                {isSaving ? 'Saving...' : 'Save Profile Changes'}
               </Button>
             </div>
           </form>
         </CardContent>
       </Card>
+      ) : null}
+
+      {view !== 'profile' ? (
+      <Card>
+        <CardHeader>
+          <CardTitle>Billing Information</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit} className='space-y-4'>
+            <div className='flex flex-wrap items-center justify-between gap-3'>
+              <div className='space-y-1'>
+                <p className='text-sm text-muted-foreground'>
+                  Current payment method:{' '}
+                  <span className='font-medium text-foreground'>
+                    {billingPaymentMethodDisplay || 'Not set'}
+                  </span>
+                </p>
+              </div>
+              <div className='flex flex-wrap gap-2'>
+                {isBillingEditing ? (
+                  <Button
+                    type='button'
+                    variant='outline'
+                    onClick={handleCancelBillingEdit}
+                    disabled={isSaving}
+                  >
+                    Cancel
+                  </Button>
+                ) : null}
+                <Button
+                  type='button'
+                  variant={isBillingEditing ? 'secondary' : 'outline'}
+                  onClick={handleStartBillingEdit}
+                  disabled={isSaving || isBillingEditing}
+                >
+                  {isBillingEditing ? 'Editing Billing' : 'Edit Billing'}
+                </Button>
+              </div>
+            </div>
+
+            {hasInsuranceBilling(formData.payment_method) ? (
+              <>
+                <div className='grid gap-3 lg:grid-cols-2'>
+                  {[
+                    {
+                      side: 'front' as const,
+                      label: 'Front of Card',
+                      document: frontInsuranceCard,
+                    },
+                    {
+                      side: 'back' as const,
+                      label: 'Back of Card',
+                      document: backInsuranceCard,
+                    },
+                  ].map((slot) => (
+                    <div key={slot.side} className='rounded-lg border border-dashed p-3 space-y-3'>
+                      <div className='flex flex-col gap-2 md:flex-row md:items-center md:justify-between'>
+                        <div className='space-y-0.5'>
+                          <p className='font-medium'>Insurance {slot.label.toLowerCase()} *</p>
+                          <p className='text-sm text-muted-foreground'>
+                            Upload the {slot.label.toLowerCase()} of the insurance card. Staff will
+                            be able to view and download it from your client profile.
+                          </p>
+                        </div>
+                        <div>
+                          <input
+                            id={`insurance-card-${slot.side}-upload`}
+                            type='file'
+                            accept='.jpg,.jpeg,.png,.pdf,image/jpeg,image/png,application/pdf'
+                            className='hidden'
+                            onChange={(event) => void handleInsuranceCardSelected(slot.side, event)}
+                            disabled={
+                              isBillingFormDisabled ||
+                              uploadingInsuranceCardSide !== null ||
+                              Boolean(deletingInsuranceCardId)
+                            }
+                          />
+                          <Button
+                            type='button'
+                            onClick={() =>
+                              document.getElementById(`insurance-card-${slot.side}-upload`)?.click()
+                            }
+                            disabled={
+                              isBillingFormDisabled ||
+                              uploadingInsuranceCardSide !== null ||
+                              Boolean(deletingInsuranceCardId)
+                            }
+                          >
+                            <Upload className='mr-2 h-4 w-4' />
+                            {uploadingInsuranceCardSide === slot.side
+                              ? 'Uploading...'
+                              : slot.document
+                                ? `Upload Another ${slot.side === 'front' ? 'Front' : 'Back'} Card`
+                                : `Upload ${slot.side === 'front' ? 'Front' : 'Back'} Card`}
+                          </Button>
+                        </div>
+                      </div>
+
+                      {documentsLoading ? (
+                        <div className='flex items-center gap-2 text-sm text-muted-foreground'>
+                          <Loader2 className='h-4 w-4 animate-spin' />
+                          Loading uploaded documents...
+                        </div>
+                      ) : slot.document ? (
+                        renderInsuranceCardDocument(slot.document)
+                      ) : (
+                        <p className='text-sm text-muted-foreground'>
+                          No {slot.label.toLowerCase()} uploaded yet.
+                        </p>
+                      )}
+                    </div>
+                  ))}
+                </div>
+
+                <div className='space-y-1.5'>
+                  <Label>Payment Method</Label>
+                  <Select
+                    value={formData.payment_method || undefined}
+                    onValueChange={(value) => {
+                      const selfPaySelected = isSelfPayMethod(value);
+                      setFormData((prev) => ({
+                        ...prev,
+                        payment_method: value,
+                        insurance_provider: selfPaySelected ? '' : prev.insurance_provider,
+                        insurance_member_id: selfPaySelected ? '' : prev.insurance_member_id,
+                        policy_number: selfPaySelected ? '' : prev.policy_number,
+                      }));
+                      setBillingPaymentMethodDisplay(value);
+                    }}
+                    disabled={isBillingFormDisabled}
+                  >
+                    <SelectTrigger>
+                      <SelectValue placeholder='Select payment method' />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {BILLING_PAYMENT_METHOD_OPTIONS.map((option) => (
+                        <SelectItem key={option} value={option}>
+                          {option}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                {isSelfPayMethod(formData.payment_method) ? (
+                  <p className='text-sm text-muted-foreground'>
+                    Self-pay billing is supported without storing credit card details.
+                  </p>
+                ) : (
+                  <>
+                    <div className='space-y-1.5'>
+                      <Label htmlFor='insurance_provider'>Insurance Provider *</Label>
+                      <Input
+                        id='insurance_provider'
+                        value={formData.insurance_provider}
+                        onChange={(e) =>
+                          setFormData({ ...formData, insurance_provider: e.target.value })
+                        }
+                        disabled={isBillingFormDisabled}
+                      />
+                    </div>
+
+                    <div className='grid grid-cols-2 gap-3'>
+                      <div className='space-y-1.5'>
+                        <Label htmlFor='insurance_member_id'>Insurance Member ID *</Label>
+                        <Input
+                          id='insurance_member_id'
+                          value={formData.insurance_member_id}
+                          onChange={(e) =>
+                            setFormData({ ...formData, insurance_member_id: e.target.value })
+                          }
+                          disabled={isBillingFormDisabled}
+                        />
+                      </div>
+
+                      <div className='space-y-1.5'>
+                        <Label htmlFor='policy_number'>Policy Number *</Label>
+                        <Input
+                          id='policy_number'
+                          value={formData.policy_number}
+                          onChange={(e) =>
+                            setFormData({ ...formData, policy_number: e.target.value })
+                          }
+                          disabled={isBillingFormDisabled}
+                        />
+                      </div>
+                    </div>
+                  </>
+                )}
+
+                <div className='flex justify-end'>
+                  <Button
+                    type='submit'
+                    disabled={isBillingSaveDisabled || !isBillingEditing}
+                    title={
+                      requiresInsuranceCard && (!frontInsuranceCard || !backInsuranceCard)
+                        ? 'Upload front and back insurance cards to enable saving'
+                        : undefined
+                    }
+                  >
+                    {isSaving
+                      ? 'Saving...'
+                      : requiresInsuranceCard && (!frontInsuranceCard || !backInsuranceCard)
+                        ? 'Upload Insurance Card'
+                        : 'Save Billing Changes'}
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <p className='text-sm text-muted-foreground'>
+                Insurance details and card uploads appear here when an insurance-based payment
+                method is selected.
+              </p>
+            )}
+          </form>
+        </CardContent>
+      </Card>
+      ) : null}
+
+      {view !== 'profile' ? (
+        <div className='mt-6'>
+          {effectiveClientId ? (
+            <QuickBooksCardOnFileForm
+              clientId={effectiveClientId}
+              initialDisplayMode='compact'
+            />
+          ) : (
+            <Card>
+              <CardHeader>
+                <CardTitle>Card on File</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <p className='text-sm text-muted-foreground'>
+                  We could not load your client record yet. Please refresh and try again.
+                </p>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/src/features/client-dashboard/components/__tests__/ClientProfileTab.test.ts
+++ b/src/features/client-dashboard/components/__tests__/ClientProfileTab.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { buildClientProfileUpdatePayload } from '@/features/client-dashboard/components/ClientProfileTab';
+
+describe('buildClientProfileUpdatePayload', () => {
+  it('sends a numeric ZIP as a string', () => {
+    const payload = buildClientProfileUpdatePayload({
+      firstname: 'Jane',
+      lastname: 'Doe',
+      phone: '555-555-5555',
+      address: '123 Main St',
+      city: 'Chicago',
+      state: 'IL',
+      zip_code: 60601,
+      bio: 'hello',
+    });
+
+    expect(payload.zip_code).toBe('60601');
+  });
+
+  it('preserves leading zeros in ZIP codes', () => {
+    const payload = buildClientProfileUpdatePayload({
+      firstname: 'Jane',
+      lastname: 'Doe',
+      phone: '555-555-5555',
+      address: '123 Main St',
+      city: 'Chicago',
+      state: 'IL',
+      zip_code: ' 01234 ',
+      bio: 'hello',
+    });
+
+    expect(payload.zip_code).toBe('01234');
+  });
+});

--- a/src/features/clients/components/dialog/LeadProfileModal.tsx
+++ b/src/features/clients/components/dialog/LeadProfileModal.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/common/components/ui/dialog';
 import { Input } from '@/common/components/ui/input';
 import { Label } from '@/common/components/ui/label';
+import { Badge } from '@/common/components/ui/badge';
 import {
   Popover,
   PopoverContent,
@@ -28,13 +29,18 @@ import { PHI_KEYS } from '@/config/phi';
 import { Client } from '@/features/clients/data/schema';
 import type { ClientDetail } from '@/domain/client';
 import { cn } from '@/lib/utils';
+import { normalizeZipCode } from '@/common/utils/zipCode';
 import { format, formatDistanceToNow } from 'date-fns';
 import {
   Baby,
   Calendar as CalendarIcon,
+  Download,
   ChevronDown,
   ChevronRight,
+  ExternalLink,
   FileText,
+  FileImage,
+  Loader2,
   Mail,
   MapPin,
   MessageSquare,
@@ -46,6 +52,15 @@ import {
 import React, { useContext, useState } from 'react';
 import { toast } from 'sonner';
 import { DoulaAssignment } from '../DoulaAssignment';
+import {
+  compareClientDocumentsByUploadedAtDesc,
+  getClientDocumentLabel,
+  getClientDocumentUrl,
+  getInsuranceCardSide,
+  isInsuranceCardDocument,
+  listClientDocuments,
+  type ClientDocument,
+} from '@/api/clients/clientDocuments';
 
 interface LeadProfileModalProps {
   open: boolean;
@@ -74,7 +89,6 @@ const ANNUAL_INCOME_OPTIONS = [
   '100k and above'
 ];
 const PAYMENT_METHOD_OPTIONS = ['Self-Pay', 'Commercial Insurance', 'Private Insurance', 'Medicaid', 'Other'];
-const INSURANCE_PROVIDER_OPTIONS = ['Private', 'Medicaid', 'Medicare', 'Other'];
 const RACE_OPTIONS = ['African American/Black', 'Asian/Pacific Islander', 'Caucasian/White', 'Hispanic', 'Two or more races', 'Other'];
 const LANGUAGE_OPTIONS = ['English', 'Spanish', 'French', 'Mandarin', 'Arabic', 'Other'];
 const AGE_OPTIONS = ['Under 20', '20-25', '26-35', '36 and older'];
@@ -132,6 +146,42 @@ function isSelfPayMethod(method: string): boolean {
   return normalized === 'self-pay' || normalized === 'self pay' || normalized === 'selfpay';
 }
 
+function hasInsuranceBilling(method: string): boolean {
+  const normalized = method.trim();
+  return normalized.length > 0 && !isSelfPayMethod(normalized);
+}
+
+function isImageDocument(document: ClientDocument): boolean {
+  const contentType = document.contentType?.toLowerCase() || '';
+  if (contentType.startsWith('image/')) return true;
+  return /\.(png|jpe?g|gif|webp|bmp|svg)$/i.test(document.fileName);
+}
+
+function normalizeBillingPaymentMethod(method: unknown): string {
+  const raw = String(method ?? '').trim();
+  if (!raw) return '';
+
+  const normalized = raw.toLowerCase().replace(/_/g, ' ').replace(/\s+/g, ' ');
+
+  if (normalized === 'self-pay' || normalized === 'self pay' || normalized === 'selfpay') {
+    return 'Self-Pay';
+  }
+  if (normalized === 'commercial insurance') {
+    return 'Commercial Insurance';
+  }
+  if (normalized === 'private insurance') {
+    return 'Private Insurance';
+  }
+  if (normalized === 'medicaid') {
+    return 'Medicaid';
+  }
+  if (normalized === 'other') {
+    return 'Other';
+  }
+
+  return raw;
+}
+
 function isEndpointUnavailableStatus(status: number): boolean {
   return status === 404 || status === 405 || status === 501;
 }
@@ -158,6 +208,10 @@ export function LeadProfileModal({
   const [isSavingBirthOutcomes, setIsSavingBirthOutcomes] = useState(false);
   // Primary source for display: full detail from GET /clients/:id (authorized users get PHI).
   const [fetchedDetail, setFetchedDetail] = useState<ClientDetail | null>(null);
+  const [clientDocuments, setClientDocuments] = useState<ClientDocument[]>([]);
+  const [documentsLoading, setDocumentsLoading] = useState(false);
+  const [activeDocumentId, setActiveDocumentId] = useState<string | null>(null);
+  const [documentPreviewUrls, setDocumentPreviewUrls] = useState<Record<string, string>>({});
   const currentUserDisplayName = React.useMemo(() => {
     const first = String(user?.firstname ?? (user as any)?.first_name ?? '').trim();
     const last = String(user?.lastname ?? (user as any)?.last_name ?? '').trim();
@@ -257,6 +311,75 @@ export function LeadProfileModal({
     };
   }, [open, client?.id, getClientById]);
 
+  React.useEffect(() => {
+    let cancelled = false;
+
+    const loadDocuments = async () => {
+      if (!open || !client?.id) {
+        setClientDocuments([]);
+        setDocumentsLoading(false);
+        return;
+      }
+
+      setDocumentsLoading(true);
+      try {
+        const documents = await listClientDocuments('staff', client.id);
+        if (cancelled) return;
+        setClientDocuments(documents);
+      } catch (error) {
+        if (!cancelled) {
+          console.error('❌ [Docs] Failed to load client documents:', error);
+          setClientDocuments([]);
+        }
+      } finally {
+        if (!cancelled) setDocumentsLoading(false);
+      }
+    };
+
+    void loadDocuments();
+    return () => {
+      cancelled = true;
+    };
+  }, [open, client?.id]);
+
+  React.useEffect(() => {
+    let cancelled = false;
+
+    const populatePreviewUrls = async () => {
+      const imageDocs = clientDocuments.filter(isInsuranceCardDocument).filter(isImageDocument);
+      const missingDocs = imageDocs.filter((doc) => !documentPreviewUrls[doc.id]);
+      if (missingDocs.length === 0) return;
+
+      const entries = await Promise.all(
+        missingDocs.map(async (doc) => {
+          try {
+            const url = doc.url || (await getClientDocumentUrl('staff', doc.id, client?.id || undefined));
+            return [doc.id, url] as const;
+          } catch {
+            return null;
+          }
+        })
+      );
+
+      if (cancelled) return;
+
+      setDocumentPreviewUrls((prev) => {
+        const next = { ...prev };
+        entries.forEach((entry) => {
+          if (entry) {
+            next[entry[0]] = entry[1];
+          }
+        });
+        return next;
+      });
+    };
+
+    void populatePreviewUrls();
+    return () => {
+      cancelled = true;
+    };
+  }, [client?.id, clientDocuments, documentPreviewUrls]);
+
   const fetchNotes = async () => {
     if (!client?.id) return;
 
@@ -322,7 +445,7 @@ export function LeadProfileModal({
     const d = detailSource as Record<string, unknown>;
     const get = (key: string, alt: string) => (d[key] ?? d[alt]) as string | undefined;
     const stripRedacted = (v: unknown): string | undefined => {
-      if (v === '[redacted]' || v === null || v === undefined) return undefined;
+      if (v === '[redacted]' || v === null || v === undefined || v === -1 || v === '-1') return undefined;
       const str = String(v).trim();
       return str === '' ? undefined : str;
     };
@@ -330,8 +453,11 @@ export function LeadProfileModal({
       obj && typeof obj === 'object' && !Array.isArray(obj) ? (obj as Record<string, unknown>)[key] : undefined;
     const rawPhone =
       get('phone_number', 'phoneNumber') ?? nested(d.phi, 'phone_number') ?? nested(d.data, 'phone_number') ?? d.mobile_phone;
-    const phoneNumber = (stripRedacted(rawPhone) ?? '') as string;
-    const phone_number = stripRedacted(rawPhone) ?? undefined;
+      const phoneNumber = (stripRedacted(rawPhone) ?? '') as string;
+      const phone_number = stripRedacted(rawPhone) ?? undefined;
+    const paymentMethod = normalizeBillingPaymentMethod(
+      get('payment_method', 'paymentMethod') ?? d.payment_method ?? d.paymentMethod
+    );
     console.log('🔍 [Init] Phone extraction:', {
       'detailSource.phoneNumber': d.phoneNumber,
       'detailSource.phone_number': d.phone_number,
@@ -347,13 +473,20 @@ export function LeadProfileModal({
       email: stripRedacted(d.email) as string | undefined,
       phoneNumber,
       phone_number,
+      zip_code: normalizeZipCode(stripRedacted(get('zip_code', 'zipCode'))),
       due_date: get('due_date', 'dueDate'),
       address: (get('address_line1', 'address') ?? get('addressLine1', 'address') ?? '') as string | undefined,
       address_line1: get('address_line1', 'addressLine1'),
       date_of_birth: get('date_of_birth', 'dateOfBirth'),
       serviceNeeded: (get('service_needed', 'serviceNeeded') ?? '') as string,
       service_needed: (get('service_needed', 'serviceNeeded') ?? '') as string,
+      payment_method: paymentMethod,
+      insurance_provider: (get('insurance_provider', 'insuranceProvider') ?? get('insurance', 'insurance')) as string | undefined,
+      insurance_member_id: (get('insurance_member_id', 'insuranceMemberId') ?? '') as string | undefined,
+      policy_number: (get('policy_number', 'policyNumber') ?? '') as string | undefined,
     };
+    delete (initializedData as Record<string, unknown>).self_pay_card_info;
+    delete (initializedData as Record<string, unknown>).selfPayCardInfo;
     console.log('🔍 [Init] Final initializedData:', {
       phoneNumber: initializedData.phoneNumber,
       phone_number: (initializedData as any).phone_number,
@@ -487,8 +620,8 @@ export function LeadProfileModal({
       };
 
       // Tie billing fields to payment method:
-      // - Self-pay keeps credit card info and clears insurance fields
-      // - Insurance methods keep insurance fields and clear self-pay card info
+      // - Self-pay clears insurance fields
+      // - Insurance methods keep insurance fields
       if (effectivePaymentMethod) {
         if (isSelfPayMethod(effectivePaymentMethod)) {
           markChanged('insurance_provider', '');
@@ -505,7 +638,6 @@ export function LeadProfileModal({
             markChanged('insurance_provider', insuranceProvider);
             markChanged('insurance', insuranceProvider);
           }
-          markChanged('self_pay_card_info', '');
         }
       }
 
@@ -514,6 +646,10 @@ export function LeadProfileModal({
         toast('No changes detected');
         setIsEditing(false);
         return;
+      }
+
+      if (updateData.zip_code !== undefined && updateData.zip_code !== null) {
+        updateData.zip_code = normalizeZipCode(updateData.zip_code);
       }
 
       // Map demographics_annual_income to annual_income for backend
@@ -576,7 +712,6 @@ export function LeadProfileModal({
         'insurance_provider',
         'insurance_member_id',
         'policy_number',
-        'self_pay_card_info',
       ]);
       const billingData: Record<string, unknown> = {};
       Object.keys(phiData).forEach((key) => {
@@ -629,6 +764,10 @@ export function LeadProfileModal({
       // Update billing fields via dedicated endpoint when available;
       // fallback to PHI endpoint for backwards compatibility.
       if (Object.keys(billingData).length > 0) {
+        const normalizedBillingData = {
+          ...billingData,
+          payment_method: normalizeBillingPaymentMethod(billingData.payment_method),
+        };
         const billingResponse = await fetchWithAuth(
           buildUrl(`/api/clients/${encodeURIComponent(client.id)}/billing`),
           {
@@ -636,18 +775,24 @@ export function LeadProfileModal({
             headers: {
               'Content-Type': 'application/json',
             },
-            body: JSON.stringify(billingData),
+            body: JSON.stringify(normalizedBillingData),
           }
         );
 
         if (!billingResponse.ok) {
           if (isEndpointUnavailableStatus(billingResponse.status)) {
-            const fallbackResult = await updateClientPhi(client.id, billingData);
+            const fallbackResult = await updateClientPhi(client.id, normalizedBillingData);
             if (!fallbackResult.success) {
               billingSuccess = false;
               errors.push(fallbackResult.error || 'Failed to update billing fields');
             } else {
-              setEditedData((prev) => ({ ...prev, ...billingData }));
+              setEditedData((prev) => ({
+                ...prev,
+                ...normalizedBillingData,
+                payment_method: normalizeBillingPaymentMethod(
+                  normalizedBillingData.payment_method ?? prev.payment_method ?? ''
+                ),
+              }));
             }
           } else {
             billingSuccess = false;
@@ -657,7 +802,13 @@ export function LeadProfileModal({
             );
           }
         } else {
-          setEditedData((prev) => ({ ...prev, ...billingData }));
+          setEditedData((prev) => ({
+            ...prev,
+            ...normalizedBillingData,
+            payment_method: normalizeBillingPaymentMethod(
+              normalizedBillingData.payment_method ?? prev.payment_method ?? ''
+            ),
+          }));
         }
       }
 
@@ -793,8 +944,127 @@ export function LeadProfileModal({
     [notes]
   );
 
+  const insuranceCardDocuments = clientDocuments
+    .filter(isInsuranceCardDocument)
+    .sort(compareClientDocumentsByUploadedAtDesc);
+  const frontInsuranceCard =
+    insuranceCardDocuments.find(
+      (document) => getInsuranceCardSide(document.documentType, document.fileName) === 'front'
+    ) ??
+    insuranceCardDocuments.find((document) => document.documentType === 'insurance_card') ??
+    null;
+  const backInsuranceCard =
+    insuranceCardDocuments.find(
+      (document) => getInsuranceCardSide(document.documentType, document.fileName) === 'back'
+    ) ?? null;
+
+  const renderInsuranceCardDocument = (documentItem: ClientDocument) => {
+    const parsed = documentItem.uploadedAt ? new Date(documentItem.uploadedAt) : null;
+    const uploadedAt =
+      parsed && !Number.isNaN(parsed.getTime())
+        ? format(parsed, 'MMM d, yyyy')
+        : documentItem.uploadedAt || '';
+    const isBusy = activeDocumentId === documentItem.id;
+    const previewUrl = documentPreviewUrls[documentItem.id] || documentItem.url || '';
+    const showPreview = isImageDocument(documentItem) && previewUrl;
+
+    return (
+      <div
+        key={documentItem.id}
+        className="flex flex-col gap-3 rounded-lg border p-3 md:flex-row md:items-start md:justify-between"
+      >
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <FileImage className="h-4 w-4 text-primary" />
+            <p className="truncate text-sm font-medium">{documentItem.fileName}</p>
+            <Badge variant="secondary">
+              {getClientDocumentLabel(documentItem.documentType, documentItem.fileName)}
+            </Badge>
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            {uploadedAt ? `Uploaded ${uploadedAt}` : 'Upload date unavailable'}
+          </p>
+          {showPreview ? (
+            <img
+              src={previewUrl}
+              alt={documentItem.fileName}
+              className="mt-3 max-h-56 rounded-md border object-contain"
+            />
+          ) : null}
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void handleOpenDocument(documentItem)}
+            disabled={isBusy}
+          >
+            <ExternalLink className="mr-1 h-4 w-4" />
+            {activeDocumentId === documentItem.id ? 'Opening...' : 'View'}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void handleDownloadDocument(documentItem)}
+            disabled={isBusy}
+          >
+            <Download className="mr-1 h-4 w-4" />
+            {activeDocumentId === documentItem.id ? 'Working...' : 'Download'}
+          </Button>
+        </div>
+      </div>
+    );
+  };
+
+  const handleOpenDocument = async (documentItem: ClientDocument) => {
+    setActiveDocumentId(documentItem.id);
+    try {
+      const url =
+        documentItem.url ||
+        (await getClientDocumentUrl('staff', documentItem.id, client?.id || undefined));
+      window.open(url, '_blank', 'noopener,noreferrer');
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to open insurance card');
+    } finally {
+      setActiveDocumentId(null);
+    }
+  };
+
+  const handleDownloadDocument = async (documentItem: ClientDocument) => {
+    setActiveDocumentId(documentItem.id);
+    try {
+      const url =
+        documentItem.url ||
+        (await getClientDocumentUrl('staff', documentItem.id, client?.id || undefined));
+      const response = await fetch(url, {
+        credentials: 'omit',
+        mode: 'cors',
+      });
+
+      if (!response.ok) {
+        throw new Error('Failed to download insurance card');
+      }
+
+      const blob = await response.blob();
+      const objectUrl = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = objectUrl;
+      link.download = documentItem.fileName || 'insurance-card';
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(objectUrl);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Failed to download insurance card');
+    } finally {
+      setActiveDocumentId(null);
+    }
+  };
+
   const handleCancelEdit = () => {
-    setEditedData(detailedClient || {});
+    setEditedData((detailSource ?? detailedClient ?? {}) as Partial<Client>);
     setIsEditing(false);
   };
 
@@ -824,6 +1094,9 @@ export function LeadProfileModal({
     // Use isEmpty to treat empty string as "no value" and fallback to next source
     const v = isEmpty(fromEdited) ? (isEmpty(fromDetail) ? fromClient : fromDetail) : fromEdited;
     if (v === null || v === undefined) return '';
+    if (fieldKey === 'payment_method') {
+      return normalizeBillingPaymentMethod(v);
+    }
     const s = String(v);
     if (s === '[redacted]' || s === '') return '';
     return s;
@@ -847,6 +1120,9 @@ export function LeadProfileModal({
       : fieldKey === 'birth_outcomes' ? 'birthOutcomes'
       : null;
     let value: string | Date = altKey !== null ? getDisplayValue(fieldKey, altKey) : (editedData[fieldKey] ?? '');
+    if (fieldKey === 'payment_method') {
+      value = normalizeBillingPaymentMethod(value);
+    }
 
     // Never show [redacted] in the detail modal (authorized view; backend gates PHI on GET /clients/:id)
     if (value === '[redacted]') value = '';
@@ -1181,19 +1457,52 @@ export function LeadProfileModal({
               'Billing Information',
               <>
                 {renderEditableField('Payment Method', 'payment_method', undefined, 'select', PAYMENT_METHOD_OPTIONS)}
-                {isSelfPayMethod(String(getDisplayValue('payment_method', 'paymentMethod') || '')) ? (
-                  renderEditableField(
-                    'Credit Card Information (Self-Pay)',
-                    'self_pay_card_info',
-                    undefined,
-                    'textarea'
-                  )
-                ) : (
+                {hasInsuranceBilling(String(getDisplayValue('payment_method', 'paymentMethod') || '')) ? (
                   <>
-                    {renderEditableField('Insurance Provider', 'insurance_provider', undefined, 'select', INSURANCE_PROVIDER_OPTIONS)}
+                    <div className="rounded-lg border p-3 space-y-3">
+                      <div className="grid gap-3 lg:grid-cols-2">
+                        {[
+                          {
+                            side: 'front' as const,
+                            label: 'Front of Card',
+                            document: frontInsuranceCard,
+                          },
+                          {
+                            side: 'back' as const,
+                            label: 'Back of Card',
+                            document: backInsuranceCard,
+                          },
+                        ].map((slot) => (
+                          <div key={slot.side} className="rounded-lg border border-dashed p-3 space-y-3">
+                            <div>
+                              <p className="font-medium">Insurance {slot.label.toLowerCase()}</p>
+                              <p className="text-sm text-muted-foreground">
+                                {slot.document
+                                  ? 'Uploaded files are shown below. Image files are previewed inline.'
+                                  : `No ${slot.label.toLowerCase()} uploaded yet.`}
+                              </p>
+                            </div>
+
+                            {documentsLoading ? (
+                              <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                                <Loader2 className="h-4 w-4 animate-spin" />
+                                Loading uploaded documents...
+                              </div>
+                            ) : slot.document ? (
+                              renderInsuranceCardDocument(slot.document)
+                            ) : null}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                    {renderEditableField('Insurance Provider', 'insurance_provider')}
                     {renderEditableField('Insurance Member ID', 'insurance_member_id')}
                     {renderEditableField('Policy Number', 'policy_number')}
                   </>
+                ) : (
+                  <div className="text-sm text-muted-foreground">
+                    Self-pay billing is supported without storing credit card details.
+                  </div>
                 )}
               </>,
               <FileText className="h-5 w-5" />

--- a/src/features/dashboard-home/Home.jsx
+++ b/src/features/dashboard-home/Home.jsx
@@ -2,9 +2,8 @@ import { useUser } from '@/common/hooks/user/useUser';
 import { useIsClientPortalUser } from '@/common/hooks/auth/useIsClientPortalUser';
 import { CalendarWidget } from './components/CalendarWidget';
 import { StatsOverview } from './components/StatsOverview';
-import ClientDashboard from '@/features/client-dashboard/ClientDashboard';
 import { useEffect } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { Navigate, useSearchParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
 
 const QUICKBOOKS_CONNECTED_KEY = 'quickbooks_just_connected';
@@ -48,7 +47,7 @@ export default function Home() {
 
   // Client portal: Supabase client session and/or backend role === client (not admin/doula metrics)
   if (isClientPortalUser) {
-    return <ClientDashboard />;
+    return <Navigate to='/profile' replace />;
   }
 
   // Show regular dashboard for admin/doula users

--- a/src/features/profiles/Documents.tsx
+++ b/src/features/profiles/Documents.tsx
@@ -146,7 +146,10 @@ export default function Documents({ clientId }: DocumentsProps) {
                         {documentItem.fileName}
                       </p>
                       <Badge variant='secondary'>
-                        {getClientDocumentLabel(documentItem.documentType)}
+                        {getClientDocumentLabel(
+                          documentItem.documentType,
+                          documentItem.fileName
+                        )}
                       </Badge>
                     </div>
                     <div className='text-xs text-muted-foreground'>

--- a/src/features/request/Step3Home.tsx
+++ b/src/features/request/Step3Home.tsx
@@ -1432,7 +1432,6 @@ export function Step9Payment({
     'Commercial Insurance',
     'Private Insurance',
     'Medicaid',
-    'Other',
   ];
 
   return (


### PR DESCRIPTION
## What changed
- Added a reusable QuickBooks card-on-file form with browser-side Intuit tokenization
- Wired the form to QuickBooks-only payment method endpoints with safe metadata handling and idempotent requests
- Embedded the card-on-file form in the client portal billing view
- Added a dev/test prefill action and coverage for the new payment flow

## Validation
- `npm run test:run -- src/features/billing/components/quickbooksPayments.test.ts src/features/billing/components/QuickBooksCardOnFileForm.test.tsx`
- `npm run build`

## Notes
- The frontend only posts `client_id`, `intuit_token`, and `request_id` to the backend
- No raw card data is persisted in app state or sent to the backend