### PR TITLE
fix(api): route backend calls through Cloud Run-aware API base

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,11 +1,15 @@
 # Copy to .env.local and fill in. Do not commit .env.local.
 # See docs/PRODUCTION_SPLIT_DB.md for production (split-db) architecture.
 
-# API (required for production)
+# Gradual cutover to Cloud Run (local or staged testing). When true, ignores local/Vercel backend URL.
+# VITE_USE_CLOUD_RUN=true
+# VITE_CLOUD_RUN_API_URL=https://sokana-private-api-634744984887.us-central1.run.app
+
+# API (required for production when not using VITE_USE_CLOUD_RUN)
 VITE_API_BASE_URL=https://your-cloud-run-url.run.app
 # Local API (no trailing /api). Match PORT in backend .env (often 5050 or 8080).
 # VITE_APP_BACKEND_URL=http://localhost:5050
-# Frontend: npm run dev → http://localhost:5173 (allowed by backend CORS in development).
+# Frontend: npm run dev → http://localhost:3001 (add that origin to Cloud Run FRONTEND_ORIGIN).
 
 # Auth: "supabase" (Bearer token) or "cookie" (credentials: include)
 VITE_AUTH_MODE=cookie

--- a/src/api/admin/adminService.ts
+++ b/src/api/admin/adminService.ts
@@ -1,8 +1,9 @@
 import type { DoulaAssignmentRole } from '@/api/clients/doulaAssignments';
+import { fetchWithAuth } from '@/api/http';
+import { apiBaseUrl } from '@/config/env';
 
 // Admin API service functions
-const API_BASE =
-  (import.meta.env.VITE_APP_BACKEND_URL || 'http://localhost:5050') + '/api';
+const API_BASE = `${apiBaseUrl}/api`;
 
 export interface MatchingClient {
   id: string;
@@ -54,8 +55,7 @@ export interface MatchingClientsResponse {
  * Get clients in matching phase
  */
 export async function getMatchingClients(): Promise<MatchingClientsResponse> {
-  const response = await fetch(`${API_BASE}/admin/clients/matching`, {
-    credentials: 'include',
+  const response = await fetchWithAuth(`${API_BASE}/admin/clients/matching`, {
     headers: {
       'Content-Type': 'application/json',
     },
@@ -101,9 +101,8 @@ export async function matchDoulaWithClient(
     body.role = role;
   }
 
-  const response = await fetch(`${API_BASE}/admin/assignments/match`, {
+  const response = await fetchWithAuth(`${API_BASE}/admin/assignments/match`, {
     method: 'POST',
-    credentials: 'include',
     headers: {
       'Content-Type': 'application/json',
     },

--- a/src/api/clients/__tests__/admin-notes-audit-log.test.ts
+++ b/src/api/clients/__tests__/admin-notes-audit-log.test.ts
@@ -59,15 +59,12 @@ describe('Admin Notes with Audit Log - createClientNote', () => {
 
     const result = await createClientNote(clientId, mockNoteData);
 
-    // Verify API call format
+    // Verify API call format (fetchWithAuth may normalize headers to Headers)
     expect(mockFetch).toHaveBeenCalledWith(
       'http://localhost:5050/api/clients/client-123/activity',
       expect.objectContaining({
         method: 'POST',
         credentials: 'include',
-        headers: {
-          'Content-Type': 'application/json',
-        },
         body: JSON.stringify({
           activity_type: 'note',
           content: mockNoteData.description,

--- a/src/api/clients/doulaAssignments.ts
+++ b/src/api/clients/doulaAssignments.ts
@@ -45,12 +45,9 @@ export function normalizeAssignmentRole(
   return null;
 }
 
-const getBaseUrl = (): string => {
-  return (
-    import.meta.env.VITE_APP_BACKEND_URL?.replace(/\/$/, '') ||
-    'http://localhost:5050'
-  );
-};
+import { apiBaseUrl } from '@/config/env';
+
+const getBaseUrl = (): string => apiBaseUrl;
 
 /**
  * Fetch all available doulas (team members with doula role)

--- a/src/api/clients/notes.ts
+++ b/src/api/clients/notes.ts
@@ -1,3 +1,6 @@
+import { apiBaseUrl } from '@/config/env';
+import { fetchWithAuth } from '@/api/http';
+
 export interface ClientNote {
   id: string;
   clientId: string;
@@ -78,8 +81,10 @@ const normalizeNotes = (raw: any, clientId: string): ClientNote[] => {
   return rawList.map((row: any) => normalizeNoteRow(row, clientId));
 };
 
+import { apiBaseUrl } from '@/config/env';
+
 const getNotesUrl = (clientId: string, role?: NotesViewerRole): string[] => {
-  const base = (import.meta.env.VITE_APP_BACKEND_URL || '').replace(/\/+$/, '');
+  const base = apiBaseUrl;
   const clientIdSafe = encodeURIComponent(clientId);
 
   // Doulas must use doula-scoped activities endpoint to reliably fetch
@@ -102,9 +107,8 @@ export const getClientNotes = async (
     const urls = getNotesUrl(clientId, role);
     const settled = await Promise.allSettled(
       urls.map(async (url) => {
-        const response = await fetch(url, {
+        const response = await fetchWithAuth(url, {
           method: 'GET',
-          credentials: 'include',
           headers: {
             'Content-Type': 'application/json',
           },
@@ -161,11 +165,10 @@ export const createClientNote = async (
       ...(noteData.metadata ? { metadata: noteData.metadata } : {}),
     };
 
-    const response = await fetch(
-      `${import.meta.env.VITE_APP_BACKEND_URL}/api/clients/${clientId}/activity`,
+    const response = await fetchWithAuth(
+      `${apiBaseUrl}/api/clients/${clientId}/activity`,
       {
         method: 'POST',
-        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
         },

--- a/src/api/doulas/doulaApi.ts
+++ b/src/api/doulas/doulaApi.ts
@@ -6,9 +6,9 @@ import type {
   DoulaNote,
   Visit,
 } from '@/features/hours/types/doula';
+import { apiBaseUrl } from '@/config/env';
 
-const API_BASE =
-  import.meta.env.VITE_APP_BACKEND_URL || 'http://localhost:5050';
+const API_BASE = apiBaseUrl;
 
 // Get all doulas (for list page)
 export async function getAllDoulas(): Promise<Doula[]> {

--- a/src/api/quickbooks/auth/status.ts
+++ b/src/api/quickbooks/auth/status.ts
@@ -1,7 +1,7 @@
 // src/api/quickbooks/status.ts
+import { apiBaseUrl } from '@/config/env';
 
-const API_BASE =
-  import.meta.env.VITE_APP_BACKEND_URL || 'http://localhost:5050';
+const API_BASE = apiBaseUrl;
 /**
  * Check whether the current user is connected to QuickBooks.
  * @returns true if connected, false otherwise

--- a/src/common/components/user/UsersList.tsx
+++ b/src/common/components/user/UsersList.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import { LoadingOverlay } from '@/common/components/loading/LoadingOverlay';
 import { useUser } from '@/common/hooks/user/useUser';
 import { User } from '@/common/types/user';
+import { fetchWithAuth, buildUrl } from '@/api/http';
 import styled from 'styled-components';
 
 const UsersContainer = styled.div`
@@ -56,11 +57,9 @@ export default function UsersList() {
   useEffect(() => {
     const fetchUsers = async () => {
       try {
-        const baseUrl = import.meta.env.VITE_APP_BACKEND_URL;
-        const response = await fetch(
-          `${baseUrl}/auth/users`,
+        const response = await fetchWithAuth(
+          buildUrl('/auth/users'),
           {
-            credentials: 'include',
             headers: {
             },
           }

--- a/src/common/hooks/contracts/useTemplates.ts
+++ b/src/common/hooks/contracts/useTemplates.ts
@@ -1,5 +1,6 @@
 import { Template } from '@/common/types/template';
 import { useState } from 'react';
+import { fetchWithAuth, buildUrl } from '@/api/http';
 
 export function useTemplates() {
   const [templates, setTemplates] = useState<Template[]>([]);
@@ -11,10 +12,9 @@ export function useTemplates() {
     setError(null);
 
     try {
-      const response = await fetch(
-        `${import.meta.env.VITE_APP_BACKEND_URL}/contracts/templates`,
+      const response = await fetchWithAuth(
+        buildUrl('/contracts/templates'),
         {
-          credentials: 'include',
           headers: {
           },
         }

--- a/src/common/hooks/dashboard/useDueDateCalendar.ts
+++ b/src/common/hooks/dashboard/useDueDateCalendar.ts
@@ -1,5 +1,7 @@
 // src/common/hooks/dashboard/useDueDateCalendar.ts
 import useSWR from 'swr';
+import { apiBaseUrl } from '@/config/env';
+import { fetchWithAuth } from '@/api/http';
 
 export interface DueDateEvent {
   id: string;
@@ -19,12 +21,11 @@ export interface DueDateCalendarResponse {
  * @returns {object} - { events, loading, error }
  */
 export function useDueDateCalendar() {
-  const BASE = import.meta.env.VITE_APP_BACKEND_URL;
+  const BASE = apiBaseUrl;
 
   const fetcher = async (url: string): Promise<DueDateCalendarResponse> => {
     try {
-      const response = await fetch(url, {
-        credentials: 'include',
+      const response = await fetchWithAuth(url, {
         headers: {
           'Content-Type': 'application/json',
         },

--- a/src/common/hooks/hours/useWorkLog.ts
+++ b/src/common/hooks/hours/useWorkLog.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import { normalizeHourType, type HourType } from '@/features/hours/data/hour-types';
+import { fetchWithAuth, buildUrl } from '@/api/http';
 
 type WorkLogEntry = {
   id: string;
@@ -33,8 +34,8 @@ export default function useWorkLog(userId?: string) {
     async function fetchWorkLog() {
       try {
 
-        const response = await fetch(
-          `${import.meta.env.VITE_APP_BACKEND_URL}/users/${userId}/hours`,
+        const response = await fetchWithAuth(
+          buildUrl(`/users/${userId}/hours`),
           {
             headers: {
             },

--- a/src/common/hooks/user/useGetUserById.ts
+++ b/src/common/hooks/user/useGetUserById.ts
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { fetchWithAuth, buildUrl } from '@/api/http';
 
 export default function useUserData(userId: string) {
   const [user, setUser] = useState<any>(null);
@@ -18,8 +19,8 @@ export default function useUserData(userId: string) {
 
       try {
 
-        const response = await fetch(
-          `${import.meta.env.VITE_APP_BACKEND_URL}/users/${userId}`,
+        const response = await fetchWithAuth(
+          buildUrl(`/users/${userId}`),
           {
             headers: {
               'Content-Type': 'application/json',

--- a/src/common/utils/addWorkSession.ts
+++ b/src/common/utils/addWorkSession.ts
@@ -1,3 +1,5 @@
+import { fetchWithAuth, buildUrl } from '@/api/http';
+
 export default async function addWorkSession(
   doula_id: string | undefined,
   client_id: string | undefined,
@@ -13,8 +15,8 @@ export default async function addWorkSession(
   async function addSession() {
     try {
 
-      const response = await fetch(
-        `${import.meta.env.VITE_APP_BACKEND_URL}/users/${doula_id}/addhours`,
+      const response = await fetchWithAuth(
+        buildUrl(`/users/${doula_id}/addhours`),
         {
           method: 'POST',
           headers: {

--- a/src/common/utils/deleteClient.test.ts
+++ b/src/common/utils/deleteClient.test.ts
@@ -30,9 +30,6 @@ describe('deleteClient', () => {
       expect.objectContaining({
         method: 'DELETE',
         credentials: 'include',
-        headers: expect.objectContaining({
-          'Content-Type': 'application/json',
-        }),
         body: JSON.stringify({ id: '123' }),
       })
     );

--- a/src/common/utils/deleteClient.ts
+++ b/src/common/utils/deleteClient.ts
@@ -2,6 +2,8 @@ import {
   getSessionExpirationMessage,
   isSessionExpiredError,
 } from './sessionUtils';
+import { apiBaseUrl } from '@/config/env';
+import { fetchWithAuth } from '@/api/http';
 
 export default async function deleteClient(
   clientId: string
@@ -13,17 +15,13 @@ export default async function deleteClient(
   console.log('🚨 Client ID type:', typeof clientId);
   console.log(
     '🚨 Full request URL:',
-    `${import.meta.env.VITE_APP_BACKEND_URL}/clients/delete`
+    `${apiBaseUrl}/clients/delete`
   );
 
   try {
-    const baseUrl =
-      import.meta.env.VITE_APP_BACKEND_URL || '';
-    const cleanBaseUrl = baseUrl.replace(/\/+$/, ''); // Remove trailing slashes
-    const url = `${cleanBaseUrl}/clients/delete`;
-    const response = await fetch(url, {
+    const url = `${apiBaseUrl}/clients/delete`;
+    const response = await fetchWithAuth(url, {
       method: 'DELETE',
-      credentials: 'include',
       headers: {
         'Content-Type': 'application/json',
       },

--- a/src/common/utils/saveUser.tsx
+++ b/src/common/utils/saveUser.tsx
@@ -1,15 +1,13 @@
+import { fetchWithAuth, buildUrl } from '@/api/http';
+
 export default async function saveUser(userData: FormData) {
   try {
-    const response = await fetch(
-      `${import.meta.env.VITE_APP_BACKEND_URL}/users/update`,
-      {
+    const response = await fetchWithAuth(buildUrl('/users/update'), {
         method: 'PUT',
-        credentials: 'include',
         headers: {
         },
         body: userData,
-      }
-    );
+      });
 
     if (!response.ok) {
       throw new Error('Failed to save user');

--- a/src/common/utils/updateClient.ts
+++ b/src/common/utils/updateClient.ts
@@ -4,6 +4,8 @@ import {
 } from './sessionUtils';
 import { PHI_KEYS } from '@/config/phi';
 import { normalizeZipCode } from './zipCode';
+import { apiBaseUrl } from '@/config/env';
+import { fetchWithAuth } from '@/api/http';
 
 /**
  * Columns that cannot be updated via PUT /clients/:id to Supabase client_info table.
@@ -53,16 +55,12 @@ export default async function updateClient(
   console.log('🚨 Update Data:', payload);
   console.log(
     '🚨 Full request URL:',
-    `${import.meta.env.VITE_APP_BACKEND_URL}/clients/${clientId}`
+    `${apiBaseUrl}/clients/${clientId}`
   );
 
   try {
-    const baseUrl =
-      import.meta.env.VITE_APP_BACKEND_URL || 'http://localhost:5050';
-    const cleanBaseUrl = baseUrl.replace(/\/+$/, ''); // Remove trailing slashes
-    const response = await fetch(`${cleanBaseUrl}/clients/${clientId}`, {
+    const response = await fetchWithAuth(`${apiBaseUrl}/clients/${clientId}`, {
       method: 'PUT',
-      credentials: 'include',
       headers: {
         'Content-type': 'application/json',
       },

--- a/src/common/utils/updateClientStatus.ts
+++ b/src/common/utils/updateClientStatus.ts
@@ -3,6 +3,7 @@ import {
   isSessionExpiredError,
 } from './sessionUtils';
 import { syncQuickBooksCustomerFromClient } from './syncQuickBooksCustomer';
+import { fetchWithAuth, buildUrl } from '@/api/http';
 
 type QuickBooksSyncSource = {
   id?: string;
@@ -22,11 +23,8 @@ export default async function updateClientStatus(
 ): Promise<{ success: boolean; client?: any; error?: string }> {
 
   try {
-    const response = await fetch(
-      `${import.meta.env.VITE_APP_BACKEND_URL}/clients/status`,
-      {
+    const response = await fetchWithAuth(buildUrl('/clients/status'), {
         method: 'PUT',
-        credentials: 'include',
         headers: {
           'Content-type': 'application/json',
         },
@@ -34,8 +32,7 @@ export default async function updateClientStatus(
           clientId: clientId,
           status: status,
         }),
-      }
-    );
+      });
 
     if (!response.ok) {
       const errorText = await response.text();

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -19,11 +19,29 @@ const appEnv: AppEnv =
     ? rawAppEnv
     : 'development';
 
-/** API base URL: VITE_API_BASE_URL, VITE_API_URL, or VITE_APP_BACKEND_URL, no trailing slash. */
-export const apiBaseUrl = (
-  (getEnv('VITE_API_BASE_URL') ?? getEnv('VITE_API_URL') ?? getEnv('VITE_APP_BACKEND_URL'))?.replace(/\/+$/, '') ||
-  'http://localhost:5050'
-);
+const DEFAULT_CLOUD_RUN_API_URL =
+  'https://sokana-private-api-634744984887.us-central1.run.app';
+
+/**
+ * Gradual cutover flag: when VITE_USE_CLOUD_RUN=true, use Cloud Run API
+ * (VITE_CLOUD_RUN_API_URL or default) instead of local/Vercel backend URL.
+ */
+const useCloudRun = (getEnv('VITE_USE_CLOUD_RUN') ?? '').toLowerCase() === 'true';
+const cloudRunApiUrl = (
+  getEnv('VITE_CLOUD_RUN_API_URL') ?? DEFAULT_CLOUD_RUN_API_URL
+).replace(/\/+$/, '');
+
+/** API base URL: Cloud Run (if flagged), else VITE_API_BASE_URL / VITE_API_URL / VITE_APP_BACKEND_URL. */
+export const apiBaseUrl = useCloudRun
+  ? cloudRunApiUrl
+  : (
+      (getEnv('VITE_API_BASE_URL') ?? getEnv('VITE_API_URL') ?? getEnv('VITE_APP_BACKEND_URL'))?.replace(
+        /\/+$/,
+        ''
+      ) || 'http://localhost:5050'
+    );
+
+export const isCloudRunApi = useCloudRun;
 
 export const isProd = appEnv === 'production';
 export const isDev = appEnv === 'development';

--- a/src/features/auth/AuthCallback.tsx
+++ b/src/features/auth/AuthCallback.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 
 import { LoadingOverlay } from '@/common/components/loading/LoadingOverlay';
 import { useUser } from '@/common/hooks/user/useUser';
+import { fetchWithAuth, buildUrl } from '@/api/http';
 import { consumeSensitiveHash } from './consumeSensitiveHash';
 
 const Container = styled.div`
@@ -28,11 +29,10 @@ export default function AuthCallback() {
           throw new Error('No access token received');
         }
 
-        const response = await fetch(
-          `${import.meta.env.VITE_APP_BACKEND_URL}/auth/callback`,
+        const response = await fetchWithAuth(
+          buildUrl('/auth/callback'),
           {
             method: 'POST',
-            credentials: 'include',
             headers: {
               'Content-Type': 'application/json',
             },

--- a/src/features/auth/SignUp.tsx
+++ b/src/features/auth/SignUp.tsx
@@ -19,6 +19,7 @@ import { Loader2 } from 'lucide-react';
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { toast } from 'sonner';
+import { fetchWithAuth, buildUrl } from '@/api/http';
 
 export default function SignUp() {
   const [error, setError] = useState<string>('');
@@ -57,8 +58,8 @@ export default function SignUp() {
     setError('');
 
     try {
-      const response = await fetch(
-        `${import.meta.env.VITE_APP_BACKEND_URL}/auth/signup`,
+      const response = await fetchWithAuth(
+        buildUrl('/auth/signup'),
         {
           method: 'POST',
           headers: {

--- a/src/features/client-dashboard/components/ClientProfileTab.tsx
+++ b/src/features/client-dashboard/components/ClientProfileTab.tsx
@@ -19,6 +19,7 @@ import { LoadingOverlay } from '@/common/components/loading/LoadingOverlay';
 import { toast } from 'sonner';
 import { useClientAuth } from '@/common/hooks/auth/useClientAuth';
 import { useUser } from '@/common/hooks/user/useUser';
+import { apiBaseUrl } from '@/config/env';
 import { supabase } from '@/lib/supabase';
 import UserAvatar from '@/common/components/user/UserAvatar';
 import {
@@ -231,8 +232,7 @@ export default function ClientProfileTab({
     secondary_policy_number: '',
   });
 
-  const getClientApiBase = () =>
-    (import.meta.env.VITE_APP_BACKEND_URL || '').replace(/\/+$/, '');
+  const getClientApiBase = () => apiBaseUrl;
 
   const getClientAuthHeaders = (token?: string) => ({
     'Content-Type': 'application/json',

--- a/src/features/clients/Clients.tsx
+++ b/src/features/clients/Clients.tsx
@@ -25,6 +25,7 @@ import { TemplatesProvider } from './contexts/TemplatesContext';
 import { userListSchema, UserSummary, type UserWithPortal } from './data/schema';
 import { derivePortalStatus } from './utils/portalStatus';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/common/components/ui/tabs';
+import { fetchWithAuth, buildUrl } from '@/api/http';
 
 type RouteParams = {
   clientId?: string;
@@ -171,11 +172,10 @@ export default function Users() {
       // Get the frontend URL (production or current origin)
       const frontendUrl = import.meta.env.VITE_APP_FRONTEND_URL || window.location.origin;
       
-      const response = await fetch(
-        `${import.meta.env.VITE_APP_BACKEND_URL}/api/admin/clients/${selectedLeadForPortal.id}/portal/invite`,
+      const response = await fetchWithAuth(
+        buildUrl(`/api/admin/clients/${selectedLeadForPortal.id}/portal/invite`),
         {
           method: 'POST',
-          credentials: 'include',
           headers: {
             'Content-Type': 'application/json',
           },
@@ -229,11 +229,10 @@ export default function Users() {
       // Get the frontend URL (production or current origin)
       const frontendUrl = import.meta.env.VITE_APP_FRONTEND_URL || window.location.origin;
 
-      const response = await fetch(
-        `${import.meta.env.VITE_APP_BACKEND_URL}/api/admin/clients/${lead.id}/portal/resend`,
+      const response = await fetchWithAuth(
+        buildUrl(`/api/admin/clients/${lead.id}/portal/resend`),
         {
           method: 'POST',
-          credentials: 'include',
           headers: {
             'Content-Type': 'application/json',
           },
@@ -278,11 +277,10 @@ export default function Users() {
     
     try {
 
-      const response = await fetch(
-        `${import.meta.env.VITE_APP_BACKEND_URL}/api/admin/clients/${lead.id}/portal/disable`,
+      const response = await fetchWithAuth(
+        buildUrl(`/api/admin/clients/${lead.id}/portal/disable`),
         {
           method: 'POST',
-          credentials: 'include',
           headers: {
             'Content-Type': 'application/json',
           },

--- a/src/features/clients/components/users-primary-buttons.tsx
+++ b/src/features/clients/components/users-primary-buttons.tsx
@@ -3,6 +3,7 @@ import { Template } from '@/common/types/template';
 import { Send, SquarePlus } from 'lucide-react';
 import { useState } from 'react';
 import { EnhancedContractDialog } from './dialog/EnhancedContractDialog';
+import { fetchWithAuth, buildUrl } from '@/api/http';
 
 interface Props {
   draggedTemplate: Template | null;
@@ -16,11 +17,8 @@ export function UsersPrimaryButtons({
   const [isEnhancedContractDialogOpen, setIsEnhancedContractDialogOpen] = useState(false);
 
   const fetchCSV = async () => {
-    const baseUrl =
-      import.meta.env.VITE_APP_BACKEND_URL || 'http://localhost:5050';
     try {
-      const data = await fetch(`${baseUrl}/clients/fetchCSV`, {
-        credentials: 'include',
+      const data = await fetchWithAuth(buildUrl('/clients/fetchCSV'), {
         headers: {
         },
       });

--- a/src/features/contracts/components/dialog/DeleteTemplateDialog.tsx
+++ b/src/features/contracts/components/dialog/DeleteTemplateDialog.tsx
@@ -13,6 +13,7 @@ import { Dialog, DialogTrigger } from '@radix-ui/react-dialog';
 import { Loader2, Trash2 } from 'lucide-react';
 import { useRef, useState } from 'react';
 import { toast } from 'sonner';
+import { fetchWithAuth, buildUrl } from '@/api/http';
 
 type Props = {
   templateName: string;
@@ -30,10 +31,8 @@ export function DeleteTemplateDialog({ templateName, onDelete }: Props) {
   const handleDelete = async () => {
     setIsLoading(true);
     try {
-      const baseUrl =
-        import.meta.env.VITE_APP_BACKEND_URL || 'http://localhost:5050';
-      const res = await fetch(
-        `${baseUrl}/contracts/templates/${encodeURIComponent(templateName)}`,
+      const res = await fetchWithAuth(
+        buildUrl(`/contracts/templates/${encodeURIComponent(templateName)}`),
         {
           method: 'DELETE',
           headers: {

--- a/src/features/contracts/components/dialog/EditTemplateDialog.tsx
+++ b/src/features/contracts/components/dialog/EditTemplateDialog.tsx
@@ -14,6 +14,7 @@ import { Label } from '@/common/components/ui/label';
 import { useToast } from '@/common/hooks/toast/use-toast';
 import { Loader2, Pencil } from 'lucide-react';
 import { useRef, useState } from 'react';
+import { fetchWithAuth, buildUrl } from '@/api/http';
 
 interface Props {
   templateId: string;
@@ -72,8 +73,8 @@ export function EditTemplateDialog({
 
 
             try {
-              const res = await fetch(
-                `${import.meta.env.VITE_APP_BACKEND_URL}/contracts/templates/${templateName}`,
+              const res = await fetchWithAuth(
+                buildUrl(`/contracts/templates/${templateName}`),
                 {
                   method: 'PUT',
                   headers: {

--- a/src/features/contracts/components/dialog/NewTemplateDialog.tsx
+++ b/src/features/contracts/components/dialog/NewTemplateDialog.tsx
@@ -14,6 +14,7 @@ import { Label } from '@/common/components/ui/label';
 import { Loader2, Plus } from 'lucide-react';
 import { useRef, useState } from 'react';
 import { toast } from 'sonner';
+import { fetchWithAuth, buildUrl } from '@/api/http';
 
 type Props = {
   onUploadSuccess: () => void;
@@ -44,8 +45,8 @@ export function NewTemplateDialog({ onUploadSuccess }: Props) {
 
 
     try {
-      const res = await fetch(
-        `${import.meta.env.VITE_APP_BACKEND_URL}/contracts/templates`,
+      const res = await fetchWithAuth(
+        buildUrl('/contracts/templates'),
         {
           method: 'POST',
           headers: {

--- a/src/features/contracts/components/pdf/PdfPreview.tsx
+++ b/src/features/contracts/components/pdf/PdfPreview.tsx
@@ -9,6 +9,7 @@ import { Separator } from '@/common/components/ui/separator';
 
 import 'react-pdf/dist/Page/AnnotationLayer.css';
 import 'react-pdf/dist/Page/TextLayer.css';
+import { fetchWithAuth, buildUrl } from '@/api/http';
 
 pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.js`;
 
@@ -23,8 +24,8 @@ export function PdfPreview() {
       setIsLoading(true);
       try {
         console.log(selectedTemplateName);
-        const res = await fetch(
-          `${import.meta.env.VITE_APP_BACKEND_URL}/contracts/templates/generate`,
+        const res = await fetchWithAuth(
+          buildUrl('/contracts/templates/generate'),
           {
             method: 'POST',
             headers: {

--- a/src/features/hours/components/DoulaDetailPage.tsx
+++ b/src/features/hours/components/DoulaDetailPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useContext } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { UserContext } from '@/common/contexts/UserContext';
+import { fetchWithAuth, buildUrl } from '@/api/http';
 import {
   Mail,
   Phone,
@@ -87,11 +88,10 @@ export default function DoulaDetailPage() {
     try {
       // For now, fetch from team members API (replace with real doula endpoints when available)
 
-      const response = await fetch(
-        `${import.meta.env.VITE_APP_BACKEND_URL}/clients/team/all`,
+      const response = await fetchWithAuth(
+        buildUrl('/clients/team/all'),
         {
           method: 'GET',
-          credentials: 'include',
           headers: {
             'Content-Type': 'application/json',
           },

--- a/src/features/hours/components/EditDoulaDialog.tsx
+++ b/src/features/hours/components/EditDoulaDialog.tsx
@@ -15,6 +15,7 @@ import { Badge } from '@/common/components/ui/badge';
 import { X, Upload, FileText, Trash2 } from 'lucide-react';
 import type { Doula } from '@/features/hours/types/doula';
 import { toast } from 'sonner';
+import { fetchWithAuth, buildUrl } from '@/api/http';
 
 interface EditDoulaDialogProps {
   open: boolean;
@@ -138,11 +139,10 @@ export function EditDoulaDialog({
       });
 
       // Update via team member endpoint (will be replaced with doula-specific endpoint)
-      const response = await fetch(
-        `${import.meta.env.VITE_APP_BACKEND_URL}/clients/team/${doula.id}`,
+      const response = await fetchWithAuth(
+        buildUrl(`/clients/team/${doula.id}`),
         {
           method: 'PUT',
-          credentials: 'include',
           headers: {
             // Don't set Content-Type header - browser will set it with boundary for FormData
           },

--- a/src/features/integrations/QuickBooksConnect.tsx
+++ b/src/features/integrations/QuickBooksConnect.tsx
@@ -1,4 +1,5 @@
 import { API_CONFIG } from '@/api/config';
+import { apiBaseUrl } from '@/config/env';
 import { getQuickBooksStatus, type QuickBooksCompany } from '@/api/quickbooks/auth/qbo';
 import { withTokenRefresh } from '@/api/quickbooks/auth/utils';
 import SubmitButton from '@/common/components/form/SubmitButton';
@@ -91,9 +92,7 @@ export default function QuickBooksConnectPage() {
       const frontendOrigin = new URL(
         import.meta.env.VITE_APP_FRONTEND_URL || window.location.origin
       ).origin;
-      const backendOrigin = new URL(
-        import.meta.env.VITE_APP_BACKEND_URL || 'http://localhost:5050'
-      ).origin;
+      const backendOrigin = new URL(apiBaseUrl).origin;
       if (event.origin !== frontendOrigin && event.origin !== backendOrigin) return;
       if (event.data?.success) {
         if (successHandledRef.current) return;

--- a/src/features/request/RequestForm.tsx
+++ b/src/features/request/RequestForm.tsx
@@ -18,6 +18,7 @@ import {
 import { RequestFormValues } from './useRequestForm';
 import { StepNavigation } from './components/StepNavigation';
 import { StepHeader } from './components/StepHeader';
+import { apiBaseUrl } from '@/config/env';
 
 function RefreshWarningModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
   if (!isOpen) return null;
@@ -414,8 +415,7 @@ export default function RequestForm() {
       submission_source: options?.isUsingTestData ? 'test_data' : 'manual',
     };
     // Use the same pattern as login endpoint (no /api prefix)
-    // @ts-ignore - Vite environment variable
-    const backendUrl = import.meta.env.VITE_APP_BACKEND_URL?.replace(/\/$/, '') || 'http://localhost:5050';
+    const backendUrl = apiBaseUrl;
 
     try {
       const response = await fetch(

--- a/src/features/teams/teams.tsx
+++ b/src/features/teams/teams.tsx
@@ -35,6 +35,7 @@ import {
   getDoulaDocumentUrl,
   type DocumentCompletenessItem,
 } from '@/api/doulas/doulaService';
+import { buildUrl, fetchWithAuth } from '@/api/http';
 import UserAvatar from '@/common/components/user/UserAvatar';
 import {
   Download,
@@ -121,10 +122,9 @@ export default function Teams() {
     //function to fetch all team members
     setIsLoading(true);
     try {
-      const baseUrl = import.meta.env.VITE_APP_BACKEND_URL;
-      const teamResponse = await fetch(`${baseUrl}/clients/team/all`, {
+      // Use shared API base (honors VITE_USE_CLOUD_RUN) + cookie/Bearer auth helpers.
+      const teamResponse = await fetchWithAuth(buildUrl('/clients/team/all'), {
         method: 'GET',
-        credentials: 'include',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -369,11 +369,10 @@ export default function Teams() {
 
     setIsUpdating(true);
     try {
-      const response = await fetch(
-        `${import.meta.env.VITE_APP_BACKEND_URL}/clients/team/${editingMember.id}`,
+      const response = await fetchWithAuth(
+        buildUrl(`/clients/team/${editingMember.id}`),
         {
           method: 'PUT',
-          credentials: 'include',
           headers: {
             'Content-Type': 'application/json',
           },
@@ -426,11 +425,10 @@ export default function Teams() {
     const timeoutId = setTimeout(() => abortController.abort(), 30000); // 30 second timeout
 
     try {
-      const response = await fetch(
-        `${import.meta.env.VITE_APP_BACKEND_URL}/clients/team/${memberToDelete}`,
+      const response = await fetchWithAuth(
+        buildUrl(`/clients/team/${memberToDelete}`),
         {
           method: 'DELETE',
-          credentials: 'include',
           headers: {
             'Content-Type': 'application/json',
           },
@@ -558,23 +556,19 @@ export default function Teams() {
 
     setIsInviting(true);
     try {
-      const response = await fetch(
-        `${import.meta.env.VITE_APP_BACKEND_URL}/clients/team/add`,
-        {
-          //create new user in users table to allow them to sign in
-          method: 'POST',
-          credentials: 'include',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            firstname: `${inviteForm.firstname}`,
-            lastname: `${inviteForm.lastname}`,
-            email: `${inviteForm.email}`,
-            role: `${inviteForm.role}`,
-          }),
-        }
-      );
+      const response = await fetchWithAuth(buildUrl('/clients/team/add'), {
+        //create new user in users table to allow them to sign in
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          firstname: `${inviteForm.firstname}`,
+          lastname: `${inviteForm.lastname}`,
+          email: `${inviteForm.email}`,
+          role: `${inviteForm.role}`,
+        }),
+      });
 
       if (!response.ok) {
         const errorData = await response.json();
@@ -583,23 +577,19 @@ export default function Teams() {
         throw new Error(errorMessage);
       }
 
-      const emailResponse = await fetch(
-        `${import.meta.env.VITE_APP_BACKEND_URL}/email/team-invite`,
-        {
-          //send the email invite after user is created
-          method: 'POST',
-          credentials: 'include',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            email: inviteForm.email,
-            firstname: inviteForm.firstname,
-            lastname: inviteForm.lastname,
-            role: inviteForm.role,
-          }),
-        }
-      );
+      const emailResponse = await fetchWithAuth(buildUrl('/email/team-invite'), {
+        //send the email invite after user is created
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: inviteForm.email,
+          firstname: inviteForm.firstname,
+          lastname: inviteForm.lastname,
+          role: inviteForm.role,
+        }),
+      });
 
       if (!emailResponse.ok) {
         const errorData = await emailResponse.json();

--- a/src/services/signNowService.ts
+++ b/src/services/signNowService.ts
@@ -18,8 +18,9 @@ export interface SignNowResponse {
 }
 
 // services/signNowService.ts
-// @ts-ignore - Vite environment variable
-const BACKEND_URL = import.meta.env.VITE_APP_BACKEND_URL || 'http://localhost:5050';
+import { apiBaseUrl } from '@/config/env';
+
+const BACKEND_URL = apiBaseUrl;
 
 export const signNowService = {
   async sendInvitation(client: SignNowClient): Promise<SignNowResponse> {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -7,6 +7,10 @@ interface ImportMetaEnv {
   readonly VITE_API_BASE_URL?: string
   /** Same as VITE_API_BASE_URL (alias for backend URL) */
   readonly VITE_API_URL?: string
+  /** Gradual cutover: when "true", use VITE_CLOUD_RUN_API_URL as API base */
+  readonly VITE_USE_CLOUD_RUN?: string
+  /** Cloud Run private API URL used when VITE_USE_CLOUD_RUN=true */
+  readonly VITE_CLOUD_RUN_API_URL?: string
   /** "production" | "staging" | "development" */
   readonly VITE_APP_ENV?: string
   /** "supabase" (Bearer token) | "cookie" (credentials: include) */


### PR DESCRIPTION
## Summary
- Add `VITE_USE_CLOUD_RUN` / shared `apiBaseUrl` cutover path
- Replace hard-coded `VITE_APP_BACKEND_URL` fetches with `buildUrl` + `fetchWithAuth`
- Update unit tests affected by `fetchWithAuth` header shape

## Test plan
- [x] `VITE_USE_CLOUD_RUN=false npm run test:run` (574 passed)

Made with [Cursor](https://cursor.com)