### PR TITLE
Fix Cloud Build: duplicate apiBaseUrl in notes.ts

### DIFF
--- a/src/api/clients/notes.ts
+++ b/src/api/clients/notes.ts
@@ -81,8 +81,6 @@ const normalizeNotes = (raw: any, clientId: string): ClientNote[] => {
   return rawList.map((row: any) => normalizeNoteRow(row, clientId));
 };
 
-import { apiBaseUrl } from '@/config/env';
-
 const getNotesUrl = (clientId: string, role?: NotesViewerRole): string[] => {
   const base = apiBaseUrl;
   const clientIdSafe = encodeURIComponent(clientId);


### PR DESCRIPTION
## Summary
- Remove duplicate `apiBaseUrl` import in `src/api/clients/notes.ts` that failed `tsc` during Cloud Run frontend image build

## Test plan
- [x] `npx tsc -p tsconfig.build.json --noEmit` passes locally
- [ ] Cloud Build for `sokana-front-end` on main succeeds after merge


Made with [Cursor](https://cursor.com)