### PR TITLE
Improve Contracts UX and Customers QuickBooks empty state

### DIFF
--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -41,7 +41,8 @@ export function buildUrl(path: string, params?: QueryParams): string {
 function assertProductionBackendUrl(_path: string): void {
   const isProductionBuild = import.meta.env.MODE === 'production';
   const base = API_CONFIG.baseUrl;
-  const isLocalhost = base.includes('localhost') || base.startsWith('http://127.');
+  const isLocalhost =
+    base.includes('localhost') || base.startsWith('http://127.');
   if (isProductionBuild && isLocalhost) {
     throw new ApiError(
       'Backend URL is not set for production. Set VITE_APP_BACKEND_URL or VITE_API_BASE_URL in Vercel to your backend, e.g. https://your-backend.run.app',
@@ -52,7 +53,10 @@ function assertProductionBackendUrl(_path: string): void {
 }
 
 function isNetworkError(err: unknown): err is TypeError {
-  return err instanceof TypeError && (err.message === 'Failed to fetch' || err.message === 'Load failed');
+  return (
+    err instanceof TypeError &&
+    (err.message === 'Failed to fetch' || err.message === 'Load failed')
+  );
 }
 
 async function parseResponseBody(response: Response): Promise<unknown> {
@@ -66,23 +70,44 @@ async function parseResponseBody(response: Response): Promise<unknown> {
 }
 
 /** Normalize error for callers: never log full payloads in production. */
-function normalizeError(parsed: unknown, response: Response): { ok: false; status: number; message: string; code?: string } {
+function normalizeError(
+  parsed: unknown,
+  response: Response
+): { ok: false; status: number; message: string; code?: string } {
   const message =
     typeof parsed === 'string'
       ? parsed
-      : (parsed as Record<string, unknown>)?.error ?? (parsed as Record<string, unknown>)?.message ?? response.statusText;
-  const code = typeof parsed === 'object' && parsed !== null ? (parsed as Record<string, unknown>)?.code : undefined;
-  return { ok: false, status: response.status, message: String(message), code: code as string | undefined };
+      : ((parsed as Record<string, unknown>)?.error ??
+        (parsed as Record<string, unknown>)?.message ??
+        response.statusText);
+  const code =
+    typeof parsed === 'object' && parsed !== null
+      ? (parsed as Record<string, unknown>)?.code
+      : undefined;
+  return {
+    ok: false,
+    status: response.status,
+    message: String(message),
+    code: code as string | undefined,
+  };
 }
 
-function buildBaseHeaders(hasBody: boolean, fetchHeaders: HeadersInit | undefined): HeadersInit {
-  const base: Record<string, string> = hasBody ? { 'Content-Type': 'application/json' } : {};
+function buildBaseHeaders(
+  hasBody: boolean,
+  fetchHeaders: HeadersInit | undefined
+): HeadersInit {
+  const base: Record<string, string> = hasBody
+    ? { 'Content-Type': 'application/json' }
+    : {};
   return { ...base, ...(fetchHeaders as Record<string, string>) };
 }
 
 /** Resolve credentials and Authorization. Always attach Supabase Bearer when available
  * (cookie mode still includes credentials; Bearer covers cases where sb-access-token cookie is missing). */
-export async function getRequestAuth(): Promise<{ credentials: RequestCredentials; headers: Record<string, string> }> {
+export async function getRequestAuth(): Promise<{
+  credentials: RequestCredentials;
+  headers: Record<string, string>;
+}> {
   const token = await getSupabaseTokenSafe();
   const headers: Record<string, string> = {};
   if (token) {
@@ -111,7 +136,10 @@ async function getSupabaseTokenSafe(): Promise<string | null> {
  * Fetch with auth applied: cookie mode sends credentials; supabase mode sends Bearer + X-Session-Token.
  * Use for any direct fetch to the backend so session is always sent. Prefer get/post/put/del when possible.
  */
-export async function fetchWithAuth(url: string, init?: RequestInit): Promise<Response> {
+export async function fetchWithAuth(
+  url: string,
+  init?: RequestInit
+): Promise<Response> {
   const auth = await getRequestAuth();
   const headers = new Headers(init?.headers);
   Object.entries(auth.headers).forEach(([k, v]) => headers.set(k, v));
@@ -122,12 +150,18 @@ export async function fetchWithAuth(url: string, init?: RequestInit): Promise<Re
   });
 }
 
-async function requestLegacy<T>(path: string, options?: RequestOptions): Promise<T> {
+async function requestLegacy<T>(
+  path: string,
+  options?: RequestOptions
+): Promise<T> {
   assertProductionBackendUrl(path);
   const { params, body, ...fetchOptions } = options ?? {};
   const hasBody = body !== undefined;
   const auth = await getRequestAuth();
-  const headers = { ...buildBaseHeaders(hasBody, fetchOptions.headers), ...auth.headers };
+  const headers = {
+    ...buildBaseHeaders(hasBody, fetchOptions.headers),
+    ...auth.headers,
+  };
   const url = buildUrl(path, params);
 
   let response: Response;
@@ -159,12 +193,18 @@ async function requestLegacy<T>(path: string, options?: RequestOptions): Promise
   return parsed as T;
 }
 
-async function requestCanonical<T>(path: string, options?: RequestOptions): Promise<T> {
+async function requestCanonical<T>(
+  path: string,
+  options?: RequestOptions
+): Promise<T> {
   assertProductionBackendUrl(path);
   const { params, body, ...fetchOptions } = options ?? {};
   const hasBody = body !== undefined;
   const auth = await getRequestAuth();
-  const headers = { ...buildBaseHeaders(hasBody, fetchOptions.headers), ...auth.headers };
+  const headers = {
+    ...buildBaseHeaders(hasBody, fetchOptions.headers),
+    ...auth.headers,
+  };
   const url = buildUrl(path, params);
 
   let response: Response;
@@ -195,7 +235,11 @@ async function requestCanonical<T>(path: string, options?: RequestOptions): Prom
     throw new ApiError(err.message, response.status, { code: err.code });
   }
 
-  if (typeof parsed !== 'object' || parsed === null || typeof (parsed as ApiResponse<unknown>).success !== 'boolean') {
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    typeof (parsed as ApiResponse<unknown>).success !== 'boolean'
+  ) {
     throw new ApiError(
       'Invalid API response: missing boolean success field. Backend must return ApiResponse wrapper.',
       response.status,
@@ -205,12 +249,17 @@ async function requestCanonical<T>(path: string, options?: RequestOptions): Prom
 
   const apiResponse = parsed as ApiResponse<T>;
   if (!apiResponse.success) {
-    throw new ApiError(apiResponse.error || 'Unknown error', response.status, { code: apiResponse.code });
+    throw new ApiError(apiResponse.error || 'Unknown error', response.status, {
+      code: apiResponse.code,
+    });
   }
   return apiResponse.data;
 }
 
-export async function get<T>(path: string, options?: Omit<RequestOptions, 'body'>): Promise<T> {
+export async function get<T>(
+  path: string,
+  options?: Omit<RequestOptions, 'body'>
+): Promise<T> {
   const request = API_CONFIG.useLegacyApi ? requestLegacy : requestCanonical;
   return request<T>(path, { method: 'GET', ...options });
 }
@@ -233,7 +282,10 @@ export async function put<T, B = unknown>(
   return request<T>(path, { method: 'PUT', body, ...options });
 }
 
-export async function del<T>(path: string, options?: Omit<RequestOptions, 'body'>): Promise<T> {
+export async function del<T>(
+  path: string,
+  options?: Omit<RequestOptions, 'body'>
+): Promise<T> {
   const request = API_CONFIG.useLegacyApi ? requestLegacy : requestCanonical;
   return request<T>(path, { method: 'DELETE', ...options });
 }

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -1,5 +1,4 @@
 import { API_CONFIG } from './config';
-import { getAuthToken } from './authToken';
 import { ApiError } from './errors';
 import { logger } from '@/utils/logger';
 
@@ -81,18 +80,31 @@ function buildBaseHeaders(hasBody: boolean, fetchHeaders: HeadersInit | undefine
   return { ...base, ...(fetchHeaders as Record<string, string>) };
 }
 
-/** Resolve credentials and Authorization. Send Supabase token when available (Bearer + X-Session-Token). */
+/** Resolve credentials and Authorization. Always attach Supabase Bearer when available
+ * (cookie mode still includes credentials; Bearer covers cases where sb-access-token cookie is missing). */
 export async function getRequestAuth(): Promise<{ credentials: RequestCredentials; headers: Record<string, string> }> {
-  if (API_CONFIG.authMode === 'cookie') {
-    return { credentials: 'include', headers: {} };
-  }
-  const token = await getAuthToken();
+  const token = await getSupabaseTokenSafe();
   const headers: Record<string, string> = {};
   if (token) {
     headers['Authorization'] = `Bearer ${token}`;
     headers['X-Session-Token'] = token;
   }
+  if (API_CONFIG.authMode === 'cookie') {
+    return { credentials: 'include', headers };
+  }
   return { credentials: 'omit', headers };
+}
+
+async function getSupabaseTokenSafe(): Promise<string | null> {
+  try {
+    const { supabase } = await import('@/lib/supabase');
+    const {
+      data: { session },
+    } = await supabase.auth.getSession();
+    return session?.access_token ?? null;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -14,8 +14,12 @@ export type ApiResponseMeta = {
 };
 
 type QueryParams = Record<string, string | number | boolean | undefined>;
+/** Derived from fetch so ESLint no-undef does not flag DOM lib type names. */
+type FetchInit = NonNullable<Parameters<typeof fetch>[1]>;
+type FetchHeaders = NonNullable<FetchInit['headers']>;
+type FetchCredentials = NonNullable<FetchInit['credentials']>;
 
-interface RequestOptions extends Omit<RequestInit, 'body'> {
+interface RequestOptions extends Omit<FetchInit, 'body'> {
   params?: QueryParams;
   body?: unknown;
 }
@@ -94,8 +98,8 @@ function normalizeError(
 
 function buildBaseHeaders(
   hasBody: boolean,
-  fetchHeaders: HeadersInit | undefined
-): HeadersInit {
+  fetchHeaders: FetchHeaders | undefined
+): Record<string, string> {
   const base: Record<string, string> = hasBody
     ? { 'Content-Type': 'application/json' }
     : {};
@@ -105,7 +109,7 @@ function buildBaseHeaders(
 /** Resolve credentials and Authorization. Always attach Supabase Bearer when available
  * (cookie mode still includes credentials; Bearer covers cases where sb-access-token cookie is missing). */
 export async function getRequestAuth(): Promise<{
-  credentials: RequestCredentials;
+  credentials: FetchCredentials;
   headers: Record<string, string>;
 }> {
   const token = await getSupabaseTokenSafe();
@@ -138,7 +142,7 @@ async function getSupabaseTokenSafe(): Promise<string | null> {
  */
 export async function fetchWithAuth(
   url: string,
-  init?: RequestInit
+  init?: FetchInit
 ): Promise<Response> {
   const auth = await getRequestAuth();
   const headers = new Headers(init?.headers);

--- a/src/api/quickbooks/auth/customer.ts
+++ b/src/api/quickbooks/auth/customer.ts
@@ -51,6 +51,16 @@ export async function createQuickBooksCustomer(
 /**
  * Fetch all invoiceable customers (status = 'customer').
  */
+function isQuickBooksUnavailableError(status: number, body: string): boolean {
+  if (status === 404 || status === 503) return true;
+  const text = body || '';
+  return (
+    text.includes('<!DOCTYPE html>') ||
+    text.includes('Cannot GET') ||
+    /not connected|no tokens|quickbooks.*(unavailable|disabled)/i.test(text)
+  );
+}
+
 export async function getInvoiceableCustomers(): Promise<
   InvoiceableCustomer[]
 > {
@@ -65,8 +75,19 @@ export async function getInvoiceableCustomers(): Promise<
     });
 
     if (!res.ok) {
-      const err = await res.text();
-      throw new Error(`Failed to fetch customers: ${err}`);
+      const err = await res.text().catch(() => '');
+      if (isQuickBooksUnavailableError(res.status, err)) {
+        // Route missing / QB not connected — let the page show a connect CTA.
+        throw new Error('QuickBooks is not connected');
+      }
+      let message = 'Failed to fetch customers';
+      try {
+        const parsed = JSON.parse(err) as { error?: string; message?: string };
+        message = parsed.error || parsed.message || message;
+      } catch {
+        if (err && !err.includes('<html')) message = err;
+      }
+      throw new Error(message);
     }
     return res.json();
   });

--- a/src/api/quickbooks/auth/customer.ts
+++ b/src/api/quickbooks/auth/customer.ts
@@ -29,7 +29,6 @@ export interface InvoiceableCustomer {
 export async function createQuickBooksCustomer(
   params: CreateCustomerParams
 ): Promise<{ qbCustomerId: string }> {
-
   return withTokenRefresh(async () => {
     const res = await fetch(`${API_BASE}/quickbooks/customer`, {
       method: 'POST',
@@ -64,7 +63,6 @@ function isQuickBooksUnavailableError(status: number, body: string): boolean {
 export async function getInvoiceableCustomers(): Promise<
   InvoiceableCustomer[]
 > {
-
   return withTokenRefresh(async () => {
     const res = await fetch(`${API_BASE}/quickbooks/customers/invoiceable`, {
       method: 'GET',
@@ -116,7 +114,6 @@ export interface QuickBooksCustomer {
 export async function getQuickBooksCustomers(
   maxResults?: number
 ): Promise<QuickBooksCustomer[]> {
-
   return withTokenRefresh(async () => {
     const url = maxResults
       ? `${API_BASE}/quickbooks/customers?maxResults=${maxResults}`

--- a/src/common/data/sidebar-data.test.ts
+++ b/src/common/data/sidebar-data.test.ts
@@ -16,7 +16,7 @@ describe('getVisibleSidebarSections', () => {
 
     expect(sections).toHaveLength(1);
     expect(sections[0]?.label).toBe('Billing');
-    expect(flattenTitles(sections)).toEqual(['Payment Schedules', 'Contracts']);
+    expect(flattenTitles(sections)).toEqual(['Payment Schedules']);
   });
 
   it('keeps admin CRM navigation intact', () => {
@@ -39,5 +39,15 @@ describe('getVisibleSidebarSections', () => {
     expect(titles).toContain('Demographics');
     expect(titles).toContain('Payment Schedules');
     expect(titles).toContain('Contracts');
+
+    const contractsItem = getVisibleSidebarSections({
+      isAdmin: true,
+      isDoula: false,
+      isClient: false,
+      isBillingOnly: false,
+    })
+      .flatMap((s) => s.items)
+      .find((i) => i.title === 'Contracts');
+    expect(contractsItem?.url).toBe('/contracts');
   });
 });

--- a/src/common/data/sidebar-data.test.ts
+++ b/src/common/data/sidebar-data.test.ts
@@ -1,7 +1,9 @@
 import { getVisibleSidebarSections } from '@/common/data/sidebar-data';
 import { describe, expect, it } from 'vitest';
 
-function flattenTitles(labels: ReturnType<typeof getVisibleSidebarSections>): string[] {
+function flattenTitles(
+  labels: ReturnType<typeof getVisibleSidebarSections>
+): string[] {
   return labels.flatMap((section) => section.items.map((item) => item.title));
 }
 

--- a/src/common/data/sidebar-data.ts
+++ b/src/common/data/sidebar-data.ts
@@ -38,7 +38,12 @@ export const sidebarSections = [
       { title: 'Dashboard', url: '/', icon: Home },
       { title: 'Inbox', url: '/inbox', icon: Inbox, clientOnly: false },
       { title: 'Leads', url: '/clients', icon: Search, adminOnly: true },
-      { title: 'Customers', url: '/clients/new', icon: UserPlus, adminOnly: true },
+      {
+        title: 'Customers',
+        url: '/clients/new',
+        icon: UserPlus,
+        adminOnly: true,
+      },
     ],
   },
   {
@@ -62,7 +67,12 @@ export const sidebarSections = [
   {
     label: 'Client Portal',
     items: [
-      { title: 'Profile Information', url: '/profile', icon: User, clientOnly: true },
+      {
+        title: 'Profile Information',
+        url: '/profile',
+        icon: User,
+        clientOnly: true,
+      },
       {
         title: 'Billing Information',
         url: '/billing',
@@ -139,7 +149,12 @@ export const sidebarSections = [
   {
     label: 'Analytics',
     items: [
-      { title: 'Demographics', url: '/demographics', icon: LucideChartColumnIncreasing, adminOnly: true },
+      {
+        title: 'Demographics',
+        url: '/demographics',
+        icon: LucideChartColumnIncreasing,
+        adminOnly: true,
+      },
     ],
   },
 ];

--- a/src/common/data/sidebar-data.ts
+++ b/src/common/data/sidebar-data.ts
@@ -51,10 +51,11 @@ export const sidebarSections = [
         billingAccess: true,
       },
       {
+        // Admin contract template manager (/contracts), not the billing schedules list.
         title: 'Contracts',
-        url: '/billing/contracts',
+        url: '/contracts',
         icon: FileText,
-        billingAccess: true,
+        adminOnly: true,
       },
     ],
   },

--- a/src/common/hooks/contracts/useTemplates.ts
+++ b/src/common/hooks/contracts/useTemplates.ts
@@ -12,20 +12,24 @@ export function useTemplates() {
     setError(null);
 
     try {
-      const response = await fetchWithAuth(
-        buildUrl('/contracts/templates'),
-        {
-          headers: {
-          },
-        }
-      );
+      const response = await fetchWithAuth(buildUrl('/contracts/templates'), {
+        cache: 'no-store',
+        headers: {},
+      });
 
-      if (!response.ok) throw new Error('Could not fetch templates');
+      if (!response.ok) {
+        throw new Error(`Could not fetch templates (${response.status})`);
+      }
 
       const data = await response.json();
-      console.log('template', data);
-      setTemplates(data as Template[]);
-      return data as Template[];
+      const list = Array.isArray(data)
+        ? (data as Template[])
+        : Array.isArray((data as { data?: Template[] })?.data)
+          ? ((data as { data: Template[] }).data)
+          : [];
+      console.log('templates response count', list.length);
+      setTemplates(list);
+      return list;
     } catch (err) {
       const message =
         err instanceof Error ? err.message : 'Error fetching templates';

--- a/src/common/hooks/contracts/useTemplates.ts
+++ b/src/common/hooks/contracts/useTemplates.ts
@@ -25,7 +25,7 @@ export function useTemplates() {
       const list = Array.isArray(data)
         ? (data as Template[])
         : Array.isArray((data as { data?: Template[] })?.data)
-          ? ((data as { data: Template[] }).data)
+          ? (data as { data: Template[] }).data
           : [];
       console.log('templates response count', list.length);
       setTemplates(list);

--- a/src/common/utils/addWorkSession.ts
+++ b/src/common/utils/addWorkSession.ts
@@ -14,7 +14,6 @@ export default async function addWorkSession(
 
   async function addSession() {
     try {
-
       const response = await fetchWithAuth(
         buildUrl(`/users/${doula_id}/addhours`),
         {
@@ -49,5 +48,5 @@ export default async function addWorkSession(
       );
     }
   }
-  addSession();
+  await addSession();
 }

--- a/src/features/clients/create-customer/createCustomer.tsx
+++ b/src/features/clients/create-customer/createCustomer.tsx
@@ -8,6 +8,7 @@ import {
   type InvoiceableCustomer,
   type QuickBooksCustomer,
 } from '@/api/quickbooks/auth/customer';
+import { getQuickBooksStatus } from '@/api/quickbooks/auth/qbo';
 import { Button } from '@/common/components/ui/button';
 import { Input } from '@/common/components/ui/input';
 import {
@@ -119,6 +120,7 @@ export default function CreateCustomerPage() {
   const [crmCustomers, setCrmCustomers] = useState<InvoiceableCustomer[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [notConnected, setNotConnected] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [statusFilter, setStatusFilter] = useState<string>('all');
   const [pageSize, setPageSize] = useState(25);
@@ -136,17 +138,43 @@ export default function CreateCustomerPage() {
   const fetchCustomers = async () => {
     setLoading(true);
     setError(null);
+    setNotConnected(false);
     try {
+      let connected = false;
+      try {
+        const status = await getQuickBooksStatus();
+        connected = Boolean(status?.connected);
+      } catch {
+        // Status route may be unavailable when QB isn't wired; treat as disconnected.
+        connected = false;
+      }
+
+      if (!connected) {
+        setNotConnected(true);
+        setQuickbooksCustomers([]);
+        setCrmCustomers([]);
+        return;
+      }
+
       const [quickbooks, crm] = await Promise.all([
         getQuickBooksCustomers(),
         getInvoiceableCustomers(),
       ]);
       setQuickbooksCustomers(quickbooks);
       setCrmCustomers(crm);
-    } catch (err: any) {
+    } catch (err: unknown) {
       const errorMessage =
-        err.message || 'Failed to load customers from QuickBooks and CRM';
-      setError(errorMessage);
+        err instanceof Error
+          ? err.message
+          : 'Failed to load customers from QuickBooks and CRM';
+      if (/not connected/i.test(errorMessage)) {
+        setNotConnected(true);
+        setQuickbooksCustomers([]);
+        setCrmCustomers([]);
+        setError(null);
+      } else {
+        setError(errorMessage);
+      }
       console.error('Error fetching customers:', err);
     } finally {
       setLoading(false);
@@ -302,20 +330,49 @@ export default function CreateCustomerPage() {
           </div>
         )}
 
-        {error && (
+        {!loading && notConnected && (
+          <div className='flex-1 flex items-center justify-center p-8'>
+            <div className='text-center max-w-md'>
+              <div className='mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-muted text-muted-foreground'>
+                <svg
+                  fill='none'
+                  viewBox='0 0 24 24'
+                  stroke='currentColor'
+                  className='h-7 w-7'
+                  aria-hidden
+                >
+                  <path
+                    strokeLinecap='round'
+                    strokeLinejoin='round'
+                    strokeWidth={2}
+                    d='M13.828 10.172a4 4 0 00-5.656 0l-4 4a4 4 0 105.656 5.656l1.102-1.101m-.758-4.899a4 4 0 005.656 0l4-4a4 4 0 00-5.656-5.656l-1.1 1.1'
+                  />
+                </svg>
+              </div>
+              <h3 className='text-lg font-medium mb-2'>
+                No customers from QuickBooks right now
+              </h3>
+              <p className='text-sm text-muted-foreground mb-4'>
+                Connect your QuickBooks account to see customers here.
+              </p>
+              <div className='flex items-center justify-center gap-2'>
+                <Button onClick={() => navigate('/integrations/quickbooks')}>
+                  Connect QuickBooks
+                </Button>
+                <Button variant='outline' onClick={fetchCustomers}>
+                  Retry
+                </Button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {error && !notConnected && (
           <div className='flex-1 flex flex-col items-center justify-center p-8'>
             <div className='rounded-lg border border-destructive/50 bg-destructive/10 p-4 max-w-md text-destructive'>
               <p className='font-medium'>Error</p>
               <p className='text-sm mt-1'>{error}</p>
               <div className='mt-3 flex gap-2'>
-                {error.includes('not connected') && (
-                  <Button
-                    size='sm'
-                    onClick={() => navigate('/integrations/quickbooks')}
-                  >
-                    Connect QuickBooks
-                  </Button>
-                )}
                 <Button variant='outline' size='sm' onClick={fetchCustomers}>
                   Retry
                 </Button>
@@ -324,7 +381,7 @@ export default function CreateCustomerPage() {
           </div>
         )}
 
-        {!loading && !error && customers.length === 0 && (
+        {!loading && !error && !notConnected && customers.length === 0 && (
           <div className='flex-1 flex items-center justify-center p-8'>
             <div className='text-center max-w-md'>
               <div className='mx-auto mb-4 h-12 w-12 text-muted-foreground'>
@@ -344,21 +401,20 @@ export default function CreateCustomerPage() {
               </div>
               <h3 className='text-lg font-medium mb-2'>No customers found</h3>
               <p className='text-sm text-muted-foreground mb-4'>
-                There are no customers in your QuickBooks account yet, or the
-                endpoint is not available.
+                There are no customers in your QuickBooks account yet.
               </p>
               <Button onClick={fetchCustomers}>Refresh</Button>
             </div>
           </div>
         )}
 
-        {!loading && !error && customers.length > 0 && filteredCustomers.length === 0 && (
+        {!loading && !error && !notConnected && customers.length > 0 && filteredCustomers.length === 0 && (
           <div className='flex-1 flex items-center justify-center p-8 text-muted-foreground'>
             No customers match the current filters.
           </div>
         )}
 
-        {!loading && !error && filteredCustomers.length > 0 && (
+        {!loading && !error && !notConnected && filteredCustomers.length > 0 && (
           <>
             <div className='overflow-auto flex-1 min-h-0'>
               <table className='min-w-full text-sm'>

--- a/src/features/clients/create-customer/createCustomer.tsx
+++ b/src/features/clients/create-customer/createCustomer.tsx
@@ -21,7 +21,14 @@ import {
 import { useContext, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ToastContainer, toast } from 'react-toastify';
-import { ChevronLeft, ChevronRight, Filter, Loader2, RefreshCw, Search } from 'lucide-react';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Filter,
+  Loader2,
+  RefreshCw,
+  Search,
+} from 'lucide-react';
 import 'react-toastify/dist/ReactToastify.css';
 import {
   normalizeQuickBooksSyncStatus,
@@ -82,7 +89,8 @@ function mergeCustomers(
     const existing = merged.get(key);
 
     if (existing) {
-      existing.source = existing.source === 'quickbooks' ? 'both' : existing.source;
+      existing.source =
+        existing.source === 'quickbooks' ? 'both' : existing.source;
       existing.quickBooksSyncStatus = normalizeQuickBooksSyncStatus(
         customer.quickbooksSyncStatus ??
           customer.syncStatus ??
@@ -116,7 +124,9 @@ export default function CreateCustomerPage() {
   const { user, isLoading: authLoading } = useContext(UserContext);
   const navigate = useNavigate();
 
-  const [quickbooksCustomers, setQuickbooksCustomers] = useState<QuickBooksCustomer[]>([]);
+  const [quickbooksCustomers, setQuickbooksCustomers] = useState<
+    QuickBooksCustomer[]
+  >([]);
   const [crmCustomers, setCrmCustomers] = useState<InvoiceableCustomer[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -198,8 +208,14 @@ export default function CreateCustomerPage() {
       const nameMatch = !q || (c.displayName?.toLowerCase() ?? '').includes(q);
       const emailMatch = !q || (c.email?.toLowerCase() ?? '').includes(q);
       if (!nameMatch && !emailMatch) return false;
-      if (statusFilter === 'active' && c.source !== 'crm' && !c.active) return false;
-      if (statusFilter === 'inactive' && c.source !== 'crm' && c.active !== false) return false;
+      if (statusFilter === 'active' && c.source !== 'crm' && !c.active)
+        return false;
+      if (
+        statusFilter === 'inactive' &&
+        c.source !== 'crm' &&
+        c.active !== false
+      )
+        return false;
       return true;
     });
   }, [customers, searchQuery, statusFilter]);
@@ -209,7 +225,10 @@ export default function CreateCustomerPage() {
     setCurrentPage(1);
   }, [searchQuery, statusFilter]);
 
-  const totalPages = Math.max(1, Math.ceil(filteredCustomers.length / pageSize));
+  const totalPages = Math.max(
+    1,
+    Math.ceil(filteredCustomers.length / pageSize)
+  );
   const startItem = (currentPage - 1) * pageSize;
   const paginatedCustomers = useMemo(
     () => filteredCustomers.slice(startItem, startItem + pageSize),
@@ -408,107 +427,132 @@ export default function CreateCustomerPage() {
           </div>
         )}
 
-        {!loading && !error && !notConnected && customers.length > 0 && filteredCustomers.length === 0 && (
-          <div className='flex-1 flex items-center justify-center p-8 text-muted-foreground'>
-            No customers match the current filters.
-          </div>
-        )}
-
-        {!loading && !error && !notConnected && filteredCustomers.length > 0 && (
-          <>
-            <div className='overflow-auto flex-1 min-h-0'>
-              <table className='min-w-full text-sm'>
-                <thead className='sticky top-0 bg-muted/80 backdrop-blur z-10'>
-                  <tr className='border-b'>
-                    <th className='px-4 py-3 text-left font-semibold'>Name</th>
-                    <th className='px-4 py-3 text-left font-semibold'>Email</th>
-                    <th className='px-4 py-3 text-left font-semibold'>Phone</th>
-                    <th className='px-4 py-3 text-right font-semibold'>Balance</th>
-                    <th className='px-4 py-3 text-left font-semibold'>Account status</th>
-                    <th className='px-4 py-3 text-left font-semibold'>QuickBooks sync</th>
-                  </tr>
-                </thead>
-              <tbody>
-                {paginatedCustomers.map((customer) => (
-                  <tr
-                    key={customer.key}
-                    className='border-b border-border/50 last:border-0 hover:bg-muted/30'
-                  >
-                    <td className='px-4 py-3'>{customer.displayName}</td>
-                    <td className='px-4 py-3 text-muted-foreground'>
-                      {customer.email || '—'}
-                    </td>
-                    <td className='px-4 py-3 text-muted-foreground'>
-                      {customer.phone || '—'}
-                    </td>
-                    <td className='px-4 py-3 text-right'>
-                      {formatCurrency(customer.balance)}
-                    </td>
-                    <td className='px-4 py-3'>
-                      {customer.source !== 'crm' ? (
-                        <span
-                          className={`inline-flex rounded-md px-2 py-0.5 text-xs font-medium ${
-                            customer.active
-                              ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
-                              : 'bg-muted text-muted-foreground'
-                          }`}
-                        >
-                          {customer.active ? 'Active' : 'Inactive'}
-                        </span>
-                      ) : (
-                        <span className='text-muted-foreground'>—</span>
-                      )}
-                    </td>
-                    <td className='px-4 py-3'>
-                      <span
-                        className={`inline-flex rounded-md px-2 py-0.5 text-xs font-medium ${
-                          QUICKBOOKS_SYNC_STATUS_META[customer.quickBooksSyncStatus].className
-                        }`}
-                      >
-                        {QUICKBOOKS_SYNC_STATUS_META[customer.quickBooksSyncStatus].label}
-                      </span>
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-
-          {/* Pagination bar */}
-          <div className='shrink-0 flex items-center justify-between gap-4 px-4 py-3 border-t bg-muted/30'>
-            <p className='text-sm text-muted-foreground'>
-              Showing {startItem + 1}–
-              {Math.min(startItem + pageSize, filteredCustomers.length)} of{' '}
-              {filteredCustomers.length}
-            </p>
-            <div className='flex items-center gap-2'>
-              <Button
-                variant='outline'
-                size='sm'
-                className='h-8 w-8 p-0'
-                disabled={currentPage <= 1}
-                onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-              >
-                <ChevronLeft className='h-4 w-4' />
-              </Button>
-              <span className='text-sm font-medium min-w-[80px] text-center'>
-                Page {currentPage} of {totalPages}
-              </span>
-              <Button
-                variant='outline'
-                size='sm'
-                className='h-8 w-8 p-0'
-                disabled={currentPage >= totalPages}
-                onClick={() =>
-                  setCurrentPage((p) => Math.min(totalPages, p + 1))
-                }
-              >
-                <ChevronRight className='h-4 w-4' />
-              </Button>
+        {!loading &&
+          !error &&
+          !notConnected &&
+          customers.length > 0 &&
+          filteredCustomers.length === 0 && (
+            <div className='flex-1 flex items-center justify-center p-8 text-muted-foreground'>
+              No customers match the current filters.
             </div>
-          </div>
-        </>
-        )}
+          )}
+
+        {!loading &&
+          !error &&
+          !notConnected &&
+          filteredCustomers.length > 0 && (
+            <>
+              <div className='overflow-auto flex-1 min-h-0'>
+                <table className='min-w-full text-sm'>
+                  <thead className='sticky top-0 bg-muted/80 backdrop-blur z-10'>
+                    <tr className='border-b'>
+                      <th className='px-4 py-3 text-left font-semibold'>
+                        Name
+                      </th>
+                      <th className='px-4 py-3 text-left font-semibold'>
+                        Email
+                      </th>
+                      <th className='px-4 py-3 text-left font-semibold'>
+                        Phone
+                      </th>
+                      <th className='px-4 py-3 text-right font-semibold'>
+                        Balance
+                      </th>
+                      <th className='px-4 py-3 text-left font-semibold'>
+                        Account status
+                      </th>
+                      <th className='px-4 py-3 text-left font-semibold'>
+                        QuickBooks sync
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {paginatedCustomers.map((customer) => (
+                      <tr
+                        key={customer.key}
+                        className='border-b border-border/50 last:border-0 hover:bg-muted/30'
+                      >
+                        <td className='px-4 py-3'>{customer.displayName}</td>
+                        <td className='px-4 py-3 text-muted-foreground'>
+                          {customer.email || '—'}
+                        </td>
+                        <td className='px-4 py-3 text-muted-foreground'>
+                          {customer.phone || '—'}
+                        </td>
+                        <td className='px-4 py-3 text-right'>
+                          {formatCurrency(customer.balance)}
+                        </td>
+                        <td className='px-4 py-3'>
+                          {customer.source !== 'crm' ? (
+                            <span
+                              className={`inline-flex rounded-md px-2 py-0.5 text-xs font-medium ${
+                                customer.active
+                                  ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+                                  : 'bg-muted text-muted-foreground'
+                              }`}
+                            >
+                              {customer.active ? 'Active' : 'Inactive'}
+                            </span>
+                          ) : (
+                            <span className='text-muted-foreground'>—</span>
+                          )}
+                        </td>
+                        <td className='px-4 py-3'>
+                          <span
+                            className={`inline-flex rounded-md px-2 py-0.5 text-xs font-medium ${
+                              QUICKBOOKS_SYNC_STATUS_META[
+                                customer.quickBooksSyncStatus
+                              ].className
+                            }`}
+                          >
+                            {
+                              QUICKBOOKS_SYNC_STATUS_META[
+                                customer.quickBooksSyncStatus
+                              ].label
+                            }
+                          </span>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              {/* Pagination bar */}
+              <div className='shrink-0 flex items-center justify-between gap-4 px-4 py-3 border-t bg-muted/30'>
+                <p className='text-sm text-muted-foreground'>
+                  Showing {startItem + 1}–
+                  {Math.min(startItem + pageSize, filteredCustomers.length)} of{' '}
+                  {filteredCustomers.length}
+                </p>
+                <div className='flex items-center gap-2'>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    className='h-8 w-8 p-0'
+                    disabled={currentPage <= 1}
+                    onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                  >
+                    <ChevronLeft className='h-4 w-4' />
+                  </Button>
+                  <span className='text-sm font-medium min-w-[80px] text-center'>
+                    Page {currentPage} of {totalPages}
+                  </span>
+                  <Button
+                    variant='outline'
+                    size='sm'
+                    className='h-8 w-8 p-0'
+                    disabled={currentPage >= totalPages}
+                    onClick={() =>
+                      setCurrentPage((p) => Math.min(totalPages, p + 1))
+                    }
+                  >
+                    <ChevronRight className='h-4 w-4' />
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
       </div>
 
       <ToastContainer position='top-right' newestOnTop closeOnClick />

--- a/src/features/contracts/ContractRoutes.tsx
+++ b/src/features/contracts/ContractRoutes.tsx
@@ -3,8 +3,6 @@ import { Route } from 'react-router-dom';
 import Contracts from './Contracts';
 
 const ContractRoutes = () => (
-  <Route>
-    <Route path='contracts' element={<Contracts />} />
-  </Route>
+  <Route path='/contracts' element={<Contracts />} />
 );
 export default ContractRoutes;

--- a/src/features/contracts/components/common/Viewport.tsx
+++ b/src/features/contracts/components/common/Viewport.tsx
@@ -16,6 +16,7 @@ export function Viewport() {
   const {
     templates,
     isLoading,
+    error,
     getTemplates,
     selectedTemplateName,
     setSelectedTemplateName,
@@ -29,12 +30,12 @@ export function Viewport() {
     <div>
       <LoadingOverlay isLoading={isLoading} />
 
-      <div className='flex flex-row lg:flex-row w-full flex-1 overflow-hidden px-4 py-10 gap-6'>
-        <div className='flex-1 overflow-y-auto'>
+      <div className='flex flex-col-reverse xl:flex-row w-full flex-1 overflow-hidden px-2 sm:px-4 py-6 gap-6'>
+        <div className='flex-1 min-w-0 overflow-y-auto'>
           {selectedTemplateName ? (
             <PdfPreview />
           ) : (
-            <div className='flex items-center justify-center h-[500px] border rounded-lg'>
+            <div className='flex items-center justify-center h-[min(70vh,720px)] border rounded-lg bg-muted/20'>
               <p className='text-muted-foreground'>
                 Select a template to preview.
               </p>
@@ -42,20 +43,25 @@ export function Viewport() {
           )}
         </div>
 
-        <Card className='w-60 flex-shrink-0'>
-          <CardHeader className='flex flex-row items-center justify-between  pb-2'>
-            <div>
-              <CardTitle className='text-l pb-1'> Templates </CardTitle>
+        <Card className='w-full xl:w-[22rem] 2xl:w-96 shrink-0'>
+          <CardHeader className='flex flex-row items-start justify-between gap-3 pb-3'>
+            <div className='min-w-0'>
+              <CardTitle className='text-lg pb-1'>Templates</CardTitle>
               <CardDescription>
-                {' '}
-                Click on a template to view or edit{' '}
+                Click a template to preview or edit.
               </CardDescription>
             </div>
             <NewTemplateDialog onUploadSuccess={getTemplates} />
           </CardHeader>
 
           <CardContent className='p-4 pt-0'>
-            <div className='flex flex-col gap-2'>
+            <div className='flex flex-col gap-3'>
+              {error && <p className='text-sm text-destructive'>{error}</p>}
+              {!isLoading && !error && templates.length === 0 && (
+                <p className='text-sm text-muted-foreground'>
+                  No templates found.
+                </p>
+              )}
               {templates.map((template) => (
                 <TemplateItem
                   key={template.id}

--- a/src/features/contracts/components/pdf/PdfPreview.tsx
+++ b/src/features/contracts/components/pdf/PdfPreview.tsx
@@ -7,10 +7,9 @@ import { Separator } from '@/common/components/ui/separator';
 import { ExternalLink } from 'lucide-react';
 
 function buildPublicStorageUrl(storagePath: string): string {
-  const base = (import.meta.env.VITE_SUPABASE_URL as string | undefined)?.replace(
-    /\/+$/,
-    ''
-  );
+  const base = (
+    import.meta.env.VITE_SUPABASE_URL as string | undefined
+  )?.replace(/\/+$/, '');
   if (!base) {
     throw new Error('VITE_SUPABASE_URL is not configured');
   }

--- a/src/features/contracts/components/pdf/PdfPreview.tsx
+++ b/src/features/contracts/components/pdf/PdfPreview.tsx
@@ -1,106 +1,105 @@
 import { useTemplatesContext } from '@/features/contracts/contexts/TemplatesContext';
-import { useEffect, useState } from 'react';
-import { Document, Page, pdfjs } from 'react-pdf';
+import { useMemo, useState } from 'react';
 
-import { LoadingOverlay } from '@/common/components/loading/LoadingOverlay';
 import { Badge } from '@/common/components/ui/badge';
-import { ScrollArea } from '@/common/components/ui/scroll-area';
+import { Button } from '@/common/components/ui/button';
 import { Separator } from '@/common/components/ui/separator';
+import { ExternalLink } from 'lucide-react';
 
-import 'react-pdf/dist/Page/AnnotationLayer.css';
-import 'react-pdf/dist/Page/TextLayer.css';
-import { fetchWithAuth, buildUrl } from '@/api/http';
-
-pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.js`;
+function buildPublicStorageUrl(storagePath: string): string {
+  const base = (import.meta.env.VITE_SUPABASE_URL as string | undefined)?.replace(
+    /\/+$/,
+    ''
+  );
+  if (!base) {
+    throw new Error('VITE_SUPABASE_URL is not configured');
+  }
+  const encodedPath = storagePath
+    .split('/')
+    .map((part) => encodeURIComponent(part))
+    .join('/');
+  return `${base}/storage/v1/object/public/contract-templates/${encodedPath}`;
+}
 
 export function PdfPreview() {
-  const [pdfUrl, setPdfUrl] = useState<string | null>(null);
-  const [numPages, setNumPages] = useState<number | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const { selectedTemplateName } = useTemplatesContext();
+  const { selectedTemplateName, templates } = useTemplatesContext();
+  const [embedFailed, setEmbedFailed] = useState(false);
 
-  useEffect(() => {
-    const fetchPdf = async () => {
-      setIsLoading(true);
-      try {
-        console.log(selectedTemplateName);
-        const res = await fetchWithAuth(
-          buildUrl('/contracts/templates/generate'),
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-              name: selectedTemplateName,
-              fields: {
-                clientname: 'CLIENT_NAME',
-                deposit: 'DEPOSIT',
-              },
-            }),
-          }
-        );
+  const selected = useMemo(
+    () => templates.find((t) => t.name === selectedTemplateName) ?? null,
+    [templates, selectedTemplateName]
+  );
 
-        if (!res.ok) throw new Error('PDF preview fetch failed');
+  const storagePath =
+    selected?.storagePath ||
+    (selectedTemplateName ? `${selectedTemplateName}.docx` : null);
 
-        const blob = await res.blob();
-        const objectUrl = URL.createObjectURL(blob);
-        setPdfUrl(objectUrl);
-      } catch (err) {
-        console.error(err);
-      } finally {
-        setIsLoading(false);
-      }
-    };
+  const publicUrl = useMemo(() => {
+    if (!storagePath) return null;
+    try {
+      return buildPublicStorageUrl(storagePath);
+    } catch {
+      return null;
+    }
+  }, [storagePath]);
 
-    fetchPdf();
-  }, [selectedTemplateName]);
+  const isPdf = !!storagePath?.toLowerCase().endsWith('.pdf');
+
+  const viewerUrl = useMemo(() => {
+    if (!publicUrl) return null;
+    if (isPdf) return publicUrl;
+    // Microsoft Office Online viewer for public DOCX URLs
+    return `https://view.officeapps.live.com/op/embed.aspx?src=${encodeURIComponent(publicUrl)}`;
+  }, [publicUrl, isPdf]);
+
+  if (!selectedTemplateName || !viewerUrl || !publicUrl) {
+    return (
+      <div className='flex items-center justify-center h-[min(70vh,720px)] border rounded-lg'>
+        <p className='text-muted-foreground'>Select a template to preview.</p>
+      </div>
+    );
+  }
 
   return (
-    <div className='relative w-full'>
-      <LoadingOverlay isLoading={isLoading} />
-
-      <div className='flex items-center justify-between px-4 py-2 bg-white border rounded-t-md'>
-        <div className='flex items-center gap-2 text-sm font-medium'>
-          <span className='text-muted-foreground'>Template:</span>
-          <Badge variant='outline'>{selectedTemplateName}</Badge>
+    <div className='relative w-full min-w-0'>
+      <div className='flex flex-wrap items-center justify-between gap-3 px-4 py-3 bg-white border rounded-t-md'>
+        <div className='flex items-center gap-2 text-sm font-medium min-w-0'>
+          <span className='text-muted-foreground shrink-0'>Template:</span>
+          <Badge variant='outline' className='truncate max-w-[min(100%,28rem)]'>
+            {selectedTemplateName}
+          </Badge>
         </div>
-        {numPages && (
-          <div className='text-muted-foreground text-sm'>
-            Pages: <span className='font-semibold'>{numPages}</span>
-          </div>
-        )}
+        <Button variant='outline' size='sm' asChild>
+          <a href={publicUrl} target='_blank' rel='noreferrer'>
+            <ExternalLink className='h-4 w-4 mr-2' />
+            Open file
+          </a>
+        </Button>
       </div>
 
       <Separator />
 
-      <div className='border border-t-0 rounded-b-md max-h-[600px] h-[600px] w-full overflow-hidden bg-muted'>
-        <ScrollArea className='h-full w-full px-4 py-2'>
-          {pdfUrl ? (
-            <Document
-              file={pdfUrl}
-              onLoadSuccess={({ numPages }: { numPages: number }) =>
-                setNumPages(numPages)
-              }
-              loading=''
-            >
-              <div className='flex flex-col items-center gap-6 py-4'>
-                {Array.from({ length: numPages || 0 }, (_, i) => (
-                  <Page
-                    key={i}
-                    pageNumber={i + 1}
-                    width={480}
-                    className='shadow rounded'
-                    renderAnnotationLayer={false}
-                    renderTextLayer={true}
-                  />
-                ))}
-              </div>
-            </Document>
-          ) : (
-            <p className='text-muted-foreground'>No PDF to show</p>
-          )}
-        </ScrollArea>
+      <div className='border border-t-0 rounded-b-md h-[min(70vh,720px)] w-full overflow-hidden bg-muted'>
+        {embedFailed ? (
+          <div className='flex flex-col items-center justify-center h-full gap-3 px-6 text-center'>
+            <p className='text-sm text-muted-foreground'>
+              Inline preview could not load. Open the file in a new tab instead.
+            </p>
+            <Button asChild>
+              <a href={publicUrl} target='_blank' rel='noreferrer'>
+                Open template
+              </a>
+            </Button>
+          </div>
+        ) : (
+          <iframe
+            key={viewerUrl}
+            title={`Preview ${selectedTemplateName}`}
+            src={viewerUrl}
+            className='h-full w-full bg-white'
+            onError={() => setEmbedFailed(true)}
+          />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Send Supabase Bearer alongside cookie auth so Contracts/Customers calls stay authenticated after Cloud Run cutover
- Fix Contracts route/sidebar; load templates with `cache: 'no-store'`; preview via Office Online embed
- Customers page shows a connect-QuickBooks empty state instead of raw HTML 404 errors

## Test plan
- [ ] Admin → Contracts: templates list loads; selecting a template shows Office preview
- [ ] Sidebar Contracts goes to `/contracts` (admin-only)
- [ ] Customers page with QB disconnected shows connect CTA (no HTML error dump)
- [ ] Smoke login + another authenticated page still works


Made with [Cursor](https://cursor.com)