### PR TITLE
Fix mobile layout: hamburger shell and usable Home on 375/768

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,9 +1,9 @@
 # Copy to .env.local and fill in. Do not commit .env.local.
 # See docs/PRODUCTION_SPLIT_DB.md for production (split-db) architecture.
 
-# Gradual cutover to Cloud Run (local or staged testing). When true, ignores local/Vercel backend URL.
+# Gradual cutover to Cloud Run (local or staged testing). When true, VITE_CLOUD_RUN_API_URL is required in production builds.
 # VITE_USE_CLOUD_RUN=true
-# VITE_CLOUD_RUN_API_URL=https://sokana-private-api-634744984887.us-central1.run.app
+# VITE_CLOUD_RUN_API_URL=https://your-cloud-run-url.run.app
 
 # API (required for production when not using VITE_USE_CLOUD_RUN)
 VITE_API_BASE_URL=https://your-cloud-run-url.run.app
@@ -22,6 +22,9 @@ VITE_AUTH_MODE=cookie
 
 # Environment: production | staging | development
 VITE_APP_ENV=development
+
+# Public /request "Fill with test data" — always on in Vite dev. Production builds stay off unless true.
+# VITE_ENABLE_REQUEST_TEST_DATA=true
 
 # Optional: client id for smoke test (npm run smoke:api)
 # VITE_SMOKE_CLIENT_ID=uuid

--- a/e2e/request-form-home-people-count.spec.ts
+++ b/e2e/request-form-home-people-count.spec.ts
@@ -70,7 +70,7 @@ test.describe('Request form — People in the Home counts (E2E)', () => {
           home_adults_count?: string;
           home_youth_count?: string;
           email?: string;
-          skip_email_notifications?: boolean;
+          submission_source?: string;
         }
       | undefined;
 
@@ -105,7 +105,7 @@ test.describe('Request form — People in the Home counts (E2E)', () => {
     expect(capturedPayload?.email).toBe(uniqueEmail);
     expect(capturedPayload?.home_adults_count).toBe('5+');
     expect(capturedPayload?.home_youth_count).toBe('3');
-    expect(capturedPayload?.skip_email_notifications).toBe(true);
+    expect(capturedPayload).not.toHaveProperty('skip_email_notifications');
 
     await expect(page.getByText('Request Form Submitted Successfully', { exact: false })).toBeVisible({
       timeout: 15000,

--- a/e2e/request-form-home-people-count.spec.ts
+++ b/e2e/request-form-home-people-count.spec.ts
@@ -13,7 +13,9 @@ const HOME_PEOPLE_QUESTION =
 const HOME_PEOPLE_COUNT_OPTIONS = ['0', '1', '2', '3', '4', '5+'] as const;
 
 test.describe('Request form — People in the Home counts (E2E)', () => {
-  test('shows question and adult/youth count dropdowns on Home Details', async ({ page }) => {
+  test('shows question and adult/youth count dropdowns on Home Details', async ({
+    page,
+  }) => {
     await reachHomeDetailsStep(page);
 
     await expect(page.getByText('Support Person')).toBeVisible();
@@ -38,7 +40,9 @@ test.describe('Request form — People in the Home counts (E2E)', () => {
 
     await clickFormNext(page);
 
-    await expect(page.getByText('Home type (check all that apply)')).toBeVisible();
+    await expect(
+      page.getByText('Home type (check all that apply)')
+    ).toBeVisible();
     await expect(
       page.locator('[class*="form-error"]').filter({
         hasText: /adults live in the home/i,
@@ -62,7 +66,9 @@ test.describe('Request form — People in the Home counts (E2E)', () => {
     await expect(page.locator('#referral_source')).toBeVisible();
   });
 
-  test('submits home_adults_count and home_youth_count to backend', async ({ page }) => {
+  test('submits home_adults_count and home_youth_count to backend', async ({
+    page,
+  }) => {
     test.setTimeout(120000);
     const uniqueEmail = `home-people-e2e-${Date.now()}@example.com`;
     let capturedPayload:
@@ -75,7 +81,9 @@ test.describe('Request form — People in the Home counts (E2E)', () => {
       | undefined;
 
     await page.route('**/requestService/requestSubmission', async (route) => {
-      capturedPayload = route.request().postDataJSON() as typeof capturedPayload;
+      capturedPayload = route
+        .request()
+        .postDataJSON() as typeof capturedPayload;
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -107,7 +115,9 @@ test.describe('Request form — People in the Home counts (E2E)', () => {
     expect(capturedPayload?.home_youth_count).toBe('3');
     expect(capturedPayload).not.toHaveProperty('skip_email_notifications');
 
-    await expect(page.getByText('Request Form Submitted Successfully', { exact: false })).toBeVisible({
+    await expect(
+      page.getByText('Request Form Submitted Successfully', { exact: false })
+    ).toBeVisible({
       timeout: 15000,
     });
   });

--- a/e2e/request-form-home-type.spec.ts
+++ b/e2e/request-form-home-type.spec.ts
@@ -74,7 +74,7 @@ test.describe('Request form — Home Type multi-select (E2E)', () => {
           home_type?: string[];
           home_type_other?: string;
           email?: string;
-          skip_email_notifications?: boolean;
+          submission_source?: string;
         }
       | undefined;
 
@@ -121,7 +121,7 @@ test.describe('Request form — Home Type multi-select (E2E)', () => {
       ])
     );
     expect(capturedPayload?.home_type_other).toBe('Emergency shelter placement — week 32');
-    expect(capturedPayload?.skip_email_notifications).toBe(true);
+    expect(capturedPayload).not.toHaveProperty('skip_email_notifications');
 
     await expect(page.getByText('Request Form Submitted Successfully', { exact: false })).toBeVisible({
       timeout: 15000,

--- a/e2e/request-form-home-type.spec.ts
+++ b/e2e/request-form-home-type.spec.ts
@@ -10,12 +10,18 @@ import {
 } from './helpers/requestForm';
 
 test.describe('Request form — Home Type multi-select (E2E)', () => {
-  test('shows check-all-that-apply options on Home Details step', async ({ page }) => {
+  test('shows check-all-that-apply options on Home Details step', async ({
+    page,
+  }) => {
     await reachHomeDetailsStep(page);
 
-    await expect(page.getByText('Home type (check all that apply)')).toBeVisible();
+    await expect(
+      page.getByText('Home type (check all that apply)')
+    ).toBeVisible();
     for (const label of Object.values(HOME_TYPE_CHECKBOX_LABELS)) {
-      await expect(page.getByRole('checkbox', { name: label, exact: true })).toBeVisible();
+      await expect(
+        page.getByRole('checkbox', { name: label, exact: true })
+      ).toBeVisible();
     }
   });
 
@@ -36,37 +42,62 @@ test.describe('Request form — Home Type multi-select (E2E)', () => {
     await reachHomeDetailsStep(page);
     await completeStep2HomeDetailsAddress(page);
 
-    await page.getByRole('checkbox', { name: HOME_TYPE_CHECKBOX_LABELS.other, exact: true }).check();
+    await page
+      .getByRole('checkbox', {
+        name: HOME_TYPE_CHECKBOX_LABELS.other,
+        exact: true,
+      })
+      .check();
     await clickFormNext(page);
 
-    await expect(page.locator('[class*="form-error"]').filter({
-      hasText: 'Please describe your housing situation',
-    })).toBeVisible();
+    await expect(
+      page.locator('[class*="form-error"]').filter({
+        hasText: 'Please describe your housing situation',
+      })
+    ).toBeVisible();
 
-    await page.locator('#home_type_other').fill('Co-living in a converted garage unit');
+    await page
+      .locator('#home_type_other')
+      .fill('Co-living in a converted garage unit');
     await clickFormNext(page);
     await expect(page.locator('#referral_source')).toBeVisible();
   });
 
-  test('Prefer not to answer is mutually exclusive with other options', async ({ page }) => {
+  test('Prefer not to answer is mutually exclusive with other options', async ({
+    page,
+  }) => {
     await reachHomeDetailsStep(page);
 
     await page
-      .getByRole('checkbox', { name: HOME_TYPE_CHECKBOX_LABELS.rent, exact: true })
+      .getByRole('checkbox', {
+        name: HOME_TYPE_CHECKBOX_LABELS.rent,
+        exact: true,
+      })
       .check();
     await page
-      .getByRole('checkbox', { name: HOME_TYPE_CHECKBOX_LABELS.preferNot, exact: true })
+      .getByRole('checkbox', {
+        name: HOME_TYPE_CHECKBOX_LABELS.preferNot,
+        exact: true,
+      })
       .check();
 
     await expect(
-      page.getByRole('checkbox', { name: HOME_TYPE_CHECKBOX_LABELS.rent, exact: true })
+      page.getByRole('checkbox', {
+        name: HOME_TYPE_CHECKBOX_LABELS.rent,
+        exact: true,
+      })
     ).not.toBeChecked();
     await expect(
-      page.getByRole('checkbox', { name: HOME_TYPE_CHECKBOX_LABELS.preferNot, exact: true })
+      page.getByRole('checkbox', {
+        name: HOME_TYPE_CHECKBOX_LABELS.preferNot,
+        exact: true,
+      })
     ).toBeChecked();
   });
 
-  test('submits home_type array and home_type_other to backend', async ({ page }) => {
+  test('submits home_type array and home_type_other to backend', async ({
+    page,
+  }) => {
     test.setTimeout(120000);
     const uniqueEmail = `home-type-e2e-${Date.now()}@example.com`;
     let capturedPayload:
@@ -79,7 +110,9 @@ test.describe('Request form — Home Type multi-select (E2E)', () => {
       | undefined;
 
     await page.route('**/requestService/requestSubmission', async (route) => {
-      capturedPayload = route.request().postDataJSON() as typeof capturedPayload;
+      capturedPayload = route
+        .request()
+        .postDataJSON() as typeof capturedPayload;
       await route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -98,16 +131,23 @@ test.describe('Request form — Home Type multi-select (E2E)', () => {
     await page.locator('#email').fill(uniqueEmail);
     await clickFormNext(page);
 
-    await expect(page.getByText('Home type (check all that apply)')).toBeVisible();
+    await expect(
+      page.getByText('Home type (check all that apply)')
+    ).toBeVisible();
     await page
-      .getByRole('checkbox', { name: HOME_TYPE_CHECKBOX_LABELS.rent, exact: true })
+      .getByRole('checkbox', {
+        name: HOME_TYPE_CHECKBOX_LABELS.rent,
+        exact: true,
+      })
       .uncheck()
       .catch(() => {});
     await checkHomeTypeOptions(page, [
       HOME_TYPE_CHECKBOX_LABELS.other,
       HOME_TYPE_CHECKBOX_LABELS.shelter,
     ]);
-    await page.locator('#home_type_other').fill('Emergency shelter placement — week 32');
+    await page
+      .locator('#home_type_other')
+      .fill('Emergency shelter placement — week 32');
     await clickFormNext(page);
 
     await advanceFromHomeDetailsToSubmit(page);
@@ -120,10 +160,14 @@ test.describe('Request form — Home Type multi-select (E2E)', () => {
         HOME_TYPE_CHECKBOX_LABELS.shelter,
       ])
     );
-    expect(capturedPayload?.home_type_other).toBe('Emergency shelter placement — week 32');
+    expect(capturedPayload?.home_type_other).toBe(
+      'Emergency shelter placement — week 32'
+    );
     expect(capturedPayload).not.toHaveProperty('skip_email_notifications');
 
-    await expect(page.getByText('Request Form Submitted Successfully', { exact: false })).toBeVisible({
+    await expect(
+      page.getByText('Request Form Submitted Successfully', { exact: false })
+    ).toBeVisible({
       timeout: 15000,
     });
   });

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/favicon.png" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title> SokanaCRM </title>
   </head>
   <body>

--- a/src/App.css
+++ b/src/App.css
@@ -6,11 +6,7 @@
 
 @custom-variant dark (&:is(.dark *));
 
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
- :root {
+:root {
   --background: oklch(1 0 0);
   --foreground: oklch(0.36 0.063 190.1);
   --card: oklch(1 0 0);

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -11,9 +11,11 @@ import RequestRoutes from '@/features/request/RequestRoutes';
 import { Route, Routes } from 'react-router-dom';
 import {
   BillingPortalRoute,
+  ClientPortalRoute,
   NonBillingOnlyRoute,
   PrivateRoute,
   PublicOnlyRoute,
+  StaffCrmRoute,
 } from './common/components/routes/ProtectedRoutes';
 import DashboardLayout from './common/layouts/DashboardLayout';
 import { DemographicsRoute } from './features/demographics/DemographicsRoute';
@@ -63,23 +65,27 @@ const AppRoutes = () => (
           </Route>
           <Route element={<NonBillingOnlyRoute />}>
             <Route index element={<Home />} />
-            <Route path='/profile' element={<ClientDashboard view='profile' />} />
-            <Route path='/billing' element={<ClientDashboard view='billing' />} />
-            {ContractRoutes()}
-            {PipelineRoutes()}
-            {ClientRoutes()}
-            {PaymentsRoute()}
-            {HoursRoutes()}
-            {ProfileRoutes()}
             {MyAccountRoutes()}
-            {TeamRoutes()}
-            {InboxRoutes()}
-            {QuickBooksRoutes()}
-            {CreateCustomerRoutes()}
-            {InvoiceRoute()}
-            {FinancialRoute()}
-            {DemographicsRoute()}
-            {DoulaDashboardRoutes()}
+            <Route element={<ClientPortalRoute />}>
+              <Route path='/profile' element={<ClientDashboard view='profile' />} />
+              <Route path='/billing' element={<ClientDashboard view='billing' />} />
+            </Route>
+            <Route element={<StaffCrmRoute />}>
+              {ContractRoutes()}
+              {PipelineRoutes()}
+              {ClientRoutes()}
+              {PaymentsRoute()}
+              {HoursRoutes()}
+              {ProfileRoutes()}
+              {TeamRoutes()}
+              {InboxRoutes()}
+              {QuickBooksRoutes()}
+              {CreateCustomerRoutes()}
+              {InvoiceRoute()}
+              {FinancialRoute()}
+              {DemographicsRoute()}
+              {DoulaDashboardRoutes()}
+            </Route>
           </Route>
         </Route>
       </Route>

--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -38,11 +38,11 @@ const AppRoutes = () => (
   <Routes>
     {/* Client Portal Auth Routes - Must be first, No Sidebar, Always Accessible */}
     {/* These routes are completely standalone, outside all wrappers */}
-    <Route path="/auth/set-password" element={<SetPassword />} />
-    <Route path="/auth/client-login" element={<ClientLogin />} />
+    <Route path='/auth/set-password' element={<SetPassword />} />
+    <Route path='/auth/client-login' element={<ClientLogin />} />
 
     {/* Contract Signed Success Page - No Sidebar, No Auth */}
-    <Route path="/contract-signed" element={<ContractSignedPage />} />
+    <Route path='/contract-signed' element={<ContractSignedPage />} />
 
     <Route>
       <Route element={<NavLayout />}>
@@ -55,7 +55,7 @@ const AppRoutes = () => (
     </Route>
 
     {/* Contract Signed Success Page - No Sidebar, No Auth */}
-    <Route path="/contract-signed" element={<ContractSignedPage />} />
+    <Route path='/contract-signed' element={<ContractSignedPage />} />
 
     <Route>
       <Route element={<DashboardLayout />}>
@@ -67,8 +67,14 @@ const AppRoutes = () => (
             <Route index element={<Home />} />
             {MyAccountRoutes()}
             <Route element={<ClientPortalRoute />}>
-              <Route path='/profile' element={<ClientDashboard view='profile' />} />
-              <Route path='/billing' element={<ClientDashboard view='billing' />} />
+              <Route
+                path='/profile'
+                element={<ClientDashboard view='profile' />}
+              />
+              <Route
+                path='/billing'
+                element={<ClientDashboard view='billing' />}
+              />
             </Route>
             <Route element={<StaffCrmRoute />}>
               {ContractRoutes()}

--- a/src/api/clients/doulaAssignments.ts
+++ b/src/api/clients/doulaAssignments.ts
@@ -46,6 +46,7 @@ export function normalizeAssignmentRole(
 }
 
 import { apiBaseUrl } from '@/config/env';
+import { fetchWithAuth } from '@/api/http';
 
 const getBaseUrl = (): string => apiBaseUrl;
 
@@ -56,7 +57,7 @@ export const fetchAvailableDoulas = async (): Promise<Doula[]> => {
   const url = `${getBaseUrl()}/clients/team/doulas`;
   console.log('🔍 API: Fetching available doulas from:', url);
 
-  const response = await fetch(url, {
+  const response = await fetchWithAuth(url, {
     method: 'GET',
     credentials: 'include',
     headers: {
@@ -88,7 +89,7 @@ export const fetchAssignedDoulas = async (
   const url = `${getBaseUrl()}/clients/${clientId}/assigned-doulas`;
   console.log('🔍 API: Fetching assigned doulas from:', url);
 
-  const response = await fetch(url, {
+  const response = await fetchWithAuth(url, {
     method: 'GET',
     credentials: 'include',
     headers: {
@@ -130,7 +131,7 @@ export const assignDoula = async (
     body.services = options.services;
   }
 
-  const response = await fetch(
+  const response = await fetchWithAuth(
     `${getBaseUrl()}/clients/${clientId}/assign-doula`,
     {
       method: 'POST',
@@ -155,7 +156,7 @@ export const unassignDoula = async (
   clientId: string,
   doulaId: string
 ): Promise<void> => {
-  const response = await fetch(
+  const response = await fetchWithAuth(
     `${getBaseUrl()}/clients/${clientId}/assign-doula/${doulaId}`,
     {
       method: 'DELETE',

--- a/src/api/doulas/doulaApi.ts
+++ b/src/api/doulas/doulaApi.ts
@@ -1,4 +1,5 @@
 // API functions for fetching doula-related data
+import { fetchWithAuth } from '@/api/http';
 import type {
   ActivityLog,
   AssignedClient,
@@ -13,7 +14,7 @@ const API_BASE = apiBaseUrl;
 // Get all doulas (for list page)
 export async function getAllDoulas(): Promise<Doula[]> {
 
-  const response = await fetch(`${API_BASE}/admin/doulas`, {
+  const response = await fetchWithAuth(`${API_BASE}/admin/doulas`, {
     method: 'GET',
     credentials: 'include',
     headers: {
@@ -32,7 +33,7 @@ export async function getAllDoulas(): Promise<Doula[]> {
 // Get doula by ID (for detail page)
 export async function getDoulaById(doulaId: string): Promise<Doula> {
 
-  const response = await fetch(`${API_BASE}/admin/doulas/${doulaId}`, {
+  const response = await fetchWithAuth(`${API_BASE}/admin/doulas/${doulaId}`, {
     method: 'GET',
     credentials: 'include',
     headers: {
@@ -53,7 +54,7 @@ export async function getAssignedClients(
   doulaId: string
 ): Promise<AssignedClient[]> {
 
-  const response = await fetch(
+  const response = await fetchWithAuth(
     `${API_BASE}/admin/doulas/${doulaId}/clients`,
     {
       method: 'GET',
@@ -75,7 +76,7 @@ export async function getAssignedClients(
 // Get visits for a doula
 export async function getDoulaVisits(doulaId: string): Promise<Visit[]> {
 
-  const response = await fetch(`${API_BASE}/admin/doulas/${doulaId}/visits`, {
+  const response = await fetchWithAuth(`${API_BASE}/admin/doulas/${doulaId}/visits`, {
     method: 'GET',
     credentials: 'include',
     headers: {
@@ -94,7 +95,7 @@ export async function getDoulaVisits(doulaId: string): Promise<Visit[]> {
 // Get notes for a doula
 export async function getDoulaNotes(doulaId: string): Promise<DoulaNote[]> {
 
-  const response = await fetch(`${API_BASE}/admin/doulas/${doulaId}/notes`, {
+  const response = await fetchWithAuth(`${API_BASE}/admin/doulas/${doulaId}/notes`, {
     method: 'GET',
     credentials: 'include',
     headers: {
@@ -115,7 +116,7 @@ export async function getActivityLog(
   doulaId: string
 ): Promise<ActivityLog[]> {
 
-  const response = await fetch(
+  const response = await fetchWithAuth(
     `${API_BASE}/admin/doulas/${doulaId}/activity`,
     {
       method: 'GET',
@@ -140,7 +141,7 @@ export async function updateDoula(
   updateData: Partial<Doula>
 ): Promise<Doula> {
 
-  const response = await fetch(`${API_BASE}/admin/doulas/${doulaId}`, {
+  const response = await fetchWithAuth(`${API_BASE}/admin/doulas/${doulaId}`, {
     method: 'PUT',
     credentials: 'include',
     headers: {

--- a/src/api/doulas/doulaApi.ts
+++ b/src/api/doulas/doulaApi.ts
@@ -13,7 +13,6 @@ const API_BASE = apiBaseUrl;
 
 // Get all doulas (for list page)
 export async function getAllDoulas(): Promise<Doula[]> {
-
   const response = await fetchWithAuth(`${API_BASE}/admin/doulas`, {
     method: 'GET',
     credentials: 'include',
@@ -32,7 +31,6 @@ export async function getAllDoulas(): Promise<Doula[]> {
 
 // Get doula by ID (for detail page)
 export async function getDoulaById(doulaId: string): Promise<Doula> {
-
   const response = await fetchWithAuth(`${API_BASE}/admin/doulas/${doulaId}`, {
     method: 'GET',
     credentials: 'include',
@@ -53,7 +51,6 @@ export async function getDoulaById(doulaId: string): Promise<Doula> {
 export async function getAssignedClients(
   doulaId: string
 ): Promise<AssignedClient[]> {
-
   const response = await fetchWithAuth(
     `${API_BASE}/admin/doulas/${doulaId}/clients`,
     {
@@ -75,14 +72,16 @@ export async function getAssignedClients(
 
 // Get visits for a doula
 export async function getDoulaVisits(doulaId: string): Promise<Visit[]> {
-
-  const response = await fetchWithAuth(`${API_BASE}/admin/doulas/${doulaId}/visits`, {
-    method: 'GET',
-    credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
+  const response = await fetchWithAuth(
+    `${API_BASE}/admin/doulas/${doulaId}/visits`,
+    {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }
+  );
 
   if (!response.ok) {
     const errorText = await response.text();
@@ -94,14 +93,16 @@ export async function getDoulaVisits(doulaId: string): Promise<Visit[]> {
 
 // Get notes for a doula
 export async function getDoulaNotes(doulaId: string): Promise<DoulaNote[]> {
-
-  const response = await fetchWithAuth(`${API_BASE}/admin/doulas/${doulaId}/notes`, {
-    method: 'GET',
-    credentials: 'include',
-    headers: {
-      'Content-Type': 'application/json',
-    },
-  });
+  const response = await fetchWithAuth(
+    `${API_BASE}/admin/doulas/${doulaId}/notes`,
+    {
+      method: 'GET',
+      credentials: 'include',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    }
+  );
 
   if (!response.ok) {
     const errorText = await response.text();
@@ -112,10 +113,7 @@ export async function getDoulaNotes(doulaId: string): Promise<DoulaNote[]> {
 }
 
 // Get activity log for a doula
-export async function getActivityLog(
-  doulaId: string
-): Promise<ActivityLog[]> {
-
+export async function getActivityLog(doulaId: string): Promise<ActivityLog[]> {
   const response = await fetchWithAuth(
     `${API_BASE}/admin/doulas/${doulaId}/activity`,
     {
@@ -140,7 +138,6 @@ export async function updateDoula(
   doulaId: string,
   updateData: Partial<Doula>
 ): Promise<Doula> {
-
   const response = await fetchWithAuth(`${API_BASE}/admin/doulas/${doulaId}`, {
     method: 'PUT',
     credentials: 'include',

--- a/src/api/doulas/doulaService.ts
+++ b/src/api/doulas/doulaService.ts
@@ -522,10 +522,13 @@ export async function getDoulaDocuments(): Promise<DocumentsResponse> {
 }
 
 export async function deleteDoulaDocument(documentId: string): Promise<void> {
-  const response = await fetchWithAuth(`${API_BASE}/doulas/documents/${documentId}`, {
-    method: 'DELETE',
-    credentials: 'include',
-  });
+  const response = await fetchWithAuth(
+    `${API_BASE}/doulas/documents/${documentId}`,
+    {
+      method: 'DELETE',
+      credentials: 'include',
+    }
+  );
 
   if (!response.ok) {
     const error = await response
@@ -553,12 +556,15 @@ export async function updateDoulaDocumentMetadata(
   if (Object.keys(payload).length === 0) {
     throw new Error('No document metadata changes provided');
   }
-  const response = await fetchWithAuth(`${API_BASE}/doulas/documents/${documentId}`, {
-    method: 'PATCH',
-    headers: { 'Content-Type': 'application/json' },
-    credentials: 'include',
-    body: JSON.stringify(payload),
-  });
+  const response = await fetchWithAuth(
+    `${API_BASE}/doulas/documents/${documentId}`,
+    {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(payload),
+    }
+  );
 
   if (!response.ok) {
     const error = await response
@@ -936,7 +942,7 @@ export interface LogHoursData {
   note?: string;
 }
 
-export interface UpdateHoursData extends Partial<LogHoursData> {}
+export type UpdateHoursData = Partial<LogHoursData>;
 
 export async function logHours(data: LogHoursData): Promise<HoursEntry> {
   const response = await fetchWithAuth(`${API_BASE}/doulas/hours`, {

--- a/src/api/doulas/doulaService.ts
+++ b/src/api/doulas/doulaService.ts
@@ -49,7 +49,7 @@ export interface DoulaProfile {
 }
 
 export async function getDoulaProfile(): Promise<DoulaProfile> {
-  const response = await fetch(`${API_BASE}/doulas/profile`, {
+  const response = await fetchWithAuth(`${API_BASE}/doulas/profile`, {
     headers: {
       'Content-Type': 'application/json',
     },
@@ -140,7 +140,7 @@ export async function uploadDoulaProfilePicture(
   const formData = new FormData();
   formData.append('profile_picture', file);
 
-  const response = await fetch(`${API_BASE}/doulas/profile/picture`, {
+  const response = await fetchWithAuth(`${API_BASE}/doulas/profile/picture`, {
     method: 'POST',
     credentials: 'include',
     body: formData,
@@ -166,7 +166,7 @@ export async function updateDoulaProfile(
     JSON.stringify(data, null, 2)
   );
 
-  const response = await fetch(`${API_BASE}/doulas/profile`, {
+  const response = await fetchWithAuth(`${API_BASE}/doulas/profile`, {
     method: 'PUT',
     headers: {
       'Content-Type': 'application/json',
@@ -464,7 +464,7 @@ export async function uploadDocument(
     );
   });
 
-  const response = await fetch(`${API_BASE}/doulas/documents`, {
+  const response = await fetchWithAuth(`${API_BASE}/doulas/documents`, {
     method: 'POST',
     credentials: 'include',
     body: formData,
@@ -484,7 +484,7 @@ export async function uploadDocument(
 }
 
 export async function getDoulaDocuments(): Promise<DocumentsResponse> {
-  const response = await fetch(`${API_BASE}/doulas/documents`, {
+  const response = await fetchWithAuth(`${API_BASE}/doulas/documents`, {
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include',
   });
@@ -522,7 +522,7 @@ export async function getDoulaDocuments(): Promise<DocumentsResponse> {
 }
 
 export async function deleteDoulaDocument(documentId: string): Promise<void> {
-  const response = await fetch(`${API_BASE}/doulas/documents/${documentId}`, {
+  const response = await fetchWithAuth(`${API_BASE}/doulas/documents/${documentId}`, {
     method: 'DELETE',
     credentials: 'include',
   });
@@ -553,7 +553,7 @@ export async function updateDoulaDocumentMetadata(
   if (Object.keys(payload).length === 0) {
     throw new Error('No document metadata changes provided');
   }
-  const response = await fetch(`${API_BASE}/doulas/documents/${documentId}`, {
+  const response = await fetchWithAuth(`${API_BASE}/doulas/documents/${documentId}`, {
     method: 'PATCH',
     headers: { 'Content-Type': 'application/json' },
     credentials: 'include',
@@ -696,7 +696,7 @@ export async function getAssignedClients(
   console.log('getAssignedClients - Calling URL:', url);
   console.log('getAssignedClients - Detailed mode:', detailed);
 
-  const response = await fetch(url, {
+  const response = await fetchWithAuth(url, {
     headers: {
       'Content-Type': 'application/json',
     },
@@ -848,7 +848,7 @@ export async function getAssignedClientDetails(
   clientId: string,
   detailed = false
 ): Promise<AssignedClientLite | AssignedClientDetailed> {
-  const response = await fetch(
+  const response = await fetchWithAuth(
     `${API_BASE}/doulas/clients/${clientId}?detailed=${detailed}`,
     {
       headers: {
@@ -939,7 +939,7 @@ export interface LogHoursData {
 export interface UpdateHoursData extends Partial<LogHoursData> {}
 
 export async function logHours(data: LogHoursData): Promise<HoursEntry> {
-  const response = await fetch(`${API_BASE}/doulas/hours`, {
+  const response = await fetchWithAuth(`${API_BASE}/doulas/hours`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -961,7 +961,7 @@ export async function updateHours(
   hourId: string,
   data: UpdateHoursData
 ): Promise<HoursEntry> {
-  const response = await fetch(`${API_BASE}/doulas/hours/${hourId}`, {
+  const response = await fetchWithAuth(`${API_BASE}/doulas/hours/${hourId}`, {
     method: 'PATCH',
     headers: {
       'Content-Type': 'application/json',
@@ -982,7 +982,7 @@ export async function updateHours(
 export async function getDoulaHours(): Promise<HoursEntry[]> {
   // Bust browser conditional caching to avoid 304 + empty-body parsing issues.
   const url = `${API_BASE}/doulas/hours?_=${Date.now()}`;
-  const response = await fetch(url, {
+  const response = await fetchWithAuth(url, {
     cache: 'no-store',
   });
 

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -1,5 +1,6 @@
 import { API_CONFIG } from './config';
 import { ApiError } from './errors';
+import { getSessionAccessToken } from './sessionAccessToken';
 import { logger } from '@/utils/logger';
 
 export type ApiResponse<T> =
@@ -41,15 +42,17 @@ export function buildUrl(path: string, params?: QueryParams): string {
   return url.toString();
 }
 
-/** Throw if production build is using localhost (env not set in Vercel). */
+/** Throw if production build is using localhost or has no API URL (env not set in Vercel). */
 function assertProductionBackendUrl(_path: string): void {
   const isProductionBuild = import.meta.env.MODE === 'production';
   const base = API_CONFIG.baseUrl;
   const isLocalhost =
-    base.includes('localhost') || base.startsWith('http://127.');
+    !base ||
+    base.includes('localhost') ||
+    base.startsWith('http://127.');
   if (isProductionBuild && isLocalhost) {
     throw new ApiError(
-      'Backend URL is not set for production. Set VITE_APP_BACKEND_URL or VITE_API_BASE_URL in Vercel to your backend, e.g. https://your-backend.run.app',
+      'Backend URL is not set for production. Set VITE_APP_BACKEND_URL, VITE_API_BASE_URL, or VITE_CLOUD_RUN_API_URL in Vercel to your backend, e.g. https://your-backend.run.app',
       0,
       { code: 'MISSING_BACKEND_URL' }
     );
@@ -106,13 +109,14 @@ function buildBaseHeaders(
   return { ...base, ...(fetchHeaders as Record<string, string>) };
 }
 
-/** Resolve credentials and Authorization. Always attach Supabase Bearer when available
- * (cookie mode still includes credentials; Bearer covers cases where sb-access-token cookie is missing). */
+/** Resolve credentials and Authorization.
+ * Prefer the login JSON token (needed when cross-site cookies are blocked on mobile),
+ * then a Supabase session. Cookie mode still sends credentials: include. */
 export async function getRequestAuth(): Promise<{
   credentials: FetchCredentials;
   headers: Record<string, string>;
 }> {
-  const token = await getSupabaseTokenSafe();
+  const token = getSessionAccessToken() ?? (await getSupabaseTokenSafe());
   const headers: Record<string, string> = {};
   if (token) {
     headers['Authorization'] = `Bearer ${token}`;
@@ -127,10 +131,15 @@ export async function getRequestAuth(): Promise<{
 async function getSupabaseTokenSafe(): Promise<string | null> {
   try {
     const { supabase } = await import('@/lib/supabase');
-    const {
-      data: { session },
-    } = await supabase.auth.getSession();
-    return session?.access_token ?? null;
+    const timedOut = Symbol('timeout');
+    const result = await Promise.race([
+      supabase.auth.getSession(),
+      new Promise<typeof timedOut>((resolve) => {
+        setTimeout(() => resolve(timedOut), 1500);
+      }),
+    ]);
+    if (result === timedOut) return null;
+    return result.data?.session?.access_token ?? null;
   } catch {
     return null;
   }

--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -47,9 +47,7 @@ function assertProductionBackendUrl(_path: string): void {
   const isProductionBuild = import.meta.env.MODE === 'production';
   const base = API_CONFIG.baseUrl;
   const isLocalhost =
-    !base ||
-    base.includes('localhost') ||
-    base.startsWith('http://127.');
+    !base || base.includes('localhost') || base.startsWith('http://127.');
   if (isProductionBuild && isLocalhost) {
     throw new ApiError(
       'Backend URL is not set for production. Set VITE_APP_BACKEND_URL, VITE_API_BASE_URL, or VITE_CLOUD_RUN_API_URL in Vercel to your backend, e.g. https://your-backend.run.app',

--- a/src/api/quickbooks/auth/__tests__/route.test.ts
+++ b/src/api/quickbooks/auth/__tests__/route.test.ts
@@ -3,10 +3,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('@/api/config', () => ({
   API_CONFIG: {
     baseUrl: 'https://api.example.com',
+    authMode: 'cookie',
   },
 }));
 
-import { getQuickBooksAuthUrl } from '../route';
+import { getQuickBooksAuthUrl } from '@/api/quickbooks/auth/route';
 
 describe('getQuickBooksAuthUrl', () => {
   const fetchMock = vi.fn();

--- a/src/api/quickbooks/auth/customer.ts
+++ b/src/api/quickbooks/auth/customer.ts
@@ -1,4 +1,5 @@
 // src/api/quickbooks/auth/customer.ts
+import { fetchWithAuth } from '@/api/http';
 import { API_CONFIG } from '@/api/config';
 import { withTokenRefresh } from './utils';
 
@@ -30,7 +31,7 @@ export async function createQuickBooksCustomer(
   params: CreateCustomerParams
 ): Promise<{ qbCustomerId: string }> {
   return withTokenRefresh(async () => {
-    const res = await fetch(`${API_BASE}/quickbooks/customer`, {
+    const res = await fetchWithAuth(`${API_BASE}/quickbooks/customer`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -64,7 +65,7 @@ export async function getInvoiceableCustomers(): Promise<
   InvoiceableCustomer[]
 > {
   return withTokenRefresh(async () => {
-    const res = await fetch(`${API_BASE}/quickbooks/customers/invoiceable`, {
+    const res = await fetchWithAuth(`${API_BASE}/quickbooks/customers/invoiceable`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -119,7 +120,7 @@ export async function getQuickBooksCustomers(
       ? `${API_BASE}/quickbooks/customers?maxResults=${maxResults}`
       : `${API_BASE}/quickbooks/customers`;
 
-    const res = await fetch(url, {
+    const res = await fetchWithAuth(url, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/src/api/quickbooks/auth/customer.ts
+++ b/src/api/quickbooks/auth/customer.ts
@@ -65,13 +65,16 @@ export async function getInvoiceableCustomers(): Promise<
   InvoiceableCustomer[]
 > {
   return withTokenRefresh(async () => {
-    const res = await fetchWithAuth(`${API_BASE}/quickbooks/customers/invoiceable`, {
-      method: 'GET',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-      credentials: 'include',
-    });
+    const res = await fetchWithAuth(
+      `${API_BASE}/quickbooks/customers/invoiceable`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        credentials: 'include',
+      }
+    );
 
     if (!res.ok) {
       const err = await res.text().catch(() => '');

--- a/src/api/quickbooks/auth/invoice.ts
+++ b/src/api/quickbooks/auth/invoice.ts
@@ -1,5 +1,6 @@
 import { API_CONFIG } from '@/api/config';
 import { withTokenRefresh } from './utils';
+import { fetchWithAuth } from '@/api/http';
 
 const API_BASE = API_CONFIG.baseUrl.replace(/\/$/, '');
 
@@ -64,7 +65,7 @@ export async function createQuickBooksInvoice(
       userId: 'admin', // This matches the userId we use in tokenUtils.ts
     };
 
-    const res = await fetch(`${API_BASE}/quickbooks/invoice`, {
+    const res = await fetchWithAuth(`${API_BASE}/quickbooks/invoice`, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
@@ -89,7 +90,7 @@ export async function createQuickBooksInvoice(
 //   params: CreateInvoiceParams
 // ): Promise<QuickBooksInvoiceResponse> {
 
-//   const res = await fetch(`${API_BASE}/quickbooks/invoice`, {
+//   const res = await fetchWithAuth(`${API_BASE}/quickbooks/invoice`, {
 //     method: 'POST',
 //     headers: {
 //       'Content-Type': 'application/json',
@@ -111,7 +112,7 @@ export async function createQuickBooksInvoice(
 export async function getQuickBooksInvoices(): Promise<any[]> {
 
   return withTokenRefresh(async () => {
-    const res = await fetch(`${API_BASE}/quickbooks/invoices`, {
+    const res = await fetchWithAuth(`${API_BASE}/quickbooks/invoices`, {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/src/api/quickbooks/auth/invoice.ts
+++ b/src/api/quickbooks/auth/invoice.ts
@@ -57,7 +57,6 @@ export interface CreateInvoiceParams {
 export async function createQuickBooksInvoice(
   params: CreateInvoiceParams
 ): Promise<QuickBooksInvoiceResponse> {
-
   return withTokenRefresh(async () => {
     // Since we're using admin-only approach, set userId to 'admin'
     const requestBody = {
@@ -110,7 +109,6 @@ export async function createQuickBooksInvoice(
  * Automatically pulls the JWT from localStorage.
  */
 export async function getQuickBooksInvoices(): Promise<any[]> {
-
   return withTokenRefresh(async () => {
     const res = await fetchWithAuth(`${API_BASE}/quickbooks/invoices`, {
       method: 'GET',

--- a/src/api/quickbooks/auth/qbo.ts
+++ b/src/api/quickbooks/auth/qbo.ts
@@ -1,4 +1,5 @@
 import { API_CONFIG } from '@/api/config';
+import { fetchWithAuth } from '@/api/http';
 
 const API_BASE = API_CONFIG.baseUrl.replace(/\/$/, '');
 
@@ -20,7 +21,7 @@ export interface QuickBooksStatus {
 }
 
 export async function getQuickBooksStatus(): Promise<QuickBooksStatus> {
-  const res = await fetch(`${API_BASE}/quickbooks/status`, {
+  const res = await fetchWithAuth(`${API_BASE}/quickbooks/status`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',
@@ -43,7 +44,7 @@ export async function getQuickBooksStatus(): Promise<QuickBooksStatus> {
 export async function refreshQuickBooksToken(): Promise<{
   connected: boolean;
 }> {
-  const res = await fetch(`${API_BASE}/quickbooks/refresh`, {
+  const res = await fetchWithAuth(`${API_BASE}/quickbooks/refresh`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',

--- a/src/api/quickbooks/auth/route.ts
+++ b/src/api/quickbooks/auth/route.ts
@@ -1,4 +1,5 @@
 import { API_CONFIG } from '@/api/config';
+import { fetchWithAuth } from '@/api/http';
 
 const API_BASE = API_CONFIG.baseUrl.replace(/\/$/, '');
 
@@ -19,7 +20,7 @@ export async function getQuickBooksAuthUrl(): Promise<string> {
 
   for (const path of candidates) {
     const endpoint = `${API_BASE}${path}`;
-    const res = await fetch(endpoint, {
+    const res = await fetchWithAuth(endpoint, {
       method: 'GET',
       credentials: 'include',
       headers: {

--- a/src/api/quickbooks/auth/route.ts
+++ b/src/api/quickbooks/auth/route.ts
@@ -30,7 +30,9 @@ export async function getQuickBooksAuthUrl(): Promise<string> {
 
     if (!res.ok) {
       const body = (await res.text()).trim();
-      errors.push(`${path} -> HTTP ${res.status}${body ? `: ${body.slice(0, 180)}` : ''}`);
+      errors.push(
+        `${path} -> HTTP ${res.status}${body ? `: ${body.slice(0, 180)}` : ''}`
+      );
       continue;
     }
 
@@ -43,5 +45,7 @@ export async function getQuickBooksAuthUrl(): Promise<string> {
     return payload.url;
   }
 
-  throw new Error(`Could not fetch QuickBooks auth URL. Tried ${candidates.join(', ')}. ${errors.join(' | ')}`);
+  throw new Error(
+    `Could not fetch QuickBooks auth URL. Tried ${candidates.join(', ')}. ${errors.join(' | ')}`
+  );
 }

--- a/src/api/quickbooks/auth/status.ts
+++ b/src/api/quickbooks/auth/status.ts
@@ -1,4 +1,5 @@
 // src/api/quickbooks/status.ts
+import { fetchWithAuth } from '@/api/http';
 import { apiBaseUrl } from '@/config/env';
 
 const API_BASE = apiBaseUrl;
@@ -7,7 +8,7 @@ const API_BASE = apiBaseUrl;
  * @returns true if connected, false otherwise
  */
 export async function getConnectionStatus(): Promise<boolean> {
-  const res = await fetch(`${API_BASE}/quickbooks/status`, {
+  const res = await fetchWithAuth(`${API_BASE}/quickbooks/status`, {
     method: 'GET',
     credentials: 'include',
   });
@@ -27,7 +28,7 @@ export async function getConnectionStatus(): Promise<boolean> {
  * Disconnect the current user from QuickBooks (deletes stored tokens).
  */
 export async function disconnectQuickBooks(): Promise<void> {
-  const res = await fetch(`${API_BASE}/quickbooks/disconnect`, {
+  const res = await fetchWithAuth(`${API_BASE}/quickbooks/disconnect`, {
     method: 'POST',
     credentials: 'include',
   });

--- a/src/api/sessionAccessToken.test.ts
+++ b/src/api/sessionAccessToken.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  clearSessionAccessToken,
+  getSessionAccessToken,
+  setSessionAccessToken,
+} from './sessionAccessToken';
+
+describe('sessionAccessToken', () => {
+  afterEach(() => {
+    clearSessionAccessToken();
+  });
+
+  it('stores and reads a login JWT for header auth', () => {
+    setSessionAccessToken('abc.def.ghi');
+    expect(getSessionAccessToken()).toBe('abc.def.ghi');
+  });
+
+  it('clears an empty or missing token', () => {
+    setSessionAccessToken('abc.def.ghi');
+    setSessionAccessToken('  ');
+    expect(getSessionAccessToken()).toBeNull();
+  });
+});

--- a/src/api/sessionAccessToken.ts
+++ b/src/api/sessionAccessToken.ts
@@ -1,0 +1,33 @@
+const STORAGE_KEY = 'sokana.session-token';
+
+function canUseStorage(): boolean {
+  return typeof window !== 'undefined' && typeof sessionStorage !== 'undefined';
+}
+
+export function getSessionAccessToken(): string | null {
+  if (!canUseStorage()) return null;
+  try {
+    const value = sessionStorage.getItem(STORAGE_KEY);
+    return value && value.length > 0 ? value : null;
+  } catch {
+    return null;
+  }
+}
+
+export function setSessionAccessToken(token: string | null | undefined): void {
+  if (!canUseStorage()) return;
+  try {
+    const trimmed = typeof token === 'string' ? token.trim() : '';
+    if (!trimmed) {
+      sessionStorage.removeItem(STORAGE_KEY);
+      return;
+    }
+    sessionStorage.setItem(STORAGE_KEY, trimmed);
+  } catch {
+    // Safari private mode can throw; cookie auth may still work on desktop.
+  }
+}
+
+export function clearSessionAccessToken(): void {
+  setSessionAccessToken(null);
+}

--- a/src/common/auth/roles.test.ts
+++ b/src/common/auth/roles.test.ts
@@ -4,6 +4,7 @@ import {
   getBillingHomePath,
   isBillingOnlyRole,
   isBillingRole,
+  isStaffRole,
 } from '@/common/auth/roles';
 import { describe, expect, it } from 'vitest';
 
@@ -26,6 +27,15 @@ describe('billing role helpers', () => {
   it('preserves non-billing full CRM behavior', () => {
     expect(canAccessFullCrm('admin', false)).toBe(true);
     expect(canAccessFullCrm('doula', false)).toBe(true);
-    expect(canAccessFullCrm('client', true)).toBe(true);
+    expect(canAccessFullCrm('client', true)).toBe(false);
+    expect(canAccessFullCrm('client', false)).toBe(false);
+  });
+
+  it('treats admin, doula, and billing as staff and never infers staff from empty role', () => {
+    expect(isStaffRole('admin')).toBe(true);
+    expect(isStaffRole('doula')).toBe(true);
+    expect(isStaffRole('billing')).toBe(true);
+    expect(isStaffRole('client')).toBe(false);
+    expect(isStaffRole(undefined)).toBe(false);
   });
 });

--- a/src/common/auth/roles.ts
+++ b/src/common/auth/roles.ts
@@ -20,8 +20,17 @@ export function canAccessBillingPortal(role: string | null | undefined): boolean
   return isAdminRole(role) || isBillingRole(role);
 }
 
+export function isClientRole(role: string | null | undefined): boolean {
+  return role === 'client';
+}
+
+/** Authoritative staff roles from /auth/me — never inferred from Supabase metadata. */
+export function isStaffRole(role: string | null | undefined): boolean {
+  return isAdminRole(role) || isDoulaRole(role) || isBillingRole(role);
+}
+
 export function canAccessFullCrm(role: string | null | undefined, isClientPortalUser: boolean): boolean {
-  if (isClientPortalUser) return true;
+  if (isClientPortalUser || isClientRole(role)) return false;
   if (isBillingOnlyRole(role)) return false;
   return true;
 }

--- a/src/common/auth/roles.ts
+++ b/src/common/auth/roles.ts
@@ -9,14 +9,19 @@ export function isDoulaRole(role: string | null | undefined): boolean {
 }
 
 export function isBillingRole(role: string | null | undefined): boolean {
-  return role != null && BILLING_PORTAL_ROLES.includes(role as (typeof BILLING_PORTAL_ROLES)[number]);
+  return (
+    role != null &&
+    BILLING_PORTAL_ROLES.includes(role as (typeof BILLING_PORTAL_ROLES)[number])
+  );
 }
 
 export function isBillingOnlyRole(role: string | null | undefined): boolean {
   return isBillingRole(role) && !isAdminRole(role) && !isDoulaRole(role);
 }
 
-export function canAccessBillingPortal(role: string | null | undefined): boolean {
+export function canAccessBillingPortal(
+  role: string | null | undefined
+): boolean {
   return isAdminRole(role) || isBillingRole(role);
 }
 
@@ -29,7 +34,10 @@ export function isStaffRole(role: string | null | undefined): boolean {
   return isAdminRole(role) || isDoulaRole(role) || isBillingRole(role);
 }
 
-export function canAccessFullCrm(role: string | null | undefined, isClientPortalUser: boolean): boolean {
+export function canAccessFullCrm(
+  role: string | null | undefined,
+  isClientPortalUser: boolean
+): boolean {
   if (isClientPortalUser || isClientRole(role)) return false;
   if (isBillingOnlyRole(role)) return false;
   return true;

--- a/src/common/components/form/PasswordInput.tsx
+++ b/src/common/components/form/PasswordInput.tsx
@@ -15,7 +15,7 @@ const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
       <div className={cn('relative rounded-md', className)}>
         <input
           type={showPassword ? 'text' : 'password'}
-          className='flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50'
+          className='flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base md:text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50'
           ref={ref}
           disabled={disabled}
           {...props}
@@ -25,7 +25,7 @@ const PasswordInput = React.forwardRef<HTMLInputElement, PasswordInputProps>(
           size='icon'
           variant='ghost'
           disabled={disabled}
-          className='absolute right-1 top-1/2 h-6 w-6 -translate-y-1/2 rounded-md text-muted-foreground'
+          className='absolute right-1 top-1/2 size-11 -translate-y-1/2 rounded-md text-muted-foreground sm:size-6'
           onClick={() => setShowPassword((prev) => !prev)}
         >
           {showPassword ? <Eye size={18} /> : <EyeClosed size={18} />}

--- a/src/common/components/navigation/navbar/NavBar.tsx
+++ b/src/common/components/navigation/navbar/NavBar.tsx
@@ -5,7 +5,10 @@ import { Button } from '@/common/components/ui/button';
 
 const StyledNav = styled.nav`
   display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   gap: 10px;
+  min-width: 0;
   padding: 10px 20px;
   font-size: 20px;
 `;

--- a/src/common/components/navigation/sidebar/SidebarSection.tsx
+++ b/src/common/components/navigation/sidebar/SidebarSection.tsx
@@ -5,6 +5,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  useSidebar,
 } from '@/common/components/ui/sidebar';
 import { Link, useLocation } from 'react-router-dom';
 
@@ -20,6 +21,7 @@ interface SidebarSectionProps {
 
 export function SidebarSection({ label, items }: SidebarSectionProps) {
   const location = useLocation();
+  const { isMobile, setOpenMobile } = useSidebar();
 
   return (
     <SidebarGroup>
@@ -39,7 +41,12 @@ export function SidebarSection({ label, items }: SidebarSectionProps) {
                   asChild
                   className={isActive ? 'bg-gray-200/50' : ''}
                 >
-                  <Link to={item.url}>
+                  <Link
+                    to={item.url}
+                    onClick={() => {
+                      if (isMobile) setOpenMobile(false);
+                    }}
+                  >
                     <item.icon />
                     <span>{item.title}</span>
                   </Link>

--- a/src/common/components/navigation/sidebar/SidebarSection.tsx
+++ b/src/common/components/navigation/sidebar/SidebarSection.tsx
@@ -33,7 +33,8 @@ export function SidebarSection({ label, items }: SidebarSectionProps) {
           {items.map((item) => {
             const isActive =
               location.pathname === item.url ||
-              (item.url !== '/' && location.pathname.startsWith(`${item.url}/`));
+              (item.url !== '/' &&
+                location.pathname.startsWith(`${item.url}/`));
 
             return (
               <SidebarMenuItem key={item.title}>

--- a/src/common/components/routes/ProtectedRoutes.test.tsx
+++ b/src/common/components/routes/ProtectedRoutes.test.tsx
@@ -63,7 +63,10 @@ describe('billing route guards', () => {
       'doula',
       '/billing/contracts',
       <Route element={<BillingPortalRoute />}>
-        <Route path='/billing/contracts' element={<div>Billing contracts</div>} />
+        <Route
+          path='/billing/contracts'
+          element={<div>Billing contracts</div>}
+        />
       </Route>
     );
 

--- a/src/common/components/routes/ProtectedRoutes.test.tsx
+++ b/src/common/components/routes/ProtectedRoutes.test.tsx
@@ -1,5 +1,9 @@
 import { UserContext } from '@/common/contexts/UserContext';
-import { BillingPortalRoute, NonBillingOnlyRoute } from '@/common/components/routes/ProtectedRoutes';
+import {
+  BillingPortalRoute,
+  NonBillingOnlyRoute,
+  StaffCrmRoute,
+} from '@/common/components/routes/ProtectedRoutes';
 import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
@@ -65,5 +69,30 @@ describe('billing route guards', () => {
 
     expect(await screen.findByText('Access denied')).toBeInTheDocument();
     expect(screen.queryByText('Billing contracts')).not.toBeInTheDocument();
+  });
+
+  it('denies client portal users CRM routes', async () => {
+    renderWithUser(
+      'client',
+      '/clients',
+      <Route element={<StaffCrmRoute />}>
+        <Route path='/clients' element={<div>Clients</div>} />
+      </Route>
+    );
+
+    expect(await screen.findByText('Access denied')).toBeInTheDocument();
+    expect(screen.queryByText('Clients')).not.toBeInTheDocument();
+  });
+
+  it('allows admin users on CRM routes', async () => {
+    renderWithUser(
+      'admin',
+      '/clients',
+      <Route element={<StaffCrmRoute />}>
+        <Route path='/clients' element={<div>Clients</div>} />
+      </Route>
+    );
+
+    expect(await screen.findByText('Clients')).toBeInTheDocument();
   });
 });

--- a/src/common/components/routes/ProtectedRoutes.tsx
+++ b/src/common/components/routes/ProtectedRoutes.tsx
@@ -104,9 +104,7 @@ export function StaffCrmRoute() {
   }
 
   if (isClientPortalUser) {
-    return (
-      <AccessDenied description='This area is limited to Sokana staff.' />
-    );
+    return <AccessDenied description='This area is limited to Sokana staff.' />;
   }
 
   if (isBillingOnlyRole(user?.role)) {

--- a/src/common/components/routes/ProtectedRoutes.tsx
+++ b/src/common/components/routes/ProtectedRoutes.tsx
@@ -1,27 +1,31 @@
 import { AccessDenied } from '@/common/components/routes/AccessDenied';
-import { getBillingHomePath, isBillingOnlyRole, canAccessBillingPortal } from '@/common/auth/roles';
+import {
+  getBillingHomePath,
+  isBillingOnlyRole,
+  canAccessBillingPortal,
+} from '@/common/auth/roles';
 import { Navigate, Outlet } from 'react-router-dom';
 
 import { useUser } from '@/common/hooks/user/useUser';
 import { useClientAuth } from '@/common/hooks/auth/useClientAuth';
+import { useIsClientPortalUser } from '@/common/hooks/auth/useIsClientPortalUser';
+
+function SessionLoading() {
+  return <div className='p-6 text-center'>Loading session…</div>;
+}
 
 export function PrivateRoute() {
   const { user, isLoading } = useUser();
   const { client, isLoading: isClientLoading } = useClientAuth();
 
-  // Allow access if either backend user (admin/doula) or Supabase client is authenticated
-  // Show loading state while checking auth - this prevents redirecting clients who just logged in
-  if (isLoading || isClientLoading) {
-    return <div className='p-6 text-center'>Loading session…</div>;
+  if ((isLoading || isClientLoading) && !user && !client) {
+    return <SessionLoading />;
   }
 
-  // Allow access if user has backend auth OR client has Supabase auth
   if (user || client) {
     return <Outlet />;
   }
 
-  // Redirect to login if neither backend user nor client is authenticated
-  // Note: This redirects to admin login, but clients should use /auth/client-login
   return <Navigate to='/login' replace />;
 }
 
@@ -39,8 +43,8 @@ export function NonBillingOnlyRoute() {
   const { user, isLoading } = useUser();
   const { isLoading: isClientLoading } = useClientAuth();
 
-  if (isLoading || isClientLoading) {
-    return <div className='p-6 text-center'>Loading session…</div>;
+  if ((isLoading || isClientLoading) && !user) {
+    return <SessionLoading />;
   }
 
   if (isBillingOnlyRole(user?.role)) {
@@ -52,13 +56,14 @@ export function NonBillingOnlyRoute() {
 
 export function BillingPortalRoute() {
   const { user, isLoading } = useUser();
-  const { client, isLoading: isClientLoading } = useClientAuth();
+  const { isClientPortalUser, isLoading: portalLoading } =
+    useIsClientPortalUser();
 
-  if (isLoading || isClientLoading) {
-    return <div className='p-6 text-center'>Loading session…</div>;
+  if ((isLoading || portalLoading) && !user) {
+    return <SessionLoading />;
   }
 
-  if (client) {
+  if (isClientPortalUser) {
     return (
       <AccessDenied description='This billing workspace is limited to internal staff with billing access.' />
     );
@@ -66,6 +71,46 @@ export function BillingPortalRoute() {
 
   if (!canAccessBillingPortal(user?.role)) {
     return <AccessDenied />;
+  }
+
+  return <Outlet />;
+}
+
+/** Client portal pages (/profile, /billing). Staff are denied. */
+export function ClientPortalRoute() {
+  const { isClientPortalUser, isLoading } = useIsClientPortalUser();
+
+  if (isLoading) {
+    return <SessionLoading />;
+  }
+
+  if (!isClientPortalUser) {
+    return (
+      <AccessDenied description='You must be logged in as a client to view this page. Use client portal login.' />
+    );
+  }
+
+  return <Outlet />;
+}
+
+/** CRM screens. Clients are denied; billing-only users are sent to billing home. */
+export function StaffCrmRoute() {
+  const { user, isLoading } = useUser();
+  const { isClientPortalUser, isLoading: portalLoading } =
+    useIsClientPortalUser();
+
+  if ((isLoading || portalLoading) && !user) {
+    return <SessionLoading />;
+  }
+
+  if (isClientPortalUser) {
+    return (
+      <AccessDenied description='This area is limited to Sokana staff.' />
+    );
+  }
+
+  if (isBillingOnlyRole(user?.role)) {
+    return <Navigate to={getBillingHomePath()} replace />;
   }
 
   return <Outlet />;

--- a/src/common/components/ui/sidebar.tsx
+++ b/src/common/components/ui/sidebar.tsx
@@ -122,7 +122,7 @@ function SidebarProvider({
             } as React.CSSProperties
           }
           className={cn(
-            'group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-svh w-full overflow-x-hidden',
+            'group/sidebar-wrapper has-data-[variant=inset]:bg-sidebar flex min-h-dvh w-full min-w-0 overflow-x-hidden',
             className
           )}
           {...props}
@@ -170,7 +170,7 @@ function Sidebar({
           data-sidebar='sidebar'
           data-slot='sidebar'
           data-mobile='true'
-          className='bg-sidebar text-sidebar-foreground w-(--sidebar-width) p-0 [&>button]:hidden'
+          className='bg-sidebar text-sidebar-foreground w-(--sidebar-width) overflow-y-auto p-0 [&>button]:hidden'
           style={
             {
               '--sidebar-width': SIDEBAR_WIDTH_MOBILE,
@@ -182,7 +182,9 @@ function Sidebar({
             <SheetTitle>Sidebar</SheetTitle>
             <SheetDescription>Displays the mobile sidebar.</SheetDescription>
           </SheetHeader>
-          <div className='flex h-full w-full flex-col'>{children}</div>
+          <div className='flex h-full min-h-0 w-full flex-col overflow-y-auto'>
+            {children}
+          </div>
         </SheetContent>
       </Sheet>
     );
@@ -190,7 +192,7 @@ function Sidebar({
 
   return (
     <div
-      className='group peer text-sidebar-foreground md:block'
+      className='group peer text-sidebar-foreground hidden lg:block'
       data-state={state}
       data-collapsible={state === 'collapsed' ? collapsible : ''}
       data-variant={variant}
@@ -212,7 +214,7 @@ function Sidebar({
       <div
         data-slot='sidebar-container'
         className={cn(
-          'fixed inset-y-0 z-10 h-svh w-(--sidebar-width) transition-[left,right,width] duration-300 ease-in-out md:flex',
+          'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-300 ease-in-out lg:flex',
           side === 'left'
             ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
             : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
@@ -292,8 +294,8 @@ function SidebarInset({ className, ...props }: React.ComponentProps<'main'>) {
     <main
       data-slot='sidebar-inset'
       className={cn(
-        'bg-background relative flex w-full flex-1 flex-col',
-        'md:peer-data-[variant=inset]:m-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow-sm md:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
+        'bg-background relative flex min-w-0 w-full flex-1 flex-col',
+        'lg:peer-data-[variant=inset]:m-2 lg:peer-data-[variant=inset]:ml-0 lg:peer-data-[variant=inset]:rounded-xl lg:peer-data-[variant=inset]:shadow-sm lg:peer-data-[variant=inset]:peer-data-[state=collapsed]:ml-2',
         className
       )}
       {...props}
@@ -411,7 +413,7 @@ function SidebarGroupAction({
       className={cn(
         'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground absolute top-3.5 right-3 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
         // Increases the hit area of the button on mobile.
-        'after:absolute after:-inset-2 md:after:hidden',
+        'after:absolute after:-inset-2 lg:after:hidden',
         'group-data-[collapsible=icon]:hidden',
         className
       )}
@@ -466,7 +468,7 @@ const sidebarMenuButtonVariants = cva(
           'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
       },
       size: {
-        default: 'h-8 text-sm',
+        default: 'h-11 min-h-11 text-sm lg:h-8 lg:min-h-8',
         sm: 'h-7 text-xs',
         lg: 'h-12 text-sm group-data-[collapsible=icon]:p-0!',
       },
@@ -550,13 +552,13 @@ function SidebarMenuAction({
       className={cn(
         'text-sidebar-foreground ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground peer-hover/menu-button:text-sidebar-accent-foreground absolute top-1.5 right-1 flex aspect-square w-5 items-center justify-center rounded-md p-0 outline-hidden transition-transform focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
         // Increases the hit area of the button on mobile.
-        'after:absolute after:-inset-2 md:after:hidden',
+        'after:absolute after:-inset-2 lg:after:hidden',
         'peer-data-[size=sm]/menu-button:top-1',
         'peer-data-[size=default]/menu-button:top-1.5',
         'peer-data-[size=lg]/menu-button:top-2.5',
         'group-data-[collapsible=icon]:hidden',
         showOnHover &&
-          'peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 md:opacity-0',
+          'peer-data-[active=true]/menu-button:text-sidebar-accent-foreground group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 lg:opacity-0',
         className
       )}
       {...props}

--- a/src/common/contexts/UserContext.tsx
+++ b/src/common/contexts/UserContext.tsx
@@ -52,7 +52,9 @@ export function UserProvider({
     }
   };
 
-  const checkAuth = async (options?: { silent?: boolean }): Promise<boolean> => {
+  const checkAuth = async (options?: {
+    silent?: boolean;
+  }): Promise<boolean> => {
     if (!options?.silent) {
       setIsLoading(true);
     }
@@ -66,7 +68,11 @@ export function UserProvider({
     } catch (err) {
       setUser(null);
       // Let login flow show actionable backend/network errors
-      if (err instanceof ApiError && (err.options?.code === 'NETWORK_ERROR' || err.options?.code === 'MISSING_BACKEND_URL')) {
+      if (
+        err instanceof ApiError &&
+        (err.options?.code === 'NETWORK_ERROR' ||
+          err.options?.code === 'MISSING_BACKEND_URL')
+      ) {
         throw err;
       }
       return false;
@@ -80,7 +86,10 @@ export function UserProvider({
   const login = async (email: string, password: string): Promise<boolean> => {
     try {
       if (API_CONFIG.authMode === 'supabase') {
-        const { data, error } = await supabase.auth.signInWithPassword({ email, password });
+        const { data, error } = await supabase.auth.signInWithPassword({
+          email,
+          password,
+        });
         if (error) throw new Error(error.message);
         if (!data.session) throw new Error('No session after sign in');
         await checkAuth();
@@ -107,10 +116,17 @@ export function UserProvider({
     } catch (error) {
       console.error('Login error:', error);
       // Surface actionable message for "Failed to fetch" (Supabase or backend)
-      if (error instanceof ApiError && (error.options?.code === 'NETWORK_ERROR' || error.options?.code === 'MISSING_BACKEND_URL')) {
+      if (
+        error instanceof ApiError &&
+        (error.options?.code === 'NETWORK_ERROR' ||
+          error.options?.code === 'MISSING_BACKEND_URL')
+      ) {
         throw error;
       }
-      if (error instanceof TypeError && (error.message === 'Failed to fetch' || error.message === 'Load failed')) {
+      if (
+        error instanceof TypeError &&
+        (error.message === 'Failed to fetch' || error.message === 'Load failed')
+      ) {
         throw new Error(
           'Network error. Check: (1) Supabase URL and anon key (VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY), (2) Backend URL (VITE_APP_BACKEND_URL or VITE_API_BASE_URL) and CORS.'
         );
@@ -121,11 +137,15 @@ export function UserProvider({
 
   const googleAuth = async (): Promise<void> => {
     try {
-      const opts = API_CONFIG.authMode === 'supabase'
-        ? { redirectTo: `${window.location.origin}/auth/callback` }
-        : {};
+      const opts =
+        API_CONFIG.authMode === 'supabase'
+          ? { redirectTo: `${window.location.origin}/auth/callback` }
+          : {};
       if (API_CONFIG.authMode === 'supabase') {
-        const { error } = await supabase.auth.signInWithOAuth({ provider: 'google', options: opts });
+        const { error } = await supabase.auth.signInWithOAuth({
+          provider: 'google',
+          options: opts,
+        });
         if (error) throw new Error(error.message);
         return;
       }
@@ -234,7 +254,8 @@ export function UserProvider({
           <div className='bg-white text-gray-900 rounded-lg shadow-xl p-6 max-w-sm w-full space-y-4'>
             <h2 className='text-lg font-semibold'>Session expiring soon</h2>
             <p className='text-sm text-gray-600'>
-              Your session is about to expire due to inactivity. Click below to stay logged in.
+              Your session is about to expire due to inactivity. Click below to
+              stay logged in.
             </p>
             <div className='flex justify-end gap-3'>
               <button

--- a/src/common/contexts/UserContext.tsx
+++ b/src/common/contexts/UserContext.tsx
@@ -1,9 +1,13 @@
 import type { UserContextType } from '@/common/types/auth';
 import { User } from '@/common/types/user';
 import React, { createContext, ReactNode, useEffect, useState } from 'react';
-import { get, buildUrl, fetchWithAuth } from '@/api/http';
+import { buildUrl, fetchWithAuth } from '@/api/http';
 import { ApiError } from '@/api/errors';
 import { API_CONFIG } from '@/api/config';
+import {
+  clearSessionAccessToken,
+  setSessionAccessToken,
+} from '@/api/sessionAccessToken';
 import { useIdleTimeout } from '@/common/hooks/auth/useIdleTimeout';
 import { supabase } from '@/lib/supabase';
 
@@ -48,17 +52,13 @@ export function UserProvider({
     }
   };
 
-  const checkAuth = async (): Promise<boolean> => {
-    setIsLoading(true);
+  const checkAuth = async (options?: { silent?: boolean }): Promise<boolean> => {
+    if (!options?.silent) {
+      setIsLoading(true);
+    }
     try {
-      if (API_CONFIG.authMode === 'supabase') {
-        const userData = await get<User>('/auth/me');
-        setUser(userData);
-        return true;
-      }
-      const response = await fetch(buildUrl('/auth/me'), {
-        credentials: 'include',
-      });
+      // /auth/me is an unwrapped user object — do not use canonical get().
+      const response = await fetchWithAuth(buildUrl('/auth/me'));
       if (!response.ok) throw new Error('Auth check failed');
       const userData = await response.json();
       setUser(userData);
@@ -71,7 +71,9 @@ export function UserProvider({
       }
       return false;
     } finally {
-      setIsLoading(false);
+      if (!options?.silent) {
+        setIsLoading(false);
+      }
     }
   };
 
@@ -95,7 +97,12 @@ export function UserProvider({
         const data = await response.json().catch(() => ({}));
         throw new Error((data as { error?: string })?.error || 'Login failed');
       }
-      await checkAuth();
+      const sessionOk = await checkAuth();
+      if (!sessionOk) {
+        throw new Error(
+          'Signed in, but the session could not be verified. If you are on a phone, confirm the API URL is reachable (not localhost) and that cookies are allowed.'
+        );
+      }
       return true;
     } catch (error) {
       console.error('Login error:', error);
@@ -191,13 +198,13 @@ export function UserProvider({
     void checkAuth();
   }, []);
 
-  // After client portal login (Supabase session only), refresh /auth/me so user.role is available on Home.
+  // After portal or OAuth sign-in, refresh /auth/me so user.role is authoritative.
   useEffect(() => {
-    if (API_CONFIG.authMode !== 'supabase') return;
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange(() => {
-      void checkAuth();
+    } = supabase.auth.onAuthStateChange((event) => {
+      if (event === 'INITIAL_SESSION') return;
+      void checkAuth({ silent: true });
     });
     return () => {
       subscription.unsubscribe();

--- a/src/common/hooks/auth/useClientAuth.ts
+++ b/src/common/hooks/auth/useClientAuth.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
-import type { User } from '@supabase/supabase-js';
+import { isStaffRole } from '@/common/auth/roles';
+import { useUser } from '@/common/hooks/user/useUser';
 import { supabase } from '@/lib/supabase';
 
 interface ClientUser {
@@ -10,74 +11,61 @@ interface ClientUser {
   role: 'client';
 }
 
-/** Staff roles must not use the client dashboard session. */
-function isStaffRole(user: User): boolean {
-  const r =
-    (user.user_metadata?.role as string | undefined) ||
-    (user.app_metadata?.role as string | undefined);
-  return r === 'admin' || r === 'doula';
+type SessionIdentity = Omit<ClientUser, 'role'>;
+
+function identityFromSession(session: {
+  user: {
+    id: string;
+    email?: string;
+    user_metadata?: Record<string, unknown>;
+  };
+} | null): SessionIdentity | null {
+  if (!session?.user) return null;
+  const meta = session.user.user_metadata ?? {};
+  return {
+    id: session.user.id,
+    email: session.user.email || '',
+    firstname: typeof meta.firstname === 'string' ? meta.firstname : undefined,
+    lastname: typeof meta.lastname === 'string' ? meta.lastname : undefined,
+  };
 }
 
 /**
- * Hook to detect if the current user is a client logged in via Supabase
- * Returns the client user data if authenticated, null otherwise
+ * Supabase session identity for the client portal.
+ * Staff vs client is decided by /auth/me (`user.role`), never by user_metadata.
  */
 export function useClientAuth() {
-  const [client, setClient] = useState<ClientUser | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const { user, isLoading: userLoading } = useUser();
+  const [sessionIdentity, setSessionIdentity] = useState<SessionIdentity | null>(
+    null
+  );
+  const [sessionLoading, setSessionLoading] = useState(true);
 
   useEffect(() => {
+    const applySession = (session: Parameters<typeof identityFromSession>[0]) => {
+      setSessionIdentity(identityFromSession(session));
+      setSessionLoading(false);
+    };
+
     const checkClientSession = async () => {
       try {
         const {
           data: { session },
         } = await supabase.auth.getSession();
-
-        if (session?.user) {
-          if (isStaffRole(session.user)) {
-            setClient(null);
-          } else {
-            setClient({
-              id: session.user.id,
-              email: session.user.email || '',
-              firstname: session.user.user_metadata?.firstname,
-              lastname: session.user.user_metadata?.lastname,
-              role: 'client',
-            });
-          }
-        } else {
-          setClient(null);
-        }
+        applySession(session);
       } catch (error) {
         console.error('Error checking client session:', error);
-        setClient(null);
-      } finally {
-        setIsLoading(false);
+        setSessionIdentity(null);
+        setSessionLoading(false);
       }
     };
 
-    checkClientSession();
+    void checkClientSession();
 
-    // Listen for auth state changes
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((_event, session) => {
-      if (session?.user) {
-        if (isStaffRole(session.user)) {
-          setClient(null);
-        } else {
-          setClient({
-            id: session.user.id,
-            email: session.user.email || '',
-            firstname: session.user.user_metadata?.firstname,
-            lastname: session.user.user_metadata?.lastname,
-            role: 'client',
-          });
-        }
-      } else {
-        setClient(null);
-      }
-      setIsLoading(false);
+      applySession(session);
     });
 
     return () => {
@@ -85,6 +73,11 @@ export function useClientAuth() {
     };
   }, []);
 
+  const isLoading = userLoading || sessionLoading;
+  const client =
+    !userLoading && !isStaffRole(user?.role) && sessionIdentity
+      ? { ...sessionIdentity, role: 'client' as const }
+      : null;
+
   return { client, isLoading, isClient: !!client };
 }
-

--- a/src/common/hooks/auth/useClientAuth.ts
+++ b/src/common/hooks/auth/useClientAuth.ts
@@ -13,13 +13,15 @@ interface ClientUser {
 
 type SessionIdentity = Omit<ClientUser, 'role'>;
 
-function identityFromSession(session: {
-  user: {
-    id: string;
-    email?: string;
-    user_metadata?: Record<string, unknown>;
-  };
-} | null): SessionIdentity | null {
+function identityFromSession(
+  session: {
+    user: {
+      id: string;
+      email?: string;
+      user_metadata?: Record<string, unknown>;
+    };
+  } | null
+): SessionIdentity | null {
   if (!session?.user) return null;
   const meta = session.user.user_metadata ?? {};
   return {
@@ -36,13 +38,14 @@ function identityFromSession(session: {
  */
 export function useClientAuth() {
   const { user, isLoading: userLoading } = useUser();
-  const [sessionIdentity, setSessionIdentity] = useState<SessionIdentity | null>(
-    null
-  );
+  const [sessionIdentity, setSessionIdentity] =
+    useState<SessionIdentity | null>(null);
   const [sessionLoading, setSessionLoading] = useState(true);
 
   useEffect(() => {
-    const applySession = (session: Parameters<typeof identityFromSession>[0]) => {
+    const applySession = (
+      session: Parameters<typeof identityFromSession>[0]
+    ) => {
       setSessionIdentity(identityFromSession(session));
       setSessionLoading(false);
     };

--- a/src/common/hooks/auth/useIsClientPortalUser.ts
+++ b/src/common/hooks/auth/useIsClientPortalUser.ts
@@ -1,10 +1,11 @@
+import { isClientRole, isStaffRole } from '@/common/auth/roles';
 import { useUser } from '@/common/hooks/user/useUser';
 import { useClientAuth } from '@/common/hooks/auth/useClientAuth';
 
 /**
- * True when this session should see the client portal (not admin/doula CRM).
- * Uses both Supabase session (useClientAuth) and backend /auth/me (user.role) so we
- * never show org metrics if the backend already classified the user as client.
+ * True when this session should see the client portal (not admin/doula/billing CRM).
+ * Staff vs client comes from /auth/me. A Supabase session is a client fallback only
+ * when the backend has not classified the user as staff.
  */
 export function useIsClientPortalUser(): {
   isClientPortalUser: boolean;
@@ -14,9 +15,9 @@ export function useIsClientPortalUser(): {
   const { user, isLoading: userLoading } = useUser();
   const { client, isLoading: clientLoading } = useClientAuth();
 
-  const isStaffUser = user?.role === 'admin' || user?.role === 'doula';
+  const isStaffUser = isStaffRole(user?.role);
   const isClientPortalUser =
-    !isStaffUser && (!!client || user?.role === 'client');
+    !isStaffUser && (isClientRole(user?.role) || !!client);
 
   return {
     isClientPortalUser,

--- a/src/common/hooks/ui/useMobile.test.ts
+++ b/src/common/hooks/ui/useMobile.test.ts
@@ -1,0 +1,10 @@
+import { MOBILE_BREAKPOINT } from '@/common/hooks/ui/useMobile';
+import { describe, expect, it } from 'vitest';
+
+describe('useIsMobile breakpoint', () => {
+  it('treats tablet 768 as mobile/hamburger (below Tailwind lg)', () => {
+    expect(MOBILE_BREAKPOINT).toBe(1024);
+    expect(768).toBeLessThan(MOBILE_BREAKPOINT);
+    expect(1024).toBeGreaterThanOrEqual(MOBILE_BREAKPOINT);
+  });
+});

--- a/src/common/hooks/ui/useMobile.ts
+++ b/src/common/hooks/ui/useMobile.ts
@@ -1,21 +1,25 @@
 import * as React from 'react';
 
-const MOBILE_BREAKPOINT = 768;
+/** Hamburger / Sheet below this width. Matches Tailwind `lg` (1024px). */
+export const MOBILE_BREAKPOINT = 1024;
+
+function getIsMobileWidth(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.innerWidth < MOBILE_BREAKPOINT;
+}
 
 export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
-    undefined
-  );
+  const [isMobile, setIsMobile] = React.useState<boolean>(getIsMobileWidth);
 
   React.useEffect(() => {
     const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
     const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+      setIsMobile(getIsMobileWidth());
     };
     mql.addEventListener('change', onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    setIsMobile(getIsMobileWidth());
     return () => mql.removeEventListener('change', onChange);
   }, []);
 
-  return !!isMobile;
+  return isMobile;
 }

--- a/src/common/hooks/user/useSaveUser.ts
+++ b/src/common/hooks/user/useSaveUser.ts
@@ -1,5 +1,6 @@
 import { User } from '@/common/utils/User';
 import { apiBaseUrl } from '@/config/env';
+import { fetchWithAuth } from '@/api/http';
 
 export default async function useSaveUser(userData: User) {
   console.assert(
@@ -7,7 +8,7 @@ export default async function useSaveUser(userData: User) {
     `in useSaveUser, no userData.id provided. the userData is ${JSON.stringify(userData)}`
   );
   try {
-    const response = await fetch(`${apiBaseUrl}/users/update`, {
+    const response = await fetchWithAuth(`${apiBaseUrl}/users/update`, {
       method: 'PUT',
       credentials: 'include',
       headers: {

--- a/src/common/layouts/DashboardLayout.tsx
+++ b/src/common/layouts/DashboardLayout.tsx
@@ -1,20 +1,26 @@
 import { AppSidebar } from '@/common/components/navigation/sidebar/AppSidebar';
-import { SidebarProvider } from '@/common/components/ui/sidebar';
+import {
+  SidebarInset,
+  SidebarProvider,
+  SidebarTrigger,
+} from '@/common/components/ui/sidebar';
 import { SearchProvider } from '@/common/contexts/SearchContext';
 import { Outlet } from 'react-router-dom';
 
 export default function DashboardLayout() {
   return (
     <SearchProvider>
-      <SidebarProvider>
-        <div className='flex min-h-screen w-full overflow-x-hidden'>
-          <aside className='w-64 shrink-0 border-r bg-muted p-4'>
-            <AppSidebar />
-          </aside>
-          <main className='min-w-0 flex-1'>
+      <SidebarProvider className='min-h-dvh min-w-0 overflow-x-hidden'>
+        <AppSidebar />
+        <SidebarInset className='min-w-0 overflow-x-hidden'>
+          <header className='flex h-12 shrink-0 items-center gap-2 border-b px-3 pt-[env(safe-area-inset-top)] lg:hidden'>
+            <SidebarTrigger className='min-h-11 min-w-11' />
+            <span className='text-sm font-medium'>Sokana CRM</span>
+          </header>
+          <div className='min-w-0 flex-1 overflow-x-hidden pb-[env(safe-area-inset-bottom)]'>
             <Outlet />
-          </main>
-        </div>
+          </div>
+        </SidebarInset>
       </SidebarProvider>
     </SearchProvider>
   );

--- a/src/common/layouts/Header.tsx
+++ b/src/common/layouts/Header.tsx
@@ -30,7 +30,7 @@ export const Header = ({
   return (
     <header
       className={cn(
-        'flex h-16 items-center gap-3 bg-background p-4 sm:gap-4',
+        'flex min-h-16 min-w-0 flex-wrap items-center gap-3 bg-background p-4 sm:gap-4',
         fixed && 'header-fixed peer/header fixed z-50 w-[inherit] rounded-md',
         offset > 10 && fixed ? 'shadow' : 'shadow-none',
         className

--- a/src/common/layouts/Main.tsx
+++ b/src/common/layouts/Main.tsx
@@ -11,7 +11,7 @@ export const Main = ({ fixed, ...props }: MainProps) => {
     <main
       className={cn(
         'peer-[.header-fixed]/header:mt-16',
-        'h-full max-h-screen w-full max-w-full overflow-x-hidden px-4 py-6',
+        'h-full max-h-screen w-full min-w-0 max-w-full overflow-x-hidden px-4 py-6',
         fixed && 'fixed-main flex h-full flex-grow min-h-0 flex-col overflow-hidden'
       )}
       {...props}

--- a/src/common/layouts/Main.tsx
+++ b/src/common/layouts/Main.tsx
@@ -12,7 +12,8 @@ export const Main = ({ fixed, ...props }: MainProps) => {
       className={cn(
         'peer-[.header-fixed]/header:mt-16',
         'h-full max-h-screen w-full min-w-0 max-w-full overflow-x-hidden px-4 py-6',
-        fixed && 'fixed-main flex h-full flex-grow min-h-0 flex-col overflow-hidden'
+        fixed &&
+          'fixed-main flex h-full flex-grow min-h-0 flex-col overflow-hidden'
       )}
       {...props}
     />

--- a/src/common/layouts/NavLayout.tsx
+++ b/src/common/layouts/NavLayout.tsx
@@ -4,9 +4,16 @@ import styled from 'styled-components';
 import NavBar from '@/common/components/navigation/navbar/NavBar';
 
 const Nav = styled.div`
-  height: 100vh;
+  min-height: 100dvh;
+  min-width: 0;
   display: flex;
   flex-direction: column;
+  overflow-x: hidden;
+  overflow-y: auto;
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
 `;
 
 export default function NavLayout() {

--- a/src/common/types/auth.ts
+++ b/src/common/types/auth.ts
@@ -15,7 +15,7 @@ export interface UserContextType {
   isLoading: boolean;
   login: (email: string, password: string) => Promise<boolean>;
   logout: () => Promise<void>;
-  checkAuth: () => Promise<boolean>;
+  checkAuth: (options?: { silent?: boolean }) => Promise<boolean>;
   googleAuth: () => Promise<void>;
   requestPasswordReset: (email: string) => Promise<boolean>;
   updatePassword: (password: string, token: string) => Promise<boolean>;

--- a/src/common/utils/sessionUtils.test.ts
+++ b/src/common/utils/sessionUtils.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { isSessionExpiredError } from './sessionUtils';
+
+describe('isSessionExpiredError', () => {
+  it('treats 401 as session expiry', () => {
+    expect(isSessionExpiredError(401, 'Unauthorized')).toBe(true);
+  });
+
+  it('does not treat 403 Forbidden as session expiry', () => {
+    expect(isSessionExpiredError(403, 'Forbidden')).toBe(false);
+    expect(isSessionExpiredError(403, 'unauthorized')).toBe(false);
+  });
+
+  it('detects expired-session messages on other statuses', () => {
+    expect(isSessionExpiredError(500, 'token expired')).toBe(true);
+    expect(isSessionExpiredError(400, 'session expired')).toBe(true);
+  });
+});

--- a/src/common/utils/sessionUtils.ts
+++ b/src/common/utils/sessionUtils.ts
@@ -9,13 +9,14 @@ export function isSessionExpiredError(
   status: number,
   errorText: string
 ): boolean {
+  // 403 is authorization failure (logged in, not allowed) — not session expiry.
+  if (status === 403) return false;
+  if (status === 401) return true;
+  const text = errorText.toLowerCase();
   return (
-    status === 401 ||
-    status === 403 ||
-    errorText.toLowerCase().includes('unauthorized') ||
-    errorText.toLowerCase().includes('not authenticated') ||
-    errorText.toLowerCase().includes('token expired') ||
-    errorText.toLowerCase().includes('session expired')
+    text.includes('not authenticated') ||
+    text.includes('token expired') ||
+    text.includes('session expired')
   );
 }
 

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -15,7 +15,9 @@ function getEnv(key: string): string | undefined {
 
 const rawAppEnv = (getEnv('VITE_APP_ENV') ?? 'development') as string;
 const appEnv: AppEnv =
-  rawAppEnv === 'production' || rawAppEnv === 'staging' || rawAppEnv === 'development'
+  rawAppEnv === 'production' ||
+  rawAppEnv === 'staging' ||
+  rawAppEnv === 'development'
     ? rawAppEnv
     : 'development';
 
@@ -25,7 +27,8 @@ const LOCAL_API_URL = 'http://localhost:5050';
  * Gradual cutover flag: when VITE_USE_CLOUD_RUN=true, use VITE_CLOUD_RUN_API_URL.
  * Production builds never fall back to a hardcoded Cloud Run URL or localhost.
  */
-const useCloudRun = (getEnv('VITE_USE_CLOUD_RUN') ?? '').toLowerCase() === 'true';
+const useCloudRun =
+  (getEnv('VITE_USE_CLOUD_RUN') ?? '').toLowerCase() === 'true';
 
 function configuredApiUrl(): string {
   const cloudRun = (getEnv('VITE_CLOUD_RUN_API_URL') ?? '').replace(/\/+$/, '');

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -19,27 +19,32 @@ const appEnv: AppEnv =
     ? rawAppEnv
     : 'development';
 
-const DEFAULT_CLOUD_RUN_API_URL =
-  'https://sokana-private-api-634744984887.us-central1.run.app';
+const LOCAL_API_URL = 'http://localhost:5050';
 
 /**
- * Gradual cutover flag: when VITE_USE_CLOUD_RUN=true, use Cloud Run API
- * (VITE_CLOUD_RUN_API_URL or default) instead of local/Vercel backend URL.
+ * Gradual cutover flag: when VITE_USE_CLOUD_RUN=true, use VITE_CLOUD_RUN_API_URL.
+ * Production builds never fall back to a hardcoded Cloud Run URL or localhost.
  */
 const useCloudRun = (getEnv('VITE_USE_CLOUD_RUN') ?? '').toLowerCase() === 'true';
-const cloudRunApiUrl = (
-  getEnv('VITE_CLOUD_RUN_API_URL') ?? DEFAULT_CLOUD_RUN_API_URL
-).replace(/\/+$/, '');
 
-/** API base URL: Cloud Run (if flagged), else VITE_API_BASE_URL / VITE_API_URL / VITE_APP_BACKEND_URL. */
-export const apiBaseUrl = useCloudRun
-  ? cloudRunApiUrl
-  : (
-      (getEnv('VITE_API_BASE_URL') ?? getEnv('VITE_API_URL') ?? getEnv('VITE_APP_BACKEND_URL'))?.replace(
-        /\/+$/,
-        ''
-      ) || 'http://localhost:5050'
-    );
+function configuredApiUrl(): string {
+  const cloudRun = (getEnv('VITE_CLOUD_RUN_API_URL') ?? '').replace(/\/+$/, '');
+  const fromEnv = (
+    getEnv('VITE_API_BASE_URL') ??
+    getEnv('VITE_API_URL') ??
+    getEnv('VITE_APP_BACKEND_URL') ??
+    ''
+  ).replace(/\/+$/, '');
+
+  if (useCloudRun) {
+    if (cloudRun) return cloudRun;
+    return import.meta.env.DEV ? LOCAL_API_URL : '';
+  }
+  if (fromEnv) return fromEnv;
+  return import.meta.env.DEV ? LOCAL_API_URL : '';
+}
+
+export const apiBaseUrl = configuredApiUrl();
 
 export const isCloudRunApi = useCloudRun;
 
@@ -47,3 +52,11 @@ export const isProd = appEnv === 'production';
 export const isDev = appEnv === 'development';
 export const isStaging = appEnv === 'staging';
 export const appEnvValue: AppEnv = appEnv;
+
+/** Public request form QA control. On in Vite dev; production only with explicit flag. */
+export function isRequestTestDataEnabled(): boolean {
+  const flagged =
+    (getEnv('VITE_ENABLE_REQUEST_TEST_DATA') ?? '').toLowerCase() === 'true';
+  if (flagged) return true;
+  return Boolean(import.meta.env.DEV);
+}

--- a/src/features/InvoicesPage/InvoicesPage.tsx
+++ b/src/features/InvoicesPage/InvoicesPage.tsx
@@ -23,8 +23,17 @@ import { UserContext } from '@/common/contexts/UserContext';
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
 import { toast, ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-import { ChevronLeft, ChevronRight, Filter, Loader2, Search } from 'lucide-react';
-import { InvoiceDetailModal, type InvoiceDetailData } from './InvoiceDetailModal';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Filter,
+  Loader2,
+  Search,
+} from 'lucide-react';
+import {
+  InvoiceDetailModal,
+  type InvoiceDetailData,
+} from './InvoiceDetailModal';
 
 const PAGE_SIZES = [10, 25, 50, 100];
 
@@ -129,7 +138,9 @@ export default function InvoicesPage() {
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(10);
   const [detailModalOpen, setDetailModalOpen] = useState(false);
-  const [selectedInvoice, setSelectedInvoice] = useState<DisplayInvoice | null>(null);
+  const [selectedInvoice, setSelectedInvoice] = useState<DisplayInvoice | null>(
+    null
+  );
 
   const fetchCustomers = useCallback(async () => {
     setLoadingCust(true);
@@ -215,12 +226,13 @@ export default function InvoicesPage() {
         due_date: inv.due_date,
         total: typeof total === 'number' ? total.toFixed(2) : '0.00',
         lineItems: (
-          <ul className="space-y-1">
+          <ul className='space-y-1'>
             {inv.line_items
               ?.filter((item) => item.DetailType === 'SalesItemLineDetail')
               .map((li, i) => (
                 <li key={i}>
-                  {li.Description ?? 'Item'} × {li.SalesItemLineDetail?.Qty ?? 1} @ $
+                  {li.Description ?? 'Item'} ×{' '}
+                  {li.SalesItemLineDetail?.Qty ?? 1} @ $
                   {li.SalesItemLineDetail?.UnitPrice?.toFixed(2) ?? '0.00'}
                 </li>
               )) ?? null}
@@ -257,13 +269,7 @@ export default function InvoicesPage() {
       );
     }
     return list;
-  }, [
-    displayList,
-    searchTerm,
-    statusFilter,
-    dateFromFilter,
-    dateToFilter,
-  ]);
+  }, [displayList, searchTerm, statusFilter, dateFromFilter, dateToFilter]);
 
   const totalPages = Math.max(1, Math.ceil(filteredList.length / pageSize));
   const startItem = (currentPage - 1) * pageSize;
@@ -361,13 +367,17 @@ export default function InvoicesPage() {
       {/* Summary stats at top */}
       <div className='mb-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4'>
         <div className='rounded-lg border bg-card p-4 shadow-sm'>
-          <p className='text-xs font-medium text-muted-foreground'>Total amount</p>
+          <p className='text-xs font-medium text-muted-foreground'>
+            Total amount
+          </p>
           <p className='text-xl font-semibold mt-1'>
             {formatAmount(invoiceStats.totalAmount)}
           </p>
         </div>
         <div className='rounded-lg border bg-card p-4 shadow-sm'>
-          <p className='text-xs font-medium text-muted-foreground'>Invoice count</p>
+          <p className='text-xs font-medium text-muted-foreground'>
+            Invoice count
+          </p>
           <p className='text-xl font-semibold mt-1'>{invoiceStats.count}</p>
         </div>
       </div>
@@ -389,7 +399,10 @@ export default function InvoicesPage() {
             </div>
           </div>
           <div className='flex flex-wrap items-center gap-2'>
-            <Select value={statusFilter} onValueChange={(v) => setStatusFilter(v)}>
+            <Select
+              value={statusFilter}
+              onValueChange={(v) => setStatusFilter(v)}
+            >
               <SelectTrigger className='w-[160px] h-9'>
                 <SelectValue placeholder='Status' />
               </SelectTrigger>
@@ -446,7 +459,9 @@ export default function InvoicesPage() {
           {filteredList.length === 0
             ? 'No invoices match your filters.'
             : `${filteredList.length} invoice${filteredList.length === 1 ? '' : 's'} total`}
-          {displayList.length !== filteredList.length && hasActiveFilters && ` (filtered from ${displayList.length})`}
+          {displayList.length !== filteredList.length &&
+            hasActiveFilters &&
+            ` (filtered from ${displayList.length})`}
         </p>
       </div>
 
@@ -470,20 +485,34 @@ export default function InvoicesPage() {
               <table className='min-w-full text-sm'>
                 <thead className='sticky top-0 bg-muted/80 backdrop-blur z-10'>
                   <tr className='border-b'>
-                    <th className='px-4 py-3 text-left font-semibold'>Invoice #</th>
-                    <th className='px-4 py-3 text-left font-semibold'>Customer</th>
-                    <th className='px-4 py-3 text-center font-semibold'>Status</th>
-                    <th className='px-4 py-3 text-center font-semibold'>Date</th>
-                    <th className='px-4 py-3 text-center font-semibold'>Due Date</th>
-                    <th className='px-4 py-3 text-right font-semibold'>Total</th>
-                    <th className='px-4 py-3 text-left font-semibold'>Line Items</th>
+                    <th className='px-4 py-3 text-left font-semibold'>
+                      Invoice #
+                    </th>
+                    <th className='px-4 py-3 text-left font-semibold'>
+                      Customer
+                    </th>
+                    <th className='px-4 py-3 text-center font-semibold'>
+                      Status
+                    </th>
+                    <th className='px-4 py-3 text-center font-semibold'>
+                      Date
+                    </th>
+                    <th className='px-4 py-3 text-center font-semibold'>
+                      Due Date
+                    </th>
+                    <th className='px-4 py-3 text-right font-semibold'>
+                      Total
+                    </th>
+                    <th className='px-4 py-3 text-left font-semibold'>
+                      Line Items
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
                   {paginatedItems.map((inv, idx) => (
                     <tr
                       key={inv.id}
-                      role="button"
+                      role='button'
                       tabIndex={0}
                       className='border-b border-border/50 last:border-0 hover:bg-muted/30 cursor-pointer'
                       onClick={() => {
@@ -498,26 +527,37 @@ export default function InvoicesPage() {
                         }
                       }}
                     >
-                      <td className='px-4 py-3 font-medium' title={inv.invoiceNumber}>
+                      <td
+                        className='px-4 py-3 font-medium'
+                        title={inv.invoiceNumber}
+                      >
                         {shortenInvoiceNumber(inv.invoiceNumber)}
                       </td>
                       <td className='px-4 py-3'>
                         <div>
                           <div className='font-medium'>{inv.customerName}</div>
                           {inv.customerEmail && (
-                            <div className='text-xs text-muted-foreground'>{inv.customerEmail}</div>
+                            <div className='text-xs text-muted-foreground'>
+                              {inv.customerEmail}
+                            </div>
                           )}
                         </div>
                       </td>
-                      <td className='px-4 py-3 text-center'>{getStatusBadge(inv.status)}</td>
+                      <td className='px-4 py-3 text-center'>
+                        {getStatusBadge(inv.status)}
+                      </td>
                       <td className='px-4 py-3 text-center text-muted-foreground'>
                         {formatDate(inv.created_at)}
                       </td>
                       <td className='px-4 py-3 text-center text-muted-foreground'>
                         {formatDate(inv.due_date)}
                       </td>
-                      <td className='px-4 py-3 text-right font-medium'>${inv.total}</td>
-                      <td className='px-4 py-3 text-muted-foreground'>{inv.lineItems}</td>
+                      <td className='px-4 py-3 text-right font-medium'>
+                        ${inv.total}
+                      </td>
+                      <td className='px-4 py-3 text-muted-foreground'>
+                        {inv.lineItems}
+                      </td>
                     </tr>
                   ))}
                 </tbody>
@@ -525,7 +565,9 @@ export default function InvoicesPage() {
             </div>
             <div className='shrink-0 flex items-center justify-between gap-4 px-4 py-3 border-t bg-muted/30'>
               <p className='text-sm text-muted-foreground'>
-                Showing {startItem + 1}–{Math.min(startItem + pageSize, filteredList.length)} of {filteredList.length}
+                Showing {startItem + 1}–
+                {Math.min(startItem + pageSize, filteredList.length)} of{' '}
+                {filteredList.length}
               </p>
               <div className='flex items-center gap-2'>
                 <Button
@@ -545,7 +587,9 @@ export default function InvoicesPage() {
                   size='sm'
                   className='h-8 w-8 p-0'
                   disabled={currentPage >= totalPages}
-                  onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+                  onClick={() =>
+                    setCurrentPage((p) => Math.min(totalPages, p + 1))
+                  }
                 >
                   <ChevronRight className='h-4 w-4' />
                 </Button>
@@ -616,10 +660,10 @@ function CreateInvoiceModal({
 
   const filtered = search
     ? customers.filter(
-      (c) =>
-        c.name.toLowerCase().includes(search.toLowerCase()) ||
-        c.email.toLowerCase().includes(search.toLowerCase())
-    )
+        (c) =>
+          c.name.toLowerCase().includes(search.toLowerCase()) ||
+          c.email.toLowerCase().includes(search.toLowerCase())
+      )
     : customers;
 
   const changeLine = (

--- a/src/features/InvoicesPage/InvoicesPage.tsx
+++ b/src/features/InvoicesPage/InvoicesPage.tsx
@@ -351,7 +351,7 @@ export default function InvoicesPage() {
 
   return (
     <div className='flex flex-col p-4 min-h-0 overflow-auto'>
-      <div className='shrink-0 flex justify-between items-center mb-4'>
+      <div className='mb-4 flex min-w-0 shrink-0 flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
         <h1 className='text-2xl font-bold tracking-tight'>Invoices</h1>
         <SubmitButton onClick={() => setShowModal(true)}>
           New Invoice
@@ -359,7 +359,7 @@ export default function InvoicesPage() {
       </div>
 
       {/* Summary stats at top */}
-      <div className='grid grid-cols-2 sm:grid-cols-4 gap-4 mb-4'>
+      <div className='mb-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4'>
         <div className='rounded-lg border bg-card p-4 shadow-sm'>
           <p className='text-xs font-medium text-muted-foreground'>Total amount</p>
           <p className='text-xl font-semibold mt-1'>

--- a/src/features/auth/ClientLogin.tsx
+++ b/src/features/auth/ClientLogin.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { supabase } from '@/lib/supabase';
+import { isStaffRole } from '@/common/auth/roles';
+import { useUser } from '@/common/hooks/user/useUser';
 import { Button } from '@/common/components/ui/button';
 import {
   Card,
@@ -18,6 +20,7 @@ import { Alert, AlertDescription } from '@/common/components/ui/alert';
 
 export default function ClientLogin() {
   const navigate = useNavigate();
+  const { user, checkAuth, isLoading: isAuthLoading } = useUser();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
@@ -52,45 +55,13 @@ export default function ClientLogin() {
     return () => window.removeEventListener('beforeunload', handleBeforeUnload);
   }, []);
 
-  // Check if user is already logged in
-  // Skip this check if there was a recent login error to prevent redirect loops
+  // Redirect staff who already have an authoritative /auth/me role.
   useEffect(() => {
-    if (hasLoginError) {
-      console.log('ClientLogin - Skipping session check due to recent login error');
-      return;
+    if (hasLoginError || isAuthLoading) return;
+    if (isStaffRole(user?.role)) {
+      navigate('/', { replace: true });
     }
-
-    const checkSession = async () => {
-      console.log('ClientLogin - Checking Supabase session');
-      const {
-        data: { session },
-      } = await supabase.auth.getSession();
-
-      console.log('ClientLogin - Session result:', session ? 'has session' : 'no session');
-
-      if (session) {
-        // Verify user role
-        const userRole = session.user.user_metadata?.role;
-        console.log('ClientLogin - User role:', userRole);
-        if (userRole === 'client') {
-          console.log('ClientLogin - Client session detected');
-          // Client has Supabase session - they're already logged in via Supabase
-          // Don't redirect to / because that requires backend auth
-          // Instead, show a message or redirect to a client-only route (when created)
-          // For now, we'll let them stay on the login page or they can manually navigate
-          console.log('ClientLogin - Client already has Supabase session, staying on page');
-        } else {
-          console.log('ClientLogin - Signing out non-client user');
-          // Sign out non-client users
-          await supabase.auth.signOut();
-        }
-      } else {
-        console.log('ClientLogin - No Supabase session, staying on page');
-      }
-    };
-
-    checkSession();
-  }, [navigate, hasLoginError]);
+  }, [hasLoginError, isAuthLoading, user?.role, navigate]);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -121,10 +92,7 @@ export default function ClientLogin() {
       setError(null);
       toast.success('Welcome! Redirecting to your dashboard...');
       
-      // Wait a moment for auth state to propagate so useClientAuth can detect the session
-      await new Promise(resolve => setTimeout(resolve, 300));
-      
-      // Redirect to home page which will show client dashboard
+      await checkAuth({ silent: true });
       navigate('/', { replace: true });
     } catch (err: any) {
       console.error('Client login error:', err);
@@ -161,7 +129,7 @@ export default function ClientLogin() {
   }, []);
 
   return (
-    <div className='flex flex-col gap-6 max-w-md mx-auto p-4'>
+    <div className='mx-auto flex w-full min-w-0 max-w-md flex-col gap-6 p-4'>
       <Card>
         <CardHeader>
           <CardTitle className='text-2xl'>Client Portal Login</CardTitle>
@@ -190,6 +158,7 @@ export default function ClientLogin() {
                 required
                 disabled={isLoading}
                 autoComplete='email'
+                className='text-base md:text-sm'
               />
             </div>
 

--- a/src/features/auth/ClientLogin.tsx
+++ b/src/features/auth/ClientLogin.tsx
@@ -34,15 +34,18 @@ export default function ClientLogin() {
     console.log('Current path:', window.location.pathname);
     console.log('Current hash:', window.location.hash);
     console.log('Full URL:', window.location.href);
-    
+
     // Track navigation changes
     const interval = setInterval(() => {
       if (window.location.pathname !== '/auth/client-login') {
-        console.error('🚨 PATH CHANGED FROM /auth/client-login TO:', window.location.pathname);
+        console.error(
+          '🚨 PATH CHANGED FROM /auth/client-login TO:',
+          window.location.pathname
+        );
         console.trace('Stack trace of what changed the path');
       }
     }, 100);
-    
+
     return () => clearInterval(interval);
   }, []);
 
@@ -71,10 +74,11 @@ export default function ClientLogin() {
 
     try {
       // Sign in with Supabase Auth (same approach as admin login - just authenticate)
-      const { data, error: signInError } = await supabase.auth.signInWithPassword({
-        email,
-        password,
-      });
+      const { data, error: signInError } =
+        await supabase.auth.signInWithPassword({
+          email,
+          password,
+        });
 
       if (signInError) {
         throw new Error(
@@ -91,7 +95,7 @@ export default function ClientLogin() {
       // Success - client is logged in via Supabase
       setError(null);
       toast.success('Welcome! Redirecting to your dashboard...');
-      
+
       await checkAuth({ silent: true });
       navigate('/', { replace: true });
     } catch (err: any) {
@@ -118,7 +122,7 @@ export default function ClientLogin() {
 
   console.log('ClientLogin - Rendering component');
   console.log('ClientLogin - Will NOT redirect to /login from this component');
-  
+
   // Prevent any navigation away from this page unless explicitly done by user action
   useEffect(() => {
     const currentPath = window.location.pathname;
@@ -215,8 +219,8 @@ export default function ClientLogin() {
 
           <div className='mt-6 text-center text-sm space-y-2'>
             <p className='text-muted-foreground'>
-              Don't have an account? Contact your administrator to receive a portal
-              invite.
+              Don't have an account? Contact your administrator to receive a
+              portal invite.
             </p>
             <div className='pt-2 border-t'>
               <p className='text-muted-foreground'>
@@ -235,4 +239,3 @@ export default function ClientLogin() {
     </div>
   );
 }
-

--- a/src/features/auth/Login.tsx
+++ b/src/features/auth/Login.tsx
@@ -73,7 +73,7 @@ export default function Login() {
   };
 
   return (
-    <div className='flex flex-col gap-6 max-w-md mx-auto'>
+    <div className='flex flex-col gap-6 max-w-md mx-auto w-full px-4 py-6'>
       <Card>
         <CardHeader>
           <CardTitle className='text-2xl'>Log In</CardTitle>
@@ -89,6 +89,9 @@ export default function Login() {
                 id='email'
                 type='email'
                 name='email'
+                autoComplete='email'
+                inputMode='email'
+                className='text-base md:text-sm'
                 placeholder='jsmith or j@example.com'
                 value={formState.email}
                 onChange={handleChange}
@@ -108,6 +111,8 @@ export default function Login() {
               <PasswordInput
                 id='password'
                 name='password'
+                autoComplete='current-password'
+                className='text-base md:text-sm'
                 placeholder='Enter your password'
                 value={formState.password}
                 onChange={handleChange}

--- a/src/features/auth/SignUp.tsx
+++ b/src/features/auth/SignUp.tsx
@@ -58,21 +58,18 @@ export default function SignUp() {
     setError('');
 
     try {
-      const response = await fetchWithAuth(
-        buildUrl('/auth/signup'),
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify({
-            email: formState.email,
-            password: formState.password,
-            firstname: formState.firstname || undefined,
-            lastname: formState.lastname || undefined,
-          }),
-        }
-      );
+      const response = await fetchWithAuth(buildUrl('/auth/signup'), {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          email: formState.email,
+          password: formState.password,
+          firstname: formState.firstname || undefined,
+          lastname: formState.lastname || undefined,
+        }),
+      });
 
       const data = await response.json();
 

--- a/src/features/auth/SignUp.tsx
+++ b/src/features/auth/SignUp.tsx
@@ -97,7 +97,7 @@ export default function SignUp() {
   };
 
   return (
-    <div className='flex flex-col gap-6 max-w-md mx-auto'>
+    <div className='mx-auto flex w-full min-w-0 max-w-md flex-col gap-6 px-4 py-6'>
       <Card>
         <CardHeader>
           <CardTitle className='text-2xl'>Sign Up</CardTitle>

--- a/src/features/billing-portal/BillingContractDetailPage.tsx
+++ b/src/features/billing-portal/BillingContractDetailPage.tsx
@@ -139,7 +139,7 @@ export default function BillingContractDetailPage() {
   }
 
   return (
-    <div className='p-6 space-y-6 overflow-y-auto'>
+    <div className='min-w-0 space-y-6 overflow-y-auto p-4 sm:p-6'>
       <div className='flex flex-wrap items-start justify-between gap-4'>
         <div className='space-y-2'>
           <Button asChild variant='outline' size='sm'>
@@ -252,7 +252,8 @@ export default function BillingContractDetailPage() {
         {contract.installments.length === 0 ? (
           <div className='p-6 text-sm text-muted-foreground'>No installments available.</div>
         ) : (
-          <table className='min-w-full text-sm'>
+          <div className='overflow-x-auto'>
+          <table className='min-w-[640px] w-full text-sm'>
             <thead className='bg-muted/60'>
               <tr className='border-b'>
                 <th className='px-4 py-3 text-left font-semibold'>Installment</th>
@@ -312,6 +313,7 @@ export default function BillingContractDetailPage() {
               ))}
             </tbody>
           </table>
+          </div>
         )}
       </div>
     </div>

--- a/src/features/billing-portal/BillingContractDetailPage.tsx
+++ b/src/features/billing-portal/BillingContractDetailPage.tsx
@@ -27,7 +27,9 @@ function formatDate(value?: string | null): string {
   return Number.isNaN(date.getTime()) ? value : date.toLocaleDateString();
 }
 
-function formatBillingSetup(contract: LimitedContractPaymentSchedule): string[] {
+function formatBillingSetup(
+  contract: LimitedContractPaymentSchedule
+): string[] {
   return [
     contract.billingResponsibility,
     contract.paymentMethodSummary,
@@ -47,7 +49,9 @@ function BillingOverviewCard({
 }) {
   return (
     <div className='rounded-xl border bg-card p-4 shadow-sm'>
-      <p className='text-xs font-medium uppercase tracking-wide text-muted-foreground'>{label}</p>
+      <p className='text-xs font-medium uppercase tracking-wide text-muted-foreground'>
+        {label}
+      </p>
       <p className='mt-2 text-lg font-semibold'>{value}</p>
     </div>
   );
@@ -55,7 +59,8 @@ function BillingOverviewCard({
 
 export default function BillingContractDetailPage() {
   const { contractId } = useParams<{ contractId: string }>();
-  const [contract, setContract] = useState<LimitedContractPaymentSchedule | null>(null);
+  const [contract, setContract] =
+    useState<LimitedContractPaymentSchedule | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [errorState, setErrorState] = useState<
     'not-found' | 'access-denied' | 'load-error' | null
@@ -145,9 +150,13 @@ export default function BillingContractDetailPage() {
           <Button asChild variant='outline' size='sm'>
             <Link to='/billing/contracts'>Back to contracts</Link>
           </Button>
-          <h1 className='text-3xl font-bold tracking-tight'>{contract.clientName}</h1>
+          <h1 className='text-3xl font-bold tracking-tight'>
+            {contract.clientName}
+          </h1>
           <div className='flex flex-wrap items-center gap-3'>
-            <span className='text-muted-foreground'>{contract.contractType}</span>
+            <span className='text-muted-foreground'>
+              {contract.contractType}
+            </span>
             <BillingStatusBadge value={contract.contractStatus} />
           </div>
         </div>
@@ -158,7 +167,9 @@ export default function BillingContractDetailPage() {
             onClick={() => {
               const opened = openContractBillingOutreachEmail(contract);
               if (!opened) {
-                toast.error('Client email is unavailable for billing outreach.');
+                toast.error(
+                  'Client email is unavailable for billing outreach.'
+                );
               }
             }}
             disabled={!contract.clientEmail}
@@ -169,11 +180,19 @@ export default function BillingContractDetailPage() {
       </div>
 
       <div className='grid gap-4 md:grid-cols-2 xl:grid-cols-4'>
-        <BillingOverviewCard label='Contract total' value={formatAmount(contract.totalAmount)} />
-        <BillingOverviewCard label='Deposit amount' value={formatAmount(contract.depositAmount)} />
+        <BillingOverviewCard
+          label='Contract total'
+          value={formatAmount(contract.totalAmount)}
+        />
+        <BillingOverviewCard
+          label='Deposit amount'
+          value={formatAmount(contract.depositAmount)}
+        />
         <BillingOverviewCard
           label='Installments'
-          value={String(contract.installmentCount ?? contract.installments.length)}
+          value={String(
+            contract.installmentCount ?? contract.installments.length
+          )}
         />
         <BillingOverviewCard
           label='Payment schedule'
@@ -186,27 +205,37 @@ export default function BillingContractDetailPage() {
           <h2 className='text-lg font-semibold'>Billing summary</h2>
           <dl className='grid gap-3 sm:grid-cols-2'>
             <div>
-              <dt className='text-xs uppercase tracking-wide text-muted-foreground'>Invoice status</dt>
+              <dt className='text-xs uppercase tracking-wide text-muted-foreground'>
+                Invoice status
+              </dt>
               <dd className='mt-1'>
                 {contract.invoiceStatus ? (
                   <BillingStatusBadge value={contract.invoiceStatus} />
                 ) : (
-                  <span className='text-sm text-muted-foreground'>No invoice connected</span>
+                  <span className='text-sm text-muted-foreground'>
+                    No invoice connected
+                  </span>
                 )}
               </dd>
             </div>
             <div>
-              <dt className='text-xs uppercase tracking-wide text-muted-foreground'>QuickBooks sync</dt>
+              <dt className='text-xs uppercase tracking-wide text-muted-foreground'>
+                QuickBooks sync
+              </dt>
               <dd className='mt-1'>
                 {contract.quickBooksSyncStatus ? (
                   <BillingStatusBadge value={contract.quickBooksSyncStatus} />
                 ) : (
-                  <span className='text-sm text-muted-foreground'>QuickBooks sync unavailable</span>
+                  <span className='text-sm text-muted-foreground'>
+                    QuickBooks sync unavailable
+                  </span>
                 )}
               </dd>
             </div>
             <div>
-              <dt className='text-xs uppercase tracking-wide text-muted-foreground'>Billing setup</dt>
+              <dt className='text-xs uppercase tracking-wide text-muted-foreground'>
+                Billing setup
+              </dt>
               <dd className='mt-1 text-sm'>
                 {formatBillingSetup(contract).length > 0
                   ? formatBillingSetup(contract).join(' • ')
@@ -214,20 +243,30 @@ export default function BillingContractDetailPage() {
               </dd>
             </div>
             <div>
-              <dt className='text-xs uppercase tracking-wide text-muted-foreground'>Created</dt>
+              <dt className='text-xs uppercase tracking-wide text-muted-foreground'>
+                Created
+              </dt>
               <dd className='mt-1 text-sm'>{formatDate(contract.createdAt)}</dd>
             </div>
             <div>
-              <dt className='text-xs uppercase tracking-wide text-muted-foreground'>Sent</dt>
+              <dt className='text-xs uppercase tracking-wide text-muted-foreground'>
+                Sent
+              </dt>
               <dd className='mt-1 text-sm'>{formatDate(contract.sentAt)}</dd>
             </div>
             <div>
-              <dt className='text-xs uppercase tracking-wide text-muted-foreground'>Signed</dt>
+              <dt className='text-xs uppercase tracking-wide text-muted-foreground'>
+                Signed
+              </dt>
               <dd className='mt-1 text-sm'>{formatDate(contract.signedAt)}</dd>
             </div>
             <div>
-              <dt className='text-xs uppercase tracking-wide text-muted-foreground'>Limited view URL</dt>
-              <dd className='mt-1 text-sm break-all'>{contract.limitedViewUrl || 'Generated from route'}</dd>
+              <dt className='text-xs uppercase tracking-wide text-muted-foreground'>
+                Limited view URL
+              </dt>
+              <dd className='mt-1 text-sm break-all'>
+                {contract.limitedViewUrl || 'Generated from route'}
+              </dd>
             </div>
           </dl>
         </div>
@@ -235,8 +274,9 @@ export default function BillingContractDetailPage() {
         <div className='rounded-xl border bg-card p-5 shadow-sm space-y-3'>
           <h2 className='text-lg font-semibold'>Visible fields</h2>
           <p className='text-sm text-muted-foreground'>
-            This billing workspace intentionally excludes CRM intake, care notes, doula assignment data,
-            demographics, and full client profile details.
+            This billing workspace intentionally excludes CRM intake, care
+            notes, doula assignment data, demographics, and full client profile
+            details.
           </p>
         </div>
       </div>
@@ -250,69 +290,102 @@ export default function BillingContractDetailPage() {
         </div>
 
         {contract.installments.length === 0 ? (
-          <div className='p-6 text-sm text-muted-foreground'>No installments available.</div>
+          <div className='p-6 text-sm text-muted-foreground'>
+            No installments available.
+          </div>
         ) : (
           <div className='overflow-x-auto'>
-          <table className='min-w-[640px] w-full text-sm'>
-            <thead className='bg-muted/60'>
-              <tr className='border-b'>
-                <th className='px-4 py-3 text-left font-semibold'>Installment</th>
-                <th className='px-4 py-3 text-left font-semibold'>Due date</th>
-                <th className='px-4 py-3 text-right font-semibold'>Amount</th>
-                <th className='px-4 py-3 text-left font-semibold'>Payment status</th>
-                <th className='px-4 py-3 text-left font-semibold'>Paid date</th>
-                <th className='px-4 py-3 text-left font-semibold'>Invoice</th>
-                <th className='px-4 py-3 text-left font-semibold'>Action</th>
-              </tr>
-            </thead>
-            <tbody>
-              {contract.installments.map((installment) => (
-                <tr key={`${installment.installmentNumber}-${installment.dueDate}`} className='border-b last:border-b-0'>
-                  <td className='px-4 py-3'>#{installment.installmentNumber}</td>
-                  <td className='px-4 py-3'>{formatDate(installment.dueDate)}</td>
-                  <td className='px-4 py-3 text-right'>{formatAmount(installment.amount)}</td>
-                  <td className='px-4 py-3'>
-                    <BillingStatusBadge value={installment.status} />
-                  </td>
-                  <td className='px-4 py-3'>{formatDate(installment.paidDate)}</td>
-                  <td className='px-4 py-3'>
-                    <div className='space-y-1'>
-                      <div>{installment.invoiceId || 'No invoice connected'}</div>
-                      {installment.invoiceStatus ? (
-                        <BillingStatusBadge value={installment.invoiceStatus} />
-                      ) : null}
-                    </div>
-                  </td>
-                  <td className='px-4 py-3'>
-                    <Button
-                      type='button'
-                      variant={isActionRequiredForInstallment(installment) ? 'default' : 'outline'}
-                      size='sm'
-                      disabled={!contract.clientEmail}
-                      onClick={() => {
-                        const opened = openBillingOutreachEmail({
-                          clientName: contract.clientName,
-                          clientEmail: contract.clientEmail,
-                          contractType: contract.contractType,
-                          contractId: contract.contractId,
-                          amount: installment.amount,
-                          dueDate: installment.dueDate,
-                          issueType: installment.paymentIssueType ?? installment.status,
-                          issueSummary: installment.paymentIssueSummary,
-                          installmentNumber: installment.installmentNumber,
-                        });
-                        if (!opened) {
-                          toast.error('Client email is unavailable for billing outreach.');
-                        }
-                      }}
-                    >
-                      Email client
-                    </Button>
-                  </td>
+            <table className='min-w-[640px] w-full text-sm'>
+              <thead className='bg-muted/60'>
+                <tr className='border-b'>
+                  <th className='px-4 py-3 text-left font-semibold'>
+                    Installment
+                  </th>
+                  <th className='px-4 py-3 text-left font-semibold'>
+                    Due date
+                  </th>
+                  <th className='px-4 py-3 text-right font-semibold'>Amount</th>
+                  <th className='px-4 py-3 text-left font-semibold'>
+                    Payment status
+                  </th>
+                  <th className='px-4 py-3 text-left font-semibold'>
+                    Paid date
+                  </th>
+                  <th className='px-4 py-3 text-left font-semibold'>Invoice</th>
+                  <th className='px-4 py-3 text-left font-semibold'>Action</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {contract.installments.map((installment) => (
+                  <tr
+                    key={`${installment.installmentNumber}-${installment.dueDate}`}
+                    className='border-b last:border-b-0'
+                  >
+                    <td className='px-4 py-3'>
+                      #{installment.installmentNumber}
+                    </td>
+                    <td className='px-4 py-3'>
+                      {formatDate(installment.dueDate)}
+                    </td>
+                    <td className='px-4 py-3 text-right'>
+                      {formatAmount(installment.amount)}
+                    </td>
+                    <td className='px-4 py-3'>
+                      <BillingStatusBadge value={installment.status} />
+                    </td>
+                    <td className='px-4 py-3'>
+                      {formatDate(installment.paidDate)}
+                    </td>
+                    <td className='px-4 py-3'>
+                      <div className='space-y-1'>
+                        <div>
+                          {installment.invoiceId || 'No invoice connected'}
+                        </div>
+                        {installment.invoiceStatus ? (
+                          <BillingStatusBadge
+                            value={installment.invoiceStatus}
+                          />
+                        ) : null}
+                      </div>
+                    </td>
+                    <td className='px-4 py-3'>
+                      <Button
+                        type='button'
+                        variant={
+                          isActionRequiredForInstallment(installment)
+                            ? 'default'
+                            : 'outline'
+                        }
+                        size='sm'
+                        disabled={!contract.clientEmail}
+                        onClick={() => {
+                          const opened = openBillingOutreachEmail({
+                            clientName: contract.clientName,
+                            clientEmail: contract.clientEmail,
+                            contractType: contract.contractType,
+                            contractId: contract.contractId,
+                            amount: installment.amount,
+                            dueDate: installment.dueDate,
+                            issueType:
+                              installment.paymentIssueType ??
+                              installment.status,
+                            issueSummary: installment.paymentIssueSummary,
+                            installmentNumber: installment.installmentNumber,
+                          });
+                          if (!opened) {
+                            toast.error(
+                              'Client email is unavailable for billing outreach.'
+                            );
+                          }
+                        }}
+                      >
+                        Email client
+                      </Button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
         )}
       </div>

--- a/src/features/billing-portal/BillingContractsListPage.tsx
+++ b/src/features/billing-portal/BillingContractsListPage.tsx
@@ -16,7 +16,12 @@ import {
 import { BillingState } from '@/features/billing-portal/components/BillingState';
 import { BillingStatusBadge } from '@/features/billing-portal/components/BillingStatusBadge';
 import type { LimitedContractBillingSummary } from '@/features/billing-portal/types';
-import { AlertTriangle, CalendarClock, CircleDollarSign, Search } from 'lucide-react';
+import {
+  AlertTriangle,
+  CalendarClock,
+  CircleDollarSign,
+  Search,
+} from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
@@ -24,8 +29,19 @@ import { toast } from 'sonner';
 
 type DueFilter = 'all' | 'upcoming' | 'past-due' | 'no-due-date';
 type StatusFilter = 'all' | string;
-type ResponsibilityFilter = 'all' | 'insurance' | 'client' | 'split' | 'unknown';
-type PaymentMethodFilter = 'all' | 'card' | 'insurance' | 'ach' | 'invoice' | 'unknown';
+type ResponsibilityFilter =
+  | 'all'
+  | 'insurance'
+  | 'client'
+  | 'split'
+  | 'unknown';
+type PaymentMethodFilter =
+  | 'all'
+  | 'card'
+  | 'insurance'
+  | 'ach'
+  | 'invoice'
+  | 'unknown';
 const PAGE_SIZE_OPTIONS = [10, 25, 50] as const;
 
 function formatAmount(value: number): string {
@@ -67,17 +83,24 @@ function normalizeLabel(value?: string | null): string {
   return (value || '').trim().toLowerCase();
 }
 
-function getResponsibilityBucket(contract: LimitedContractBillingSummary): ResponsibilityFilter {
+function getResponsibilityBucket(
+  contract: LimitedContractBillingSummary
+): ResponsibilityFilter {
   const responsibility = normalizeLabel(contract.billingResponsibility);
   const coverage = normalizeLabel(contract.insuranceCoverageType);
   const deductibleMethod = normalizeLabel(contract.deductiblePaymentMethod);
   const paymentMethod = normalizeLabel(contract.paymentMethodSummary);
 
-  if (responsibility.includes('split') || responsibility.includes('shared')) return 'split';
-  if (coverage.includes('insurance') && (deductibleMethod || paymentMethod.includes('card'))) {
+  if (responsibility.includes('split') || responsibility.includes('shared'))
+    return 'split';
+  if (
+    coverage.includes('insurance') &&
+    (deductibleMethod || paymentMethod.includes('card'))
+  ) {
     return 'split';
   }
-  if (responsibility.includes('insurance') || coverage.includes('insurance')) return 'insurance';
+  if (responsibility.includes('insurance') || coverage.includes('insurance'))
+    return 'insurance';
   if (
     responsibility.includes('client') ||
     responsibility.includes('self-pay') ||
@@ -89,7 +112,9 @@ function getResponsibilityBucket(contract: LimitedContractBillingSummary): Respo
   return 'unknown';
 }
 
-function getPaymentMethodBucket(contract: LimitedContractBillingSummary): PaymentMethodFilter {
+function getPaymentMethodBucket(
+  contract: LimitedContractBillingSummary
+): PaymentMethodFilter {
   const paymentMethod = normalizeLabel(contract.paymentMethodSummary);
   const deductibleMethod = normalizeLabel(contract.deductiblePaymentMethod);
   const combined = `${paymentMethod} ${deductibleMethod}`.trim();
@@ -128,7 +153,9 @@ function BillingMetricCard({
     <div className='rounded-xl border bg-card p-4 shadow-sm'>
       <div className='flex items-center gap-2 text-muted-foreground'>
         {icon}
-        <span className='text-xs font-medium uppercase tracking-wide'>{label}</span>
+        <span className='text-xs font-medium uppercase tracking-wide'>
+          {label}
+        </span>
       </div>
       <div className='mt-3 text-2xl font-semibold tracking-tight'>{value}</div>
     </div>
@@ -136,9 +163,13 @@ function BillingMetricCard({
 }
 
 export default function BillingContractsListPage() {
-  const [contracts, setContracts] = useState<LimitedContractBillingSummary[]>([]);
+  const [contracts, setContracts] = useState<LimitedContractBillingSummary[]>(
+    []
+  );
   const [isLoading, setIsLoading] = useState(true);
-  const [errorState, setErrorState] = useState<'access-denied' | 'load-error' | null>(null);
+  const [errorState, setErrorState] = useState<
+    'access-denied' | 'load-error' | null
+  >(null);
   const [searchTerm, setSearchTerm] = useState('');
   const [dueFilter, setDueFilter] = useState<DueFilter>('all');
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
@@ -209,7 +240,10 @@ export default function BillingContractsListPage() {
         return false;
       }
 
-      if (dueFilter !== 'all' && getDueBucket(contract.nextDueDate) !== dueFilter) {
+      if (
+        dueFilter !== 'all' &&
+        getDueBucket(contract.nextDueDate) !== dueFilter
+      ) {
         return false;
       }
 
@@ -229,27 +263,53 @@ export default function BillingContractsListPage() {
 
       return true;
     });
-  }, [contracts, dueFilter, paymentMethodFilter, responsibilityFilter, searchTerm, statusFilter]);
+  }, [
+    contracts,
+    dueFilter,
+    paymentMethodFilter,
+    responsibilityFilter,
+    searchTerm,
+    statusFilter,
+  ]);
 
   const uniqueStatuses = useMemo(
-    () => Array.from(new Set(contracts.map((contract) => contract.contractStatus))).sort(),
+    () =>
+      Array.from(
+        new Set(contracts.map((contract) => contract.contractStatus))
+      ).sort(),
     [contracts]
   );
 
   const metrics = useMemo(
     () => ({
-      pastDue: contracts.filter((contract) => getDueBucket(contract.nextDueDate) === 'past-due').length,
-      upcoming: contracts.filter((contract) => getDueBucket(contract.nextDueDate) === 'upcoming').length,
-      missingDueDate: contracts.filter((contract) => getDueBucket(contract.nextDueDate) === 'no-due-date').length,
+      pastDue: contracts.filter(
+        (contract) => getDueBucket(contract.nextDueDate) === 'past-due'
+      ).length,
+      upcoming: contracts.filter(
+        (contract) => getDueBucket(contract.nextDueDate) === 'upcoming'
+      ).length,
+      missingDueDate: contracts.filter(
+        (contract) => getDueBucket(contract.nextDueDate) === 'no-due-date'
+      ).length,
     }),
     [contracts]
   );
 
   useEffect(() => {
     setPageIndex(0);
-  }, [searchTerm, dueFilter, statusFilter, responsibilityFilter, paymentMethodFilter, pageSize]);
+  }, [
+    searchTerm,
+    dueFilter,
+    statusFilter,
+    responsibilityFilter,
+    paymentMethodFilter,
+    pageSize,
+  ]);
 
-  const totalPages = Math.max(1, Math.ceil(filteredContracts.length / pageSize));
+  const totalPages = Math.max(
+    1,
+    Math.ceil(filteredContracts.length / pageSize)
+  );
   const paginatedContracts = useMemo(() => {
     const start = pageIndex * pageSize;
     return filteredContracts.slice(start, start + pageSize);
@@ -293,7 +353,8 @@ export default function BillingContractsListPage() {
       <div className='space-y-2'>
         <h1 className='text-3xl font-bold tracking-tight'>Payment Schedules</h1>
         <p className='text-muted-foreground'>
-          Limited billing-safe contract and installment visibility for internal payment follow-up.
+          Limited billing-safe contract and installment visibility for internal
+          payment follow-up.
         </p>
       </div>
 
@@ -333,7 +394,10 @@ export default function BillingContractsListPage() {
                   className='pl-9'
                 />
               </div>
-              <Select value={dueFilter} onValueChange={(value) => setDueFilter(value as DueFilter)}>
+              <Select
+                value={dueFilter}
+                onValueChange={(value) => setDueFilter(value as DueFilter)}
+              >
                 <SelectTrigger className='w-[180px]'>
                   <SelectValue placeholder='Due timing' />
                 </SelectTrigger>
@@ -346,7 +410,9 @@ export default function BillingContractsListPage() {
               </Select>
               <Select
                 value={statusFilter}
-                onValueChange={(value) => setStatusFilter(value as StatusFilter)}
+                onValueChange={(value) =>
+                  setStatusFilter(value as StatusFilter)
+                }
               >
                 <SelectTrigger className='w-[160px]'>
                   <SelectValue placeholder='Contract status' />
@@ -373,7 +439,9 @@ export default function BillingContractsListPage() {
                   <SelectItem value='all'>All payers</SelectItem>
                   <SelectItem value='insurance'>Insurance</SelectItem>
                   <SelectItem value='client'>Client / self-pay</SelectItem>
-                  <SelectItem value='split'>Split insurance + client</SelectItem>
+                  <SelectItem value='split'>
+                    Split insurance + client
+                  </SelectItem>
                   <SelectItem value='unknown'>Unavailable</SelectItem>
                 </SelectContent>
               </Select>
@@ -417,67 +485,98 @@ export default function BillingContractsListPage() {
               )}
             </div>
             <p className='mt-3 text-sm text-muted-foreground'>
-              {filteredContracts.length} of {contracts.length} payment schedules shown
+              {filteredContracts.length} of {contracts.length} payment schedules
+              shown
             </p>
           </div>
           <div className='overflow-x-auto'>
-          <table className='min-w-[720px] w-full text-sm'>
-            <thead className='bg-muted/60'>
-              <tr className='border-b'>
-                <th className='px-4 py-3 text-left font-semibold'>Client</th>
-                <th className='px-4 py-3 text-left font-semibold'>Contract</th>
-                <th className='px-4 py-3 text-left font-semibold'>Billing setup</th>
-                <th className='px-4 py-3 text-left font-semibold'>Status</th>
-                <th className='px-4 py-3 text-right font-semibold'>Total</th>
-                <th className='px-4 py-3 text-left font-semibold'>Schedule</th>
-                <th className='px-4 py-3 text-left font-semibold'>Next due</th>
-                <th className='px-4 py-3 text-left font-semibold'>Actions</th>
-              </tr>
-            </thead>
-            <tbody>
-              {paginatedContracts.map((contract) => (
-                <tr key={contract.contractId} className='border-b last:border-b-0'>
-                  <td className='px-4 py-3'>{contract.clientName}</td>
-                  <td className='px-4 py-3'>
-                    <div className='font-medium'>{contract.contractType}</div>
-                    <div className='text-xs text-muted-foreground'>
-                      {contract.installmentCount ?? 0} installments
-                    </div>
-                  </td>
-                  <td className='px-4 py-3'>
-                    <div className='max-w-[280px] text-sm'>{formatBillingContext(contract)}</div>
-                  </td>
-                  <td className='px-4 py-3'>
-                    <BillingStatusBadge value={contract.contractStatus} />
-                  </td>
-                  <td className='px-4 py-3 text-right'>{formatAmount(contract.totalAmount)}</td>
-                  <td className='px-4 py-3'>{contract.paymentSchedule || 'Schedule unavailable'}</td>
-                  <td className='px-4 py-3'>{formatDate(contract.nextDueDate)}</td>
-                  <td className='px-4 py-3'>
-                    <div className='flex flex-wrap gap-2'>
-                      <Button asChild variant='outline' size='sm'>
-                        <Link to={`/billing/contracts/${contract.contractId}`}>View schedule</Link>
-                      </Button>
-                      <Button
-                        type='button'
-                        variant={isActionRequiredForContract(contract) ? 'default' : 'outline'}
-                        size='sm'
-                        disabled={!contract.clientEmail}
-                        onClick={() => {
-                          const opened = openContractBillingOutreachEmail(contract);
-                          if (!opened) {
-                            toast.error('Client email is unavailable for billing outreach.');
-                          }
-                        }}
-                      >
-                        Email client
-                      </Button>
-                    </div>
-                  </td>
+            <table className='min-w-[720px] w-full text-sm'>
+              <thead className='bg-muted/60'>
+                <tr className='border-b'>
+                  <th className='px-4 py-3 text-left font-semibold'>Client</th>
+                  <th className='px-4 py-3 text-left font-semibold'>
+                    Contract
+                  </th>
+                  <th className='px-4 py-3 text-left font-semibold'>
+                    Billing setup
+                  </th>
+                  <th className='px-4 py-3 text-left font-semibold'>Status</th>
+                  <th className='px-4 py-3 text-right font-semibold'>Total</th>
+                  <th className='px-4 py-3 text-left font-semibold'>
+                    Schedule
+                  </th>
+                  <th className='px-4 py-3 text-left font-semibold'>
+                    Next due
+                  </th>
+                  <th className='px-4 py-3 text-left font-semibold'>Actions</th>
                 </tr>
-              ))}
-            </tbody>
-          </table>
+              </thead>
+              <tbody>
+                {paginatedContracts.map((contract) => (
+                  <tr
+                    key={contract.contractId}
+                    className='border-b last:border-b-0'
+                  >
+                    <td className='px-4 py-3'>{contract.clientName}</td>
+                    <td className='px-4 py-3'>
+                      <div className='font-medium'>{contract.contractType}</div>
+                      <div className='text-xs text-muted-foreground'>
+                        {contract.installmentCount ?? 0} installments
+                      </div>
+                    </td>
+                    <td className='px-4 py-3'>
+                      <div className='max-w-[280px] text-sm'>
+                        {formatBillingContext(contract)}
+                      </div>
+                    </td>
+                    <td className='px-4 py-3'>
+                      <BillingStatusBadge value={contract.contractStatus} />
+                    </td>
+                    <td className='px-4 py-3 text-right'>
+                      {formatAmount(contract.totalAmount)}
+                    </td>
+                    <td className='px-4 py-3'>
+                      {contract.paymentSchedule || 'Schedule unavailable'}
+                    </td>
+                    <td className='px-4 py-3'>
+                      {formatDate(contract.nextDueDate)}
+                    </td>
+                    <td className='px-4 py-3'>
+                      <div className='flex flex-wrap gap-2'>
+                        <Button asChild variant='outline' size='sm'>
+                          <Link
+                            to={`/billing/contracts/${contract.contractId}`}
+                          >
+                            View schedule
+                          </Link>
+                        </Button>
+                        <Button
+                          type='button'
+                          variant={
+                            isActionRequiredForContract(contract)
+                              ? 'default'
+                              : 'outline'
+                          }
+                          size='sm'
+                          disabled={!contract.clientEmail}
+                          onClick={() => {
+                            const opened =
+                              openContractBillingOutreachEmail(contract);
+                            if (!opened) {
+                              toast.error(
+                                'Client email is unavailable for billing outreach.'
+                              );
+                            }
+                          }}
+                        >
+                          Email client
+                        </Button>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
           </div>
           {filteredContracts.length === 0 ? (
             <div className='border-t p-6 text-sm text-muted-foreground'>
@@ -512,7 +611,9 @@ export default function BillingContractsListPage() {
                   variant='outline'
                   size='sm'
                   disabled={pageIndex === 0}
-                  onClick={() => setPageIndex((current) => Math.max(0, current - 1))}
+                  onClick={() =>
+                    setPageIndex((current) => Math.max(0, current - 1))
+                  }
                 >
                   Previous
                 </Button>
@@ -522,7 +623,9 @@ export default function BillingContractsListPage() {
                   size='sm'
                   disabled={pageIndex >= totalPages - 1}
                   onClick={() =>
-                    setPageIndex((current) => Math.min(totalPages - 1, current + 1))
+                    setPageIndex((current) =>
+                      Math.min(totalPages - 1, current + 1)
+                    )
                   }
                 >
                   Next

--- a/src/features/billing-portal/BillingContractsListPage.tsx
+++ b/src/features/billing-portal/BillingContractsListPage.tsx
@@ -289,7 +289,7 @@ export default function BillingContractsListPage() {
   }
 
   return (
-    <div className='p-6 space-y-6 overflow-y-auto'>
+    <div className='min-w-0 space-y-6 overflow-y-auto p-4 sm:p-6'>
       <div className='space-y-2'>
         <h1 className='text-3xl font-bold tracking-tight'>Payment Schedules</h1>
         <p className='text-muted-foreground'>
@@ -321,10 +321,10 @@ export default function BillingContractsListPage() {
           description='Payment schedules will appear here when billing-safe contracts are available.'
         />
       ) : (
-        <div className='rounded-xl border bg-card shadow-sm overflow-hidden'>
+        <div className='overflow-hidden rounded-xl border bg-card shadow-sm'>
           <div className='border-b p-4'>
             <div className='flex flex-wrap items-center gap-3'>
-              <div className='relative min-w-[240px] flex-1'>
+              <div className='relative min-w-0 w-full flex-1 sm:min-w-[240px]'>
                 <Search className='pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground' />
                 <Input
                   value={searchTerm}
@@ -420,7 +420,8 @@ export default function BillingContractsListPage() {
               {filteredContracts.length} of {contracts.length} payment schedules shown
             </p>
           </div>
-          <table className='min-w-full text-sm'>
+          <div className='overflow-x-auto'>
+          <table className='min-w-[720px] w-full text-sm'>
             <thead className='bg-muted/60'>
               <tr className='border-b'>
                 <th className='px-4 py-3 text-left font-semibold'>Client</th>
@@ -477,6 +478,7 @@ export default function BillingContractsListPage() {
               ))}
             </tbody>
           </table>
+          </div>
           {filteredContracts.length === 0 ? (
             <div className='border-t p-6 text-sm text-muted-foreground'>
               No payment schedules match the current filters.

--- a/src/features/client-dashboard/ClientDashboard.tsx
+++ b/src/features/client-dashboard/ClientDashboard.tsx
@@ -67,10 +67,10 @@ export default function ClientDashboard({ view = 'profile' }: ClientDashboardPro
 
   return (
     <>
-      <main className='w-full max-w-screen overflow-x-hidden px-4 py-6'>
-        <div className='p-6'>
+      <main className='w-full min-w-0 max-w-screen overflow-x-hidden px-4 py-6'>
+        <div className='min-w-0'>
           <div className='mb-6'>
-            <h1 className='text-3xl font-bold text-gray-900'>
+            <h1 className='text-2xl font-bold text-gray-900 sm:text-3xl'>
               {view === 'billing' ? 'Billing information' : 'Profile information'}
             </h1>
             <p className='mt-1 text-gray-600'>

--- a/src/features/client-dashboard/ClientDashboard.tsx
+++ b/src/features/client-dashboard/ClientDashboard.tsx
@@ -16,9 +16,12 @@ interface ClientDashboardProps {
 }
 
 /** Client-facing area: profile only (no org metrics or staff CRM). */
-export default function ClientDashboard({ view = 'profile' }: ClientDashboardProps) {
+export default function ClientDashboard({
+  view = 'profile',
+}: ClientDashboardProps) {
   const { client, isLoading: clientAuthLoading } = useClientAuth();
-  const { isClientPortalUser, isLoading: portalLoading } = useIsClientPortalUser();
+  const { isClientPortalUser, isLoading: portalLoading } =
+    useIsClientPortalUser();
   const { user } = useUser();
   const isLoading = clientAuthLoading || portalLoading;
 
@@ -71,7 +74,9 @@ export default function ClientDashboard({ view = 'profile' }: ClientDashboardPro
         <div className='min-w-0'>
           <div className='mb-6'>
             <h1 className='text-2xl font-bold text-gray-900 sm:text-3xl'>
-              {view === 'billing' ? 'Billing information' : 'Profile information'}
+              {view === 'billing'
+                ? 'Billing information'
+                : 'Profile information'}
             </h1>
             <p className='mt-1 text-gray-600'>
               Welcome, {welcomeName}.{' '}
@@ -89,7 +94,9 @@ export default function ClientDashboard({ view = 'profile' }: ClientDashboardPro
                 >
                   Service Outcomes
                 </a>
-                <span className='ml-2 text-sm text-gray-500'>(opens in a new tab)</span>
+                <span className='ml-2 text-sm text-gray-500'>
+                  (opens in a new tab)
+                </span>
               </p>
             ) : null}
           </div>

--- a/src/features/client-dashboard/components/ClientProfileTab.tsx
+++ b/src/features/client-dashboard/components/ClientProfileTab.tsx
@@ -269,7 +269,7 @@ export default function ClientProfileTab({
         token = undefined;
       }
 
-      const response = await fetch(
+      const response = await fetchWithAuth(
         `${getClientApiBase()}/clients/${effectiveClientId}/assigned-doulas`,
         {
           method: 'GET',
@@ -326,7 +326,7 @@ export default function ClientProfileTab({
         token = undefined;
       }
 
-      const response = await fetch(
+      const response = await fetchWithAuth(
         `${getClientApiBase()}/clients/${effectiveClientId}/activities`,
         {
           method: 'GET',
@@ -382,7 +382,7 @@ export default function ClientProfileTab({
         token = undefined;
       }
 
-      const response = await fetch(
+      const response = await fetchWithAuth(
         `${getClientApiBase()}/clients/${effectiveClientId}?detailed=true`,
         {
           method: 'GET',
@@ -748,7 +748,7 @@ export default function ClientProfileTab({
       }
 
       if (view === 'profile') {
-        const response = await fetch(
+        const response = await fetchWithAuth(
           `${getClientApiBase()}/clients/${effectiveClientId}`,
           {
             method: 'PUT',
@@ -934,7 +934,7 @@ export default function ClientProfileTab({
 
         if (!billingResponse.ok) {
           if (isEndpointUnavailableStatus(billingResponse.status)) {
-            const legacyBillingResponse = await fetch(
+            const legacyBillingResponse = await fetchWithAuth(
               `${getClientApiBase()}/clients/${effectiveClientId}`,
               {
                 method: 'PUT',
@@ -1078,7 +1078,7 @@ export default function ClientProfileTab({
         return;
       }
 
-      const response = await fetch(
+      const response = await fetchWithAuth(
         `${getClientApiBase()}/clients/${effectiveClientId}`,
         {
           method: 'PUT',
@@ -1152,7 +1152,7 @@ export default function ClientProfileTab({
       if (!billingResponse.ok) {
         if (isEndpointUnavailableStatus(billingResponse.status)) {
           // Backward compatibility fallback to existing profile endpoint.
-          const legacyBillingResponse = await fetch(
+          const legacyBillingResponse = await fetchWithAuth(
             `${getClientApiBase()}/clients/${effectiveClientId}`,
             {
               method: 'PUT',
@@ -1417,7 +1417,7 @@ export default function ClientProfileTab({
       const url =
         documentItem.url ||
         (await getClientDocumentUrl('client-self', documentItem.id));
-      const response = await fetch(url, {
+      const response = await fetchWithAuth(url, {
         credentials: 'omit',
         mode: 'cors',
       });
@@ -1763,7 +1763,7 @@ export default function ClientProfileTab({
                 </div>
               </div>
 
-              <div className='grid grid-cols-2 gap-3'>
+              <div className='grid grid-cols-1 gap-3 md:grid-cols-2'>
                 <div className='space-y-2'>
                   <Label htmlFor='firstname'>First Name</Label>
                   <Input
@@ -1829,7 +1829,7 @@ export default function ClientProfileTab({
                 />
               </div>
 
-              <div className='grid grid-cols-3 gap-3'>
+              <div className='grid grid-cols-1 gap-3 md:grid-cols-3'>
                 <div className='space-y-2'>
                   <Label htmlFor='city'>City</Label>
                   <Input
@@ -2182,7 +2182,7 @@ export default function ClientProfileTab({
                         />
                       </div>
 
-                      <div className='grid grid-cols-2 gap-3'>
+                      <div className='grid grid-cols-1 gap-3 md:grid-cols-2'>
                         <div className='space-y-1.5'>
                           <Label htmlFor='insurance_member_id'>
                             Member ID / Subscriber ID *
@@ -2302,7 +2302,7 @@ export default function ClientProfileTab({
                                 disabled={isBillingFormDisabled}
                               />
                             </div>
-                            <div className='grid grid-cols-2 gap-3'>
+                            <div className='grid grid-cols-1 gap-3 md:grid-cols-2'>
                               <div className='space-y-1.5'>
                                 <Label htmlFor='secondary_insurance_member_id'>
                                   Secondary Member ID *

--- a/src/features/clients/__tests__/useSaveUser.test.tsx
+++ b/src/features/clients/__tests__/useSaveUser.test.tsx
@@ -2,8 +2,31 @@ import useSaveUser from '@/common/hooks/user/useSaveUser';
 import { ROLE, User } from '@/common/utils/User';
 import { vi } from 'vitest';
 
-// Mock fetch
+vi.mock('@/api/sessionAccessToken', () => ({
+  getSessionAccessToken: () => null,
+}));
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: async () => ({ data: { session: null } }),
+    },
+  },
+}));
+
 global.fetch = vi.fn();
+
+function expectUpdateUserFetch(userData: User) {
+  expect(global.fetch).toHaveBeenCalledTimes(1);
+  const [url, init] = (global.fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+  expect(url).toBe('http://localhost:5050/users/update');
+  expect(init.method).toBe('PUT');
+  expect(init.credentials).toBe('include');
+  expect(init.body).toBe(JSON.stringify(userData));
+  expect(new Headers(init.headers).get('Content-Type')).toBe(
+    'application/json'
+  );
+}
 
 // Mock localStorage
 const mockLocalStorage = {
@@ -41,17 +64,7 @@ describe('useSaveUser', () => {
       const result = await useSaveUser(mockUserData);
 
       expect(result).toEqual(mockResponse);
-      expect(global.fetch).toHaveBeenCalledWith(
-        'http://localhost:5050/users/update',
-        {
-          method: 'PUT',
-          credentials: 'include',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(mockUserData),
-        }
-      );
+      expectUpdateUserFetch(mockUserData);
     });
 
     it('should handle user data with all fields', async () => {
@@ -74,17 +87,7 @@ describe('useSaveUser', () => {
       const result = await useSaveUser(mockUserData);
 
       expect(result).toEqual(mockResponse);
-      expect(global.fetch).toHaveBeenCalledWith(
-        'http://localhost:5050/users/update',
-        {
-          method: 'PUT',
-          credentials: 'include',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(mockUserData),
-        }
-      );
+      expectUpdateUserFetch(mockUserData);
     });
   });
 
@@ -104,7 +107,9 @@ describe('useSaveUser', () => {
         statusText: 'Bad Request',
       });
 
-      await expect(useSaveUser(mockUserData)).rejects.toThrow('Failed to save user');
+      await expect(useSaveUser(mockUserData)).rejects.toThrow(
+        'Failed to save user'
+      );
     });
 
     it('should throw error on network failure', async () => {
@@ -130,7 +135,9 @@ describe('useSaveUser', () => {
       } as User;
 
       // This should trigger the console.assert in the hook
-      const consoleSpy = vi.spyOn(console, 'assert').mockImplementation(() => { });
+      const consoleSpy = vi
+        .spyOn(console, 'assert')
+        .mockImplementation(() => {});
 
       (global.fetch as any).mockResolvedValueOnce({
         ok: true,
@@ -213,17 +220,7 @@ describe('useSaveUser', () => {
 
       await useSaveUser(mockUserData);
 
-      expect(global.fetch).toHaveBeenCalledWith(
-        'http://localhost:5050/users/update',
-        {
-          method: 'PUT',
-          credentials: 'include',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(mockUserData),
-        }
-      );
+      expectUpdateUserFetch(mockUserData);
     });
 
     it('should handle special characters in user data', async () => {
@@ -242,17 +239,7 @@ describe('useSaveUser', () => {
 
       await useSaveUser(mockUserData);
 
-      expect(global.fetch).toHaveBeenCalledWith(
-        'http://localhost:5050/users/update',
-        {
-          method: 'PUT',
-          credentials: 'include',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-          body: JSON.stringify(mockUserData),
-        }
-      );
+      expectUpdateUserFetch(mockUserData);
     });
   });
-}); 
+});

--- a/src/features/clients/components/data-table-pagination.tsx
+++ b/src/features/clients/components/data-table-pagination.tsx
@@ -24,8 +24,7 @@ export function DataTablePagination<TData>({
 }: DataTablePaginationProps<TData>) {
   return (
     <div
-      className='flex items-center justify-between overflow-clip px-2'
-      style={{ overflowClipMargin: 1 }}
+      className='flex flex-wrap items-center justify-between gap-2 px-2'
     >
       <div className='hidden flex-1 text-sm text-muted-foreground sm:block'>
         {table.getFilteredSelectedRowModel().rows.length} of{' '}

--- a/src/features/clients/components/data-table-pagination.tsx
+++ b/src/features/clients/components/data-table-pagination.tsx
@@ -23,9 +23,7 @@ export function DataTablePagination<TData>({
   table,
 }: DataTablePaginationProps<TData>) {
   return (
-    <div
-      className='flex flex-wrap items-center justify-between gap-2 px-2'
-    >
+    <div className='flex flex-wrap items-center justify-between gap-2 px-2'>
       <div className='hidden flex-1 text-sm text-muted-foreground sm:block'>
         {table.getFilteredSelectedRowModel().rows.length} of{' '}
         {table.getFilteredRowModel().rows.length} row(s) selected.

--- a/src/features/clients/components/dialog/EnhancedContractDialog.tsx
+++ b/src/features/clients/components/dialog/EnhancedContractDialog.tsx
@@ -539,31 +539,6 @@ export function EnhancedContractDialog({ open, onOpenChange }: Props) {
         toast.success(
           `Contract generated successfully! Document ID: ${response.data.contractId}. Client will receive an email to sign the contract.`
         );
-
-        // Log the response for debugging
-        console.log('Contract generated successfully:', {
-          contractId: response.data.contractId,
-          signNow: response.data.signNow,
-          emailDelivery: response.data.emailDelivery,
-        });
-
-        // Store contract verification data in localStorage for future payment integration
-        const contractVerificationData = {
-          contractId: response.data.contractId,
-          clientEmail: clientData.email,
-          clientName: clientData.name,
-          timestamp: Date.now(),
-          amounts: calculatedAmounts,
-        };
-        localStorage.setItem(
-          'contractVerification',
-          JSON.stringify(contractVerificationData)
-        );
-
-        console.log(
-          'Stored contract verification data:',
-          contractVerificationData
-        );
       } else {
         toast.error('Failed to generate contract');
       }
@@ -634,7 +609,7 @@ export function EnhancedContractDialog({ open, onOpenChange }: Props) {
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className='max-w-4xl max-h-[90vh] overflow-y-auto'>
+      <DialogContent className='left-0 top-0 h-[100dvh] max-h-[100dvh] w-full max-w-full translate-x-0 translate-y-0 overflow-y-auto rounded-none sm:left-[50%] sm:top-[50%] sm:h-auto sm:max-h-[90vh] sm:max-w-4xl sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg'>
         <DialogHeader>
           <DialogTitle className='flex items-center gap-2'>
             <Calculator className='h-5 w-5' />
@@ -734,7 +709,7 @@ export function EnhancedContractDialog({ open, onOpenChange }: Props) {
                                   </span>
                                 </div>
                               ) : (
-                                <div className='grid grid-cols-2 gap-3'>
+                                <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
                                   <div className='flex items-center gap-2'>
                                     <span className='text-sm text-gray-500'>
                                       $

--- a/src/features/clients/components/dialog/EnhancedContractDialog.tsx
+++ b/src/features/clients/components/dialog/EnhancedContractDialog.tsx
@@ -111,11 +111,13 @@ export function buildInstallmentAmounts(
 
   const balanceCents = Math.round(Math.max(balanceAmount, 0) * 100);
   const baseInstallmentCents = Math.floor(balanceCents / installmentsCount);
-  const remainderCents = balanceCents - baseInstallmentCents * installmentsCount;
+  const remainderCents =
+    balanceCents - baseInstallmentCents * installmentsCount;
 
   return Array.from({ length: installmentsCount }, (_, index) => {
     const installmentCents =
-      baseInstallmentCents + (index === installmentsCount - 1 ? remainderCents : 0);
+      baseInstallmentCents +
+      (index === installmentsCount - 1 ? remainderCents : 0);
     return installmentCents / 100;
   });
 }
@@ -339,7 +341,9 @@ export function EnhancedContractDialog({ open, onOpenChange }: Props) {
           depositType,
           depositValue
         );
-        const balanceAmount = roundToCents(Math.max(totalAmount - depositAmount, 0));
+        const balanceAmount = roundToCents(
+          Math.max(totalAmount - depositAmount, 0)
+        );
 
         const localAmounts: CalculatedAmounts = {
           total_amount: totalAmount,
@@ -388,7 +392,9 @@ export function EnhancedContractDialog({ open, onOpenChange }: Props) {
           depositValue > 0
             ? calculateDepositAmount(totalAmount, depositType, depositValue)
             : 0;
-        const balanceAmount = roundToCents(Math.max(totalAmount - depositAmount, 0));
+        const balanceAmount = roundToCents(
+          Math.max(totalAmount - depositAmount, 0)
+        );
 
         const localAmounts: CalculatedAmounts = {
           total_amount: totalAmount,

--- a/src/features/clients/components/dialog/LeadProfileModal.tsx
+++ b/src/features/clients/components/dialog/LeadProfileModal.tsx
@@ -1,7 +1,15 @@
-import { ClientNote, createClientNote, getClientNotes } from '@/api/clients/notes';
+import {
+  ClientNote,
+  createClientNote,
+  getClientNotes,
+} from '@/api/clients/notes';
 import { Button } from '@/common/components/ui/button';
 import { Calendar } from '@/common/components/ui/calendar';
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/common/components/ui/collapsible';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/common/components/ui/collapsible';
 import {
   Dialog,
   DialogContent,
@@ -18,13 +26,26 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/common/components/ui/popover';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/common/components/ui/select';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/common/components/ui/select';
 import { Textarea } from '@/common/components/ui/textarea';
 import { useClients } from '@/common/hooks/clients/useClients';
 import { UserContext } from '@/common/contexts/UserContext';
 import updateClient from '@/common/utils/updateClient';
 import updateClientStatus from '@/common/utils/updateClientStatus';
-import { updateClientPhi, fetchClientPaymentSchedule, fetchCardOnFileStatus, generateInstallmentInvoice, type PaymentInstallment, type CardOnFileStatus } from '@/api/services/clients.service';
+import {
+  updateClientPhi,
+  fetchClientPaymentSchedule,
+  fetchCardOnFileStatus,
+  generateInstallmentInvoice,
+  type PaymentInstallment,
+  type CardOnFileStatus,
+} from '@/api/services/clients.service';
 import { buildUrl, fetchWithAuth } from '@/api/http';
 import { PHI_KEYS } from '@/config/phi';
 import { Client } from '@/features/clients/data/schema';
@@ -48,11 +69,11 @@ import {
   Phone,
   Save,
   User,
-  Users
+  Users,
 } from 'lucide-react';
 import React, { useContext, useState } from 'react';
 import { toast } from 'sonner';
-import { DoulaAssignment } from '../DoulaAssignment';
+import { DoulaAssignment } from '@/features/clients/components/DoulaAssignment';
 import {
   compareClientDocumentsByUploadedAtDesc,
   getClientDocumentLabel,
@@ -91,9 +112,7 @@ import {
   REFERRAL_SOURCE_OPTIONS,
   REFERRAL_SOURCE_OTHER_VALUE,
 } from '@/features/request/referralSourceOptions';
-import {
-  HOME_PEOPLE_COUNT_OPTIONS,
-} from '@/features/request/homePeopleCountOptions';
+import { HOME_PEOPLE_COUNT_OPTIONS } from '@/features/request/homePeopleCountOptions';
 import {
   HOME_TYPE_OPTIONS,
   HOME_TYPE_OTHER_VALUE,
@@ -109,26 +128,79 @@ interface LeadProfileModalProps {
   missingClientId?: string;
 }
 
-const NOTE_CATEGORIES = ['General', 'Communication', 'Milestone', 'Follow-up', 'Health', 'Billing'];
+const NOTE_CATEGORIES = [
+  'General',
+  'Communication',
+  'Milestone',
+  'Follow-up',
+  'Health',
+  'Billing',
+];
 
 // Dropdown options from request form (exact matches)
-const PRONOUNS_OPTIONS = ['She/Her', 'He/Him', 'They/Them', 'Ze/Hir/Zir', 'None', 'Other'];
+const PRONOUNS_OPTIONS = [
+  'She/Her',
+  'He/Him',
+  'They/Them',
+  'Ze/Hir/Zir',
+  'None',
+  'Other',
+];
 const PREFERRED_CONTACT_OPTIONS = ['Phone', 'Text', 'Email'];
-const RELATIONSHIP_OPTIONS = ['Spouse', 'Partner', 'Friend', 'Parent', 'Sibling', 'Other'];
-const FAMILY_PRONOUNS_OPTIONS = ['She/Her', 'He/Him', 'They/Them', 'Ze/Hir/Zir', 'None'];
-const SERVICES_OPTIONS = ['Labor Support', 'Postpartum Support', '1st Night Care', 'Lactation Support', 'Perinatal Education', 'Abortion Support', 'Other'];
+const RELATIONSHIP_OPTIONS = [
+  'Spouse',
+  'Partner',
+  'Friend',
+  'Parent',
+  'Sibling',
+  'Other',
+];
+const FAMILY_PRONOUNS_OPTIONS = [
+  'She/Her',
+  'He/Him',
+  'They/Them',
+  'Ze/Hir/Zir',
+  'None',
+];
+const SERVICES_OPTIONS = [
+  'Labor Support',
+  'Postpartum Support',
+  '1st Night Care',
+  'Lactation Support',
+  'Perinatal Education',
+  'Abortion Support',
+  'Other',
+];
 const ANNUAL_INCOME_OPTIONS = [
   '$0-$24,999',
   '$25,000-$44,999',
   '$45,000-$64,999',
   '$65,000-$84,999',
   '$85,000-$99,999',
-  '100k and above'
+  '100k and above',
 ];
-const RACE_OPTIONS = ['African American/Black', 'Asian/Pacific Islander', 'Caucasian/White', 'Hispanic', 'Two or more races', 'Other'];
-const LANGUAGE_OPTIONS = ['English', 'Spanish', 'French', 'Mandarin', 'Arabic', 'Other'];
+const RACE_OPTIONS = [
+  'African American/Black',
+  'Asian/Pacific Islander',
+  'Caucasian/White',
+  'Hispanic',
+  'Two or more races',
+  'Other',
+];
+const LANGUAGE_OPTIONS = [
+  'English',
+  'Spanish',
+  'French',
+  'Mandarin',
+  'Arabic',
+  'Other',
+];
 const AGE_OPTIONS = ['Under 20', '20-25', '26-35', '36 and older'];
-const INSURANCE_OPTIONS = ['Private', 'Public Aid', "Currently don't have medical insurance"];
+const INSURANCE_OPTIONS = [
+  'Private',
+  'Public Aid',
+  "Currently don't have medical insurance",
+];
 const DEMOGRAPHICS_MULTI_OPTIONS = [
   'Annual income is less than $30,000',
   'Identify as a person of color',
@@ -141,7 +213,7 @@ const DEMOGRAPHICS_MULTI_OPTIONS = [
   'Refugee or religious minority',
   'Active Military or Veteran Status',
   'None apply',
-  'Other:'
+  'Other:',
 ];
 const DEMOGRAPHICS_INCOME_OPTIONS = [
   '$0-$24,999',
@@ -149,7 +221,7 @@ const DEMOGRAPHICS_INCOME_OPTIONS = [
   '$45,000-$64,999',
   '$65,000-$84,999',
   '$85,000-$99,999',
-  '$100,000 and above'
+  '$100,000 and above',
 ];
 const CLIENT_STATUS_OPTIONS = [
   'lead',
@@ -173,7 +245,7 @@ const NUMBER_OF_BABIES_OPTIONS = [
   'Quintuplets',
   'Sextuplets',
   'Septuplets',
-  'Octuplets'
+  'Octuplets',
 ];
 const PROVIDER_TYPE_OPTIONS = ['Midwife', 'OB', 'Family Doctor', 'Other'];
 
@@ -197,7 +269,9 @@ function isSelfPayMethod(method: string): boolean {
   return sharedIsSelfPayMethod(method);
 }
 
-function hasAnyInsuranceDetails(source: Record<string, unknown> | null | undefined): boolean {
+function hasAnyInsuranceDetails(
+  source: Record<string, unknown> | null | undefined
+): boolean {
   if (!source) return false;
   const fields = [
     'insurance_policy_holder_name',
@@ -231,7 +305,9 @@ function hasAnyInsuranceDetails(source: Record<string, unknown> | null | undefin
 }
 
 function normalizeLifecycleStatus(value: unknown): string {
-  const raw = String(value ?? '').trim().toLowerCase();
+  const raw = String(value ?? '')
+    .trim()
+    .toLowerCase();
   if (raw === 'matching') return 'matched';
   if (raw === 'customer') return 'not hired';
   return String(value ?? '').trim();
@@ -263,7 +339,9 @@ export function LeadProfileModal({
   const [savingNote, setSavingNote] = useState(false);
   const [notesError, setNotesError] = useState<string | null>(null);
   /** Include `notes` so Admin Notes + history are visible when the profile opens (audit trail is primary for this block). */
-  const [openSections, setOpenSections] = useState<Set<string>>(new Set(['contact', 'services', 'notes']));
+  const [openSections, setOpenSections] = useState<Set<string>>(
+    new Set(['contact', 'services', 'notes'])
+  );
   const [isEditing, setIsEditing] = useState(false);
   const [editedData, setEditedData] = useState<Partial<Client>>({});
   const [isSaving, setIsSaving] = useState(false);
@@ -273,17 +351,25 @@ export function LeadProfileModal({
   const [billingLoading, setBillingLoading] = useState(false);
   const [billingError, setBillingError] = useState<string | null>(null);
   const [isGeneratingInvoice, setIsGeneratingInvoice] = useState(false);
-  const [generatedInvoiceLink, setGeneratedInvoiceLink] = useState<string | null>(null);
+  const [generatedInvoiceLink, setGeneratedInvoiceLink] = useState<
+    string | null
+  >(null);
   const [isSavingBirthOutcomes, setIsSavingBirthOutcomes] = useState(false);
   // Primary source for display: full detail from GET /clients/:id (authorized users get PHI).
   const [fetchedDetail, setFetchedDetail] = useState<ClientDetail | null>(null);
   const [clientDocuments, setClientDocuments] = useState<ClientDocument[]>([]);
   const [documentsLoading, setDocumentsLoading] = useState(false);
   const [activeDocumentId, setActiveDocumentId] = useState<string | null>(null);
-  const [documentPreviewUrls, setDocumentPreviewUrls] = useState<Record<string, string>>({});
+  const [documentPreviewUrls, setDocumentPreviewUrls] = useState<
+    Record<string, string>
+  >({});
   const currentUserDisplayName = React.useMemo(() => {
-    const first = String(user?.firstname ?? (user as any)?.first_name ?? '').trim();
-    const last = String(user?.lastname ?? (user as any)?.last_name ?? '').trim();
+    const first = String(
+      user?.firstname ?? (user as any)?.first_name ?? ''
+    ).trim();
+    const last = String(
+      user?.lastname ?? (user as any)?.last_name ?? ''
+    ).trim();
     const full = `${first} ${last}`.trim();
     if (full) return full;
     const email = String(user?.email ?? '').trim();
@@ -297,16 +383,23 @@ export function LeadProfileModal({
   // Primary source for modal: fetched detail from GET /clients/:id when available; otherwise client prop.
   // Detail modal is for authorized users only – backend gates PHI on GET /clients/:id.
   const detailSource: Record<string, unknown> | null = React.useMemo(() => {
-    if (fetchedDetail && typeof fetchedDetail === 'object') return fetchedDetail as unknown as Record<string, unknown>;
+    if (fetchedDetail && typeof fetchedDetail === 'object')
+      return fetchedDetail as unknown as Record<string, unknown>;
     if (!client || typeof client !== 'object') return null;
     const c = client as Record<string, unknown>;
-    const dataObj = c.data && typeof c.data === 'object' && !Array.isArray(c.data) ? (c.data as Record<string, unknown>) : null;
-    const base = dataObj ?? c;
-    const phi = (c.phi && typeof c.phi === 'object' && !Array.isArray(c.phi))
-      ? (c.phi as Record<string, unknown>)
-      : (dataObj?.phi && typeof dataObj.phi === 'object' && !Array.isArray(dataObj.phi))
-        ? (dataObj.phi as Record<string, unknown>)
+    const dataObj =
+      c.data && typeof c.data === 'object' && !Array.isArray(c.data)
+        ? (c.data as Record<string, unknown>)
         : null;
+    const base = dataObj ?? c;
+    const phi =
+      c.phi && typeof c.phi === 'object' && !Array.isArray(c.phi)
+        ? (c.phi as Record<string, unknown>)
+        : dataObj?.phi &&
+            typeof dataObj.phi === 'object' &&
+            !Array.isArray(dataObj.phi)
+          ? (dataObj.phi as Record<string, unknown>)
+          : null;
     if (phi) return { ...base, ...phi };
     return base;
   }, [client, fetchedDetail]);
@@ -322,7 +415,11 @@ export function LeadProfileModal({
   // Do not rely solely on list row; backend returns full PHI for authorized users on detail.
   const detailFetchRef = React.useRef<string | null>(null);
   React.useEffect(() => {
-    console.log('🔍 [Effect] Running', { open, hasClient: !!client?.id, refValue: detailFetchRef.current });
+    console.log('🔍 [Effect] Running', {
+      open,
+      hasClient: !!client?.id,
+      refValue: detailFetchRef.current,
+    });
     if (!open) {
       console.log('🔍 [Effect] Modal closed, resetting');
       detailFetchRef.current = null;
@@ -336,7 +433,11 @@ export function LeadProfileModal({
 
     const clientId = String(client.id);
     // Only skip if we have both: ref is set AND we have the actual data for this client
-    if (detailFetchRef.current === clientId && fetchedDetail && (fetchedDetail as any).id === clientId) {
+    if (
+      detailFetchRef.current === clientId &&
+      fetchedDetail &&
+      (fetchedDetail as any).id === clientId
+    ) {
       console.log('🔍 [Effect] Already fetched and have data, skipping');
       return;
     }
@@ -346,7 +447,9 @@ export function LeadProfileModal({
     console.log('🔍 [Effect] Fetching because:', {
       'ref matches': detailFetchRef.current === clientId,
       'have data': !!fetchedDetail,
-      'data matches': fetchedDetail ? (fetchedDetail as any).id === clientId : false
+      'data matches': fetchedDetail
+        ? (fetchedDetail as any).id === clientId
+        : false,
     });
 
     console.log('🔍 [Fetch] Starting fetch for client:', clientId);
@@ -360,8 +463,14 @@ export function LeadProfileModal({
           detailFetchRef.current = null;
           return;
         }
-        console.log('🔍 [Fetch] phoneNumber in fetched data:', (data as any)?.phoneNumber);
-        console.log('🔍 [Fetch] phone_number in fetched data:', (data as any)?.phone_number);
+        console.log(
+          '🔍 [Fetch] phoneNumber in fetched data:',
+          (data as any)?.phoneNumber
+        );
+        console.log(
+          '🔍 [Fetch] phone_number in fetched data:',
+          (data as any)?.phone_number
+        );
         console.log('🔍 [Fetch] Full data:', data);
         setFetchedDetail(data);
       })
@@ -382,20 +491,34 @@ export function LeadProfileModal({
 
   const loadBillingWorkflow = React.useCallback(async () => {
     if (!client?.id) return;
-    setBillingLoading(true); setBillingError(null);
+    setBillingLoading(true);
+    setBillingError(null);
     try {
       const [schedule, card] = await Promise.all([
-        fetchClientPaymentSchedule(String(client.id)), fetchCardOnFileStatus(String(client.id)),
+        fetchClientPaymentSchedule(String(client.id)),
+        fetchCardOnFileStatus(String(client.id)),
       ]);
-      setInstallments(Array.isArray(schedule) ? schedule : []); setCardStatus(card);
+      setInstallments(Array.isArray(schedule) ? schedule : []);
+      setCardStatus(card);
     } catch (error) {
-      setBillingError(error instanceof Error ? error.message : 'Unable to load billing information.');
-    } finally { setBillingLoading(false); }
+      setBillingError(
+        error instanceof Error
+          ? error.message
+          : 'Unable to load billing information.'
+      );
+    } finally {
+      setBillingLoading(false);
+    }
   }, [client?.id]);
 
   React.useEffect(() => {
     if (open && client?.id) void loadBillingWorkflow();
-    else { setInstallments([]); setCardStatus(null); setBillingError(null); setGeneratedInvoiceLink(null); }
+    else {
+      setInstallments([]);
+      setCardStatus(null);
+      setBillingError(null);
+      setGeneratedInvoiceLink(null);
+    }
   }, [open, client?.id, loadBillingWorkflow]);
 
   React.useEffect(() => {
@@ -433,14 +556,24 @@ export function LeadProfileModal({
     let cancelled = false;
 
     const populatePreviewUrls = async () => {
-      const imageDocs = clientDocuments.filter(isInsuranceCardDocument).filter(isImageDocument);
-      const missingDocs = imageDocs.filter((doc) => !documentPreviewUrls[doc.id]);
+      const imageDocs = clientDocuments
+        .filter(isInsuranceCardDocument)
+        .filter(isImageDocument);
+      const missingDocs = imageDocs.filter(
+        (doc) => !documentPreviewUrls[doc.id]
+      );
       if (missingDocs.length === 0) return;
 
       const entries = await Promise.all(
         missingDocs.map(async (doc) => {
           try {
-            const url = doc.url || (await getClientDocumentUrl('staff', doc.id, client?.id || undefined));
+            const url =
+              doc.url ||
+              (await getClientDocumentUrl(
+                'staff',
+                doc.id,
+                client?.id || undefined
+              ));
             return [doc.id, url] as const;
           } catch {
             return null;
@@ -495,9 +628,18 @@ export function LeadProfileModal({
         console.log('  Current time (now):', now);
         console.log('  Current time ISO:', now.toISOString());
         console.log('  Current time local:', now.toString());
-        console.log('  Time difference (ms):', now.getTime() - parsedDate.getTime());
-        console.log('  Time difference (minutes):', (now.getTime() - parsedDate.getTime()) / 1000 / 60);
-        console.log('  Browser timezone offset (minutes):', now.getTimezoneOffset());
+        console.log(
+          '  Time difference (ms):',
+          now.getTime() - parsedDate.getTime()
+        );
+        console.log(
+          '  Time difference (minutes):',
+          (now.getTime() - parsedDate.getTime()) / 1000 / 60
+        );
+        console.log(
+          '  Browser timezone offset (minutes):',
+          now.getTimezoneOffset()
+        );
         console.log('  Is timestamp in future?', parsedDate > now);
       }
 
@@ -522,7 +664,9 @@ export function LeadProfileModal({
     return `${clientId}|${phone}|${service}|${dueDate}`;
   }, [detailSource, client?.id]);
 
-  const hasInsuranceDetails = hasAnyInsuranceDetails(detailSource as Record<string, unknown> | null);
+  const hasInsuranceDetails = hasAnyInsuranceDetails(
+    detailSource as Record<string, unknown> | null
+  );
 
   const lastInitFingerprintRef = React.useRef<string | null>(null);
   React.useEffect(() => {
@@ -535,20 +679,35 @@ export function LeadProfileModal({
     }
     lastInitFingerprintRef.current = dataFingerprint;
     const d = detailSource as Record<string, unknown>;
-    const get = (key: string, alt: string) => (d[key] ?? d[alt]) as string | undefined;
+    const get = (key: string, alt: string) =>
+      (d[key] ?? d[alt]) as string | undefined;
     const stripRedacted = (v: unknown): string | undefined => {
-      if (v === '[redacted]' || v === null || v === undefined || v === -1 || v === '-1') return undefined;
+      if (
+        v === '[redacted]' ||
+        v === null ||
+        v === undefined ||
+        v === -1 ||
+        v === '-1'
+      )
+        return undefined;
       const str = String(v).trim();
       return str === '' ? undefined : str;
     };
     const nested = (obj: unknown, key: string) =>
-      obj && typeof obj === 'object' && !Array.isArray(obj) ? (obj as Record<string, unknown>)[key] : undefined;
+      obj && typeof obj === 'object' && !Array.isArray(obj)
+        ? (obj as Record<string, unknown>)[key]
+        : undefined;
     const rawPhone =
-      get('phone_number', 'phoneNumber') ?? nested(d.phi, 'phone_number') ?? nested(d.data, 'phone_number') ?? d.mobile_phone;
-      const phoneNumber = (stripRedacted(rawPhone) ?? '') as string;
-      const phone_number = stripRedacted(rawPhone) ?? undefined;
+      get('phone_number', 'phoneNumber') ??
+      nested(d.phi, 'phone_number') ??
+      nested(d.data, 'phone_number') ??
+      d.mobile_phone;
+    const phoneNumber = (stripRedacted(rawPhone) ?? '') as string;
+    const phone_number = stripRedacted(rawPhone) ?? undefined;
     const paymentMethod = normalizeBillingPaymentMethod(
-      get('payment_method', 'paymentMethod') ?? d.payment_method ?? d.paymentMethod
+      get('payment_method', 'paymentMethod') ??
+        d.payment_method ??
+        d.paymentMethod
     );
     console.log('🔍 [Init] Phone extraction:', {
       'detailSource.phoneNumber': d.phoneNumber,
@@ -560,33 +719,52 @@ export function LeadProfileModal({
     const initializedData: Partial<Client> = {
       ...client,
       ...detailSource,
-      firstname: (stripRedacted(get('firstname', 'first_name') ?? get('firstName', 'first_name')) ?? '') as string,
-      lastname: (stripRedacted(get('lastname', 'last_name') ?? get('lastName', 'last_name')) ?? '') as string,
+      firstname: (stripRedacted(
+        get('firstname', 'first_name') ?? get('firstName', 'first_name')
+      ) ?? '') as string,
+      lastname: (stripRedacted(
+        get('lastname', 'last_name') ?? get('lastName', 'last_name')
+      ) ?? '') as string,
       email: stripRedacted(d.email) as string | undefined,
       phoneNumber,
       phone_number,
       zip_code: normalizeZipCode(stripRedacted(get('zip_code', 'zipCode'))),
       due_date: get('due_date', 'dueDate'),
-      address: (get('address_line1', 'address') ?? get('addressLine1', 'address') ?? '') as string | undefined,
+      address: (get('address_line1', 'address') ??
+        get('addressLine1', 'address') ??
+        '') as string | undefined,
       address_line1: get('address_line1', 'addressLine1'),
       date_of_birth: get('date_of_birth', 'dateOfBirth'),
       serviceNeeded: (get('service_needed', 'serviceNeeded') ?? '') as string,
       service_needed: (get('service_needed', 'serviceNeeded') ?? '') as string,
       status: normalizeLifecycleStatus(get('status', 'status')) as any,
       payment_method: paymentMethod,
-      insurance_policy_holder_name: get('insurance_policy_holder_name', 'insurancePolicyHolderName'),
-      insurance_policy_holder_dob: get('insurance_policy_holder_dob', 'insurancePolicyHolderDob'),
+      insurance_policy_holder_name: get(
+        'insurance_policy_holder_name',
+        'insurancePolicyHolderName'
+      ),
+      insurance_policy_holder_dob: get(
+        'insurance_policy_holder_dob',
+        'insurancePolicyHolderDob'
+      ),
       insurance_policy_holder_relationship: get(
         'insurance_policy_holder_relationship',
         'insurancePolicyHolderRelationship'
       ),
       insurance_plan_type: get('insurance_plan_type', 'insurancePlanType'),
-      insurance_provider: (get('insurance_provider', 'insuranceProvider') ?? get('insurance', 'insurance')) as string | undefined,
-      insurance_member_id: (get('insurance_member_id', 'insuranceMemberId') ?? '') as string | undefined,
-      policy_number: (get('policy_number', 'policyNumber') ?? '') as string | undefined,
-      insurance_phone_number: get('insurance_phone_number', 'insurancePhoneNumber'),
-      has_secondary_insurance:
-        (d.has_secondary_insurance ?? d.hasSecondaryInsurance) as boolean | undefined,
+      insurance_provider: (get('insurance_provider', 'insuranceProvider') ??
+        get('insurance', 'insurance')) as string | undefined,
+      insurance_member_id: (get('insurance_member_id', 'insuranceMemberId') ??
+        '') as string | undefined,
+      policy_number: (get('policy_number', 'policyNumber') ?? '') as
+        | string
+        | undefined,
+      insurance_phone_number: get(
+        'insurance_phone_number',
+        'insurancePhoneNumber'
+      ),
+      has_secondary_insurance: (d.has_secondary_insurance ??
+        d.hasSecondaryInsurance) as boolean | undefined,
       secondary_insurance_provider: get(
         'secondary_insurance_provider',
         'secondaryInsuranceProvider'
@@ -595,19 +773,29 @@ export function LeadProfileModal({
         'secondary_insurance_member_id',
         'secondaryInsuranceMemberId'
       ),
-      secondary_policy_number: get('secondary_policy_number', 'secondaryPolicyNumber'),
+      secondary_policy_number: get(
+        'secondary_policy_number',
+        'secondaryPolicyNumber'
+      ),
     };
     delete (initializedData as Record<string, unknown>).self_pay_card_info;
     delete (initializedData as Record<string, unknown>).selfPayCardInfo;
     const rawReferral = stripRedacted(get('referral_source', 'referralSource'));
     if (rawReferral !== undefined) {
-      initializedData.referral_source = normalizeReferralSourceStoredValue(rawReferral);
+      initializedData.referral_source =
+        normalizeReferralSourceStoredValue(rawReferral);
     }
     const rawHomeType = get('home_type', 'homeType');
-    if (rawHomeType !== undefined && rawHomeType !== null && rawHomeType !== '') {
+    if (
+      rawHomeType !== undefined &&
+      rawHomeType !== null &&
+      rawHomeType !== ''
+    ) {
       initializedData.home_type = normalizeHomeTypeFromApi(rawHomeType);
     }
-    const rawHomeTypeOther = stripRedacted(get('home_type_other', 'homeTypeOther'));
+    const rawHomeTypeOther = stripRedacted(
+      get('home_type_other', 'homeTypeOther')
+    );
     if (rawHomeTypeOther !== undefined) {
       initializedData.home_type_other = rawHomeTypeOther;
     }
@@ -651,13 +839,15 @@ export function LeadProfileModal({
         description: newNote,
         metadata: {
           category: noteCategory.toLowerCase(),
-          ...(currentUserDisplayName ? { createdByName: currentUserDisplayName } : {}),
+          ...(currentUserDisplayName
+            ? { createdByName: currentUserDisplayName }
+            : {}),
           ...(user?.role ? { createdByRole: user.role } : {}),
-        }
+        },
       });
 
       // Add new note to the top of the list
-      setNotes(prev => [createdNote, ...prev]);
+      setNotes((prev) => [createdNote, ...prev]);
       setNewNote('');
       setNoteCategory('General');
       toast.success('Note added successfully!');
@@ -683,18 +873,28 @@ export function LeadProfileModal({
       const changedFields: string[] = [];
 
       // Check which fields have changed by comparing with original client data
-      Object.keys(editedData).forEach(key => {
+      Object.keys(editedData).forEach((key) => {
         const originalValue = client[key as keyof Client];
         const newValue = editedData[key as keyof Client];
 
         // Skip fields that are in editedData but not meaningful for updates
-        if (key === 'id' || key === 'uuid' || key === 'text' || key === 'role' || key === 'requestedAt' || key === 'created_at' || key === 'updatedAt') {
+        if (
+          key === 'id' ||
+          key === 'uuid' ||
+          key === 'text' ||
+          key === 'role' ||
+          key === 'requestedAt' ||
+          key === 'created_at' ||
+          key === 'updatedAt'
+        ) {
           return;
         }
 
         // Handle array comparisons
         if (Array.isArray(newValue)) {
-          const originalArray = Array.isArray(originalValue) ? originalValue : [];
+          const originalArray = Array.isArray(originalValue)
+            ? originalValue
+            : [];
           const originalSorted = originalArray.sort().join(',');
           const newSorted = [...newValue].sort().join(',');
           if (originalSorted !== newSorted) {
@@ -706,8 +906,12 @@ export function LeadProfileModal({
           // 1. Both have values and they're different, OR
           // 2. Original had a value and new is empty (clearing a field), OR
           // 3. Original was empty/undefined and new has a value
-          const originalHasValue = originalValue !== undefined && originalValue !== null && originalValue !== '';
-          const newHasValue = newValue !== undefined && newValue !== null && newValue !== '';
+          const originalHasValue =
+            originalValue !== undefined &&
+            originalValue !== null &&
+            originalValue !== '';
+          const newHasValue =
+            newValue !== undefined && newValue !== null && newValue !== '';
 
           // Special handling for date fields - don't send empty strings or null
           if (key === 'due_date' && !newHasValue) {
@@ -808,16 +1012,28 @@ export function LeadProfileModal({
 
       // Handle status update separately using the dedicated status endpoint
       if (updateData.status !== undefined) {
-        const statusResult = await updateClientStatus(client.id, updateData.status, {
-          id: client.id,
-          firstName: String(
-            editedData.firstname || editedData.firstName || client.firstname || client.firstName || ''
-          ),
-          lastName: String(
-            editedData.lastname || editedData.lastName || client.lastname || client.lastName || ''
-          ),
-          email: String(editedData.email || client.email || ''),
-        });
+        const statusResult = await updateClientStatus(
+          client.id,
+          updateData.status,
+          {
+            id: client.id,
+            firstName: String(
+              editedData.firstname ||
+                editedData.firstName ||
+                client.firstname ||
+                client.firstName ||
+                ''
+            ),
+            lastName: String(
+              editedData.lastname ||
+                editedData.lastName ||
+                client.lastname ||
+                client.lastName ||
+                ''
+            ),
+            email: String(editedData.email || client.email || ''),
+          }
+        );
         if (!statusResult.success) {
           toast.error(statusResult.error || 'Failed to update client status');
           setIsSaving(false);
@@ -856,7 +1072,10 @@ export function LeadProfileModal({
       });
 
       console.log('PHI fields to update:', Object.keys(phiData));
-      console.log('Operational fields to update:', Object.keys(operationalData));
+      console.log(
+        'Operational fields to update:',
+        Object.keys(operationalData)
+      );
 
       const billingFieldKeys = new Set([
         'payment_method',
@@ -927,7 +1146,9 @@ export function LeadProfileModal({
       if (Object.keys(billingData).length > 0) {
         const normalizedBillingData = {
           ...billingData,
-          payment_method: normalizeBillingPaymentMethod(billingData.payment_method),
+          payment_method: normalizeBillingPaymentMethod(
+            billingData.payment_method
+          ),
         };
         const billingResponse = await fetchWithAuth(
           buildUrl(`/api/clients/${encodeURIComponent(client.id)}/billing`),
@@ -942,16 +1163,23 @@ export function LeadProfileModal({
 
         if (!billingResponse.ok) {
           if (isEndpointUnavailableStatus(billingResponse.status)) {
-            const fallbackResult = await updateClientPhi(client.id, normalizedBillingData);
+            const fallbackResult = await updateClientPhi(
+              client.id,
+              normalizedBillingData
+            );
             if (!fallbackResult.success) {
               billingSuccess = false;
-              errors.push(fallbackResult.error || 'Failed to update billing fields');
+              errors.push(
+                fallbackResult.error || 'Failed to update billing fields'
+              );
             } else {
               setEditedData((prev) => ({
                 ...prev,
                 ...normalizedBillingData,
                 payment_method: normalizeBillingPaymentMethod(
-                  normalizedBillingData.payment_method ?? prev.payment_method ?? ''
+                  normalizedBillingData.payment_method ??
+                    prev.payment_method ??
+                    ''
                 ),
               }));
             }
@@ -959,7 +1187,8 @@ export function LeadProfileModal({
             billingSuccess = false;
             const billingError = await billingResponse.text().catch(() => '');
             errors.push(
-              billingError || `Failed to update billing fields (${billingResponse.status})`
+              billingError ||
+                `Failed to update billing fields (${billingResponse.status})`
             );
           }
         } else {
@@ -1047,7 +1276,8 @@ export function LeadProfileModal({
     const missing: string[] = [];
     if (induction === undefined) missing.push('Induction (Yes/No)');
     if (!deliveryType) missing.push('Delivery type');
-    if (medicationsUsed.length === 0) missing.push('Medications used (select at least one)');
+    if (medicationsUsed.length === 0)
+      missing.push('Medications used (select at least one)');
     if (missing.length > 0) {
       toast.error(`Complete required fields: ${missing.join(', ')}`);
       return;
@@ -1093,10 +1323,7 @@ export function LeadProfileModal({
           },
         });
       } catch (noteErr) {
-        console.error(
-          'Error creating birth outcomes history note:',
-          noteErr
-        );
+        console.error('Error creating birth outcomes history note:', noteErr);
         toast.error(
           'Birth outcomes saved, but failed to create history record'
         );
@@ -1130,8 +1357,12 @@ export function LeadProfileModal({
     () =>
       notes.filter((note) => {
         const category = note.metadata?.category;
-        const field = (note.metadata as Record<string, unknown> | undefined)?.field;
-        return isBirthOutcomesCategory(category) || String(field ?? '') === 'birth_outcomes';
+        const field = (note.metadata as Record<string, unknown> | undefined)
+          ?.field;
+        return (
+          isBirthOutcomesCategory(category) ||
+          String(field ?? '') === 'birth_outcomes'
+        );
       }),
     [notes]
   );
@@ -1141,68 +1372,82 @@ export function LeadProfileModal({
     .sort(compareClientDocumentsByUploadedAtDesc);
   const frontInsuranceCard =
     insuranceCardDocuments.find(
-      (document) => getInsuranceCardSide(document.documentType, document.fileName) === 'front'
+      (document) =>
+        getInsuranceCardSide(document.documentType, document.fileName) ===
+        'front'
     ) ??
-    insuranceCardDocuments.find((document) => document.documentType === 'insurance_card') ??
+    insuranceCardDocuments.find(
+      (document) => document.documentType === 'insurance_card'
+    ) ??
     null;
   const backInsuranceCard =
     insuranceCardDocuments.find(
-      (document) => getInsuranceCardSide(document.documentType, document.fileName) === 'back'
+      (document) =>
+        getInsuranceCardSide(document.documentType, document.fileName) ===
+        'back'
     ) ?? null;
 
   const renderInsuranceCardDocument = (documentItem: ClientDocument) => {
-    const parsed = documentItem.uploadedAt ? new Date(documentItem.uploadedAt) : null;
+    const parsed = documentItem.uploadedAt
+      ? new Date(documentItem.uploadedAt)
+      : null;
     const uploadedAt =
       parsed && !Number.isNaN(parsed.getTime())
         ? format(parsed, 'MMM d, yyyy')
         : documentItem.uploadedAt || '';
     const isBusy = activeDocumentId === documentItem.id;
-    const previewUrl = documentPreviewUrls[documentItem.id] || documentItem.url || '';
+    const previewUrl =
+      documentPreviewUrls[documentItem.id] || documentItem.url || '';
     const showPreview = isImageDocument(documentItem) && previewUrl;
 
     return (
       <div
         key={documentItem.id}
-        className="flex flex-col gap-3 rounded-lg border p-3 md:flex-row md:items-start md:justify-between"
+        className='flex flex-col gap-3 rounded-lg border p-3 md:flex-row md:items-start md:justify-between'
       >
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
-            <FileImage className="h-4 w-4 text-primary" />
-            <p className="truncate text-sm font-medium">{documentItem.fileName}</p>
-            <Badge variant="secondary">
-              {getClientDocumentLabel(documentItem.documentType, documentItem.fileName)}
+        <div className='min-w-0 flex-1'>
+          <div className='flex items-center gap-2'>
+            <FileImage className='h-4 w-4 text-primary' />
+            <p className='truncate text-sm font-medium'>
+              {documentItem.fileName}
+            </p>
+            <Badge variant='secondary'>
+              {getClientDocumentLabel(
+                documentItem.documentType,
+                documentItem.fileName
+              )}
             </Badge>
           </div>
-          <p className="mt-1 text-xs text-muted-foreground">
+          <p className='mt-1 text-xs text-muted-foreground'>
             {uploadedAt ? `Uploaded ${uploadedAt}` : 'Upload date unavailable'}
           </p>
           {showPreview ? (
             <img
               src={previewUrl}
               alt={documentItem.fileName}
-              className="mt-3 max-h-56 rounded-md border object-contain"
+              className='mt-3 max-h-56 rounded-md border object-contain'
             />
           ) : null}
         </div>
-        <div className="flex flex-wrap items-center gap-2">
+        <div className='flex flex-wrap items-center gap-2'>
           <Button
-            type="button"
-            variant="outline"
-            size="sm"
+            type='button'
+            variant='outline'
+            size='sm'
             onClick={() => void handleOpenDocument(documentItem)}
             disabled={isBusy}
           >
-            <ExternalLink className="mr-1 h-4 w-4" />
+            <ExternalLink className='mr-1 h-4 w-4' />
             {activeDocumentId === documentItem.id ? 'Opening...' : 'View'}
           </Button>
           <Button
-            type="button"
-            variant="outline"
-            size="sm"
+            type='button'
+            variant='outline'
+            size='sm'
             onClick={() => void handleDownloadDocument(documentItem)}
             disabled={isBusy}
           >
-            <Download className="mr-1 h-4 w-4" />
+            <Download className='mr-1 h-4 w-4' />
             {activeDocumentId === documentItem.id ? 'Working...' : 'Download'}
           </Button>
         </div>
@@ -1215,10 +1460,16 @@ export function LeadProfileModal({
     try {
       const url =
         documentItem.url ||
-        (await getClientDocumentUrl('staff', documentItem.id, client?.id || undefined));
+        (await getClientDocumentUrl(
+          'staff',
+          documentItem.id,
+          client?.id || undefined
+        ));
       window.open(url, '_blank', 'noopener,noreferrer');
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to open insurance card');
+      toast.error(
+        error instanceof Error ? error.message : 'Failed to open insurance card'
+      );
     } finally {
       setActiveDocumentId(null);
     }
@@ -1229,7 +1480,11 @@ export function LeadProfileModal({
     try {
       const url =
         documentItem.url ||
-        (await getClientDocumentUrl('staff', documentItem.id, client?.id || undefined));
+        (await getClientDocumentUrl(
+          'staff',
+          documentItem.id,
+          client?.id || undefined
+        ));
       const response = await fetch(url, {
         credentials: 'omit',
         mode: 'cors',
@@ -1249,15 +1504,22 @@ export function LeadProfileModal({
       document.body.removeChild(link);
       URL.revokeObjectURL(objectUrl);
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to download insurance card');
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : 'Failed to download insurance card'
+      );
     } finally {
       setActiveDocumentId(null);
     }
   };
 
   const handleCancelEdit = () => {
-    const base = { ...(detailSource ?? detailedClient ?? {}) } as Partial<Client>;
-    const raw = base.referral_source ?? (base as Record<string, unknown>).referralSource;
+    const base = {
+      ...(detailSource ?? detailedClient ?? {}),
+    } as Partial<Client>;
+    const raw =
+      base.referral_source ?? (base as Record<string, unknown>).referralSource;
     if (raw !== undefined && raw !== null && String(raw).trim() !== '') {
       base.referral_source = normalizeReferralSourceStoredValue(String(raw));
     }
@@ -1285,11 +1547,20 @@ export function LeadProfileModal({
     // Priority: editedData (current form state) > detailSource (fetched) > client (list prop)
     // This ensures inputs show what's in the editable state, not stale fetched data
     const isEmpty = (v: unknown) => v === null || v === undefined || v === '';
-    const fromEdited = (altKey ? editedData[altKey] : undefined) ?? editedData[fieldKey];
-    const fromDetail = detailSource ? ((altKey ? detailSource[altKey] : undefined) ?? detailSource[fieldKey]) : undefined;
-    const fromClient = c ? ((altKey ? c[altKey] : undefined) ?? c[fieldKey]) : undefined;
+    const fromEdited =
+      (altKey ? editedData[altKey] : undefined) ?? editedData[fieldKey];
+    const fromDetail = detailSource
+      ? ((altKey ? detailSource[altKey] : undefined) ?? detailSource[fieldKey])
+      : undefined;
+    const fromClient = c
+      ? ((altKey ? c[altKey] : undefined) ?? c[fieldKey])
+      : undefined;
     // Use isEmpty to treat empty string as "no value" and fallback to next source
-    const v = isEmpty(fromEdited) ? (isEmpty(fromDetail) ? fromClient : fromDetail) : fromEdited;
+    const v = isEmpty(fromEdited)
+      ? isEmpty(fromDetail)
+        ? fromClient
+        : fromDetail
+      : fromEdited;
     if (v === null || v === undefined) return '';
     if (fieldKey === 'payment_method') {
       return normalizeBillingPaymentMethod(v);
@@ -1310,13 +1581,17 @@ export function LeadProfileModal({
     if (!client?.id) return;
     setIsRecordingPaymentAuth(true);
     try {
-      const pm = normalizeBillingPaymentMethod(getDisplayValue('payment_method', 'paymentMethod'));
+      const pm = normalizeBillingPaymentMethod(
+        getDisplayValue('payment_method', 'paymentMethod')
+      );
       const authorizedAt = new Date().toISOString();
       const needsIns = requiresInsuranceDetails(pm);
       const hasSecondary =
         needsIns &&
-        String(getDisplayValue('has_secondary_insurance', 'hasSecondaryInsurance') || '')
-          .toLowerCase() === 'true';
+        String(
+          getDisplayValue('has_secondary_insurance', 'hasSecondaryInsurance') ||
+            ''
+        ).toLowerCase() === 'true';
 
       const normalizedBillingData: Record<string, unknown> = {
         payment_method: pm,
@@ -1327,25 +1602,50 @@ export function LeadProfileModal({
             getDisplayValue('insurance', null)
           : '',
         insurance_policy_holder_name: needsIns
-          ? getDisplayValue('insurance_policy_holder_name', 'insurancePolicyHolderName')
+          ? getDisplayValue(
+              'insurance_policy_holder_name',
+              'insurancePolicyHolderName'
+            )
           : '',
         insurance_policy_holder_dob: needsIns
-          ? getDisplayValue('insurance_policy_holder_dob', 'insurancePolicyHolderDob')
+          ? getDisplayValue(
+              'insurance_policy_holder_dob',
+              'insurancePolicyHolderDob'
+            )
           : '',
         insurance_policy_holder_relationship: needsIns
-          ? getDisplayValue('insurance_policy_holder_relationship', 'insurancePolicyHolderRelationship')
+          ? getDisplayValue(
+              'insurance_policy_holder_relationship',
+              'insurancePolicyHolderRelationship'
+            )
           : '',
-        insurance_plan_type: needsIns ? getDisplayValue('insurance_plan_type', 'insurancePlanType') : '',
-        insurance_provider: needsIns ? getDisplayValue('insurance_provider', 'insuranceProvider') : '',
-        insurance_member_id: needsIns ? getDisplayValue('insurance_member_id', 'insuranceMemberId') : '',
-        policy_number: needsIns ? getDisplayValue('policy_number', 'policyNumber') : '',
-        insurance_phone_number: needsIns ? getDisplayValue('insurance_phone_number', 'insurancePhoneNumber') : '',
+        insurance_plan_type: needsIns
+          ? getDisplayValue('insurance_plan_type', 'insurancePlanType')
+          : '',
+        insurance_provider: needsIns
+          ? getDisplayValue('insurance_provider', 'insuranceProvider')
+          : '',
+        insurance_member_id: needsIns
+          ? getDisplayValue('insurance_member_id', 'insuranceMemberId')
+          : '',
+        policy_number: needsIns
+          ? getDisplayValue('policy_number', 'policyNumber')
+          : '',
+        insurance_phone_number: needsIns
+          ? getDisplayValue('insurance_phone_number', 'insurancePhoneNumber')
+          : '',
         has_secondary_insurance: hasSecondary,
         secondary_insurance_provider: hasSecondary
-          ? getDisplayValue('secondary_insurance_provider', 'secondaryInsuranceProvider')
+          ? getDisplayValue(
+              'secondary_insurance_provider',
+              'secondaryInsuranceProvider'
+            )
           : '',
         secondary_insurance_member_id: hasSecondary
-          ? getDisplayValue('secondary_insurance_member_id', 'secondaryInsuranceMemberId')
+          ? getDisplayValue(
+              'secondary_insurance_member_id',
+              'secondaryInsuranceMemberId'
+            )
           : '',
         secondary_policy_number: hasSecondary
           ? getDisplayValue('secondary_policy_number', 'secondaryPolicyNumber')
@@ -1363,13 +1663,20 @@ export function LeadProfileModal({
 
       if (!billingResponse.ok) {
         if (isEndpointUnavailableStatus(billingResponse.status)) {
-          const fallbackResult = await updateClientPhi(client.id, normalizedBillingData);
+          const fallbackResult = await updateClientPhi(
+            client.id,
+            normalizedBillingData
+          );
           if (!fallbackResult.success) {
-            throw new Error(fallbackResult.error || 'Failed to record payment authorization');
+            throw new Error(
+              fallbackResult.error || 'Failed to record payment authorization'
+            );
           }
         } else {
           const errText = await billingResponse.text().catch(() => '');
-          throw new Error(errText || `Request failed (${billingResponse.status})`);
+          throw new Error(
+            errText || `Request failed (${billingResponse.status})`
+          );
         }
       }
 
@@ -1393,22 +1700,47 @@ export function LeadProfileModal({
       toast.success('Payment authorization recorded as on file.');
       refreshClients?.();
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to record payment authorization');
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : 'Failed to record payment authorization'
+      );
     } finally {
       setIsRecordingPaymentAuth(false);
     }
   };
 
-  const handleGenerateInstallmentInvoice = async (installment: PaymentInstallment) => {
+  const handleGenerateInstallmentInvoice = async (
+    installment: PaymentInstallment
+  ) => {
     if (!client?.id || isGeneratingInvoice) return;
-    const amount = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(installment.amount);
-    const due = installment.due_date ? format(parseISO(installment.due_date), 'MMMM d, yyyy') : 'the scheduled date';
-    const label = installment.payment_type === 'deposit' ? 'Deposit' : `Installment ${installment.installment_number}`;
-    const warning = cardStatus?.required && cardStatus.status !== 'active' ? '\n\nThis client does not currently have an active card on file. The invoice email will include the required card-on-file warning.' : '';
-    if (!window.confirm(`Generate an invoice for ${label} in the amount of ${amount}, due ${due}?${warning}`)) return;
+    const amount = new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: 'USD',
+    }).format(installment.amount);
+    const due = installment.due_date
+      ? format(parseISO(installment.due_date), 'MMMM d, yyyy')
+      : 'the scheduled date';
+    const label =
+      installment.payment_type === 'deposit'
+        ? 'Deposit'
+        : `Installment ${installment.installment_number}`;
+    const warning =
+      cardStatus?.required && cardStatus.status !== 'active'
+        ? '\n\nThis client does not currently have an active card on file. The invoice email will include the required card-on-file warning.'
+        : '';
+    if (
+      !window.confirm(
+        `Generate an invoice for ${label} in the amount of ${amount}, due ${due}?${warning}`
+      )
+    )
+      return;
     setIsGeneratingInvoice(true);
     try {
-      const result = await generateInstallmentInvoice(String(client.id), installment.id);
+      const result = await generateInstallmentInvoice(
+        String(client.id),
+        installment.id
+      );
       setGeneratedInvoiceLink(result.payment_link);
       toast.success('Installment invoice generated.');
       await loadBillingWorkflow();
@@ -1417,12 +1749,18 @@ export function LeadProfileModal({
       if (refreshed) setFetchedDetail(refreshed);
       refreshClients?.();
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to generate installment invoice.');
-    } finally { setIsGeneratingInvoice(false); }
+      toast.error(
+        error instanceof Error
+          ? error.message
+          : 'Failed to generate installment invoice.'
+      );
+    } finally {
+      setIsGeneratingInvoice(false);
+    }
   };
 
   const eligibilitySource = React.useMemo(
-    () => detailSource ?? ((client as Record<string, unknown> | null) ?? {}),
+    () => detailSource ?? (client as Record<string, unknown> | null) ?? {},
     [detailSource, client]
   );
   const readinessSummary = React.useMemo(
@@ -1434,26 +1772,49 @@ export function LeadProfileModal({
     label: string,
     fieldKey: string,
     icon?: React.ReactNode,
-    type: 'text' | 'email' | 'tel' | 'textarea' | 'select' | 'multiselect' | 'date' | 'number' = 'text',
+    type:
+      | 'text'
+      | 'email'
+      | 'tel'
+      | 'textarea'
+      | 'select'
+      | 'multiselect'
+      | 'date'
+      | 'number' = 'text',
     options?: string[],
     textareaRows = 3
   ) => {
     const altKey =
-      fieldKey === 'phoneNumber' ? 'phone_number'
-      : fieldKey === 'service_needed' ? 'serviceNeeded'
-      : fieldKey === 'firstname' ? 'first_name'
-      : fieldKey === 'lastname' ? 'last_name'
-      : fieldKey === 'first_name' ? 'firstname'
-      : fieldKey === 'last_name' ? 'lastname'
-      : fieldKey === 'birth_outcomes' ? 'birthOutcomes'
-      : fieldKey === 'birth_outcomes_induction' ? 'birthOutcomesInduction'
-      : fieldKey === 'birth_outcomes_delivery_type' ? 'birthOutcomesDeliveryType'
-      : fieldKey === 'payment_authorization_status' ? 'paymentAuthorizationStatus'
-      : fieldKey === 'insurance_policy_holder_name' ? 'insurancePolicyHolderName'
-      : fieldKey === 'insurance_policy_holder_dob' ? 'insurancePolicyHolderDob'
-      : fieldKey === 'insurance_policy_holder_relationship' ? 'insurancePolicyHolderRelationship'
-      : fieldKey === 'insurance_plan_type' ? 'insurancePlanType'
-      : null;
+      fieldKey === 'phoneNumber'
+        ? 'phone_number'
+        : fieldKey === 'service_needed'
+          ? 'serviceNeeded'
+          : fieldKey === 'firstname'
+            ? 'first_name'
+            : fieldKey === 'lastname'
+              ? 'last_name'
+              : fieldKey === 'first_name'
+                ? 'firstname'
+                : fieldKey === 'last_name'
+                  ? 'lastname'
+                  : fieldKey === 'birth_outcomes'
+                    ? 'birthOutcomes'
+                    : fieldKey === 'birth_outcomes_induction'
+                      ? 'birthOutcomesInduction'
+                      : fieldKey === 'birth_outcomes_delivery_type'
+                        ? 'birthOutcomesDeliveryType'
+                        : fieldKey === 'payment_authorization_status'
+                          ? 'paymentAuthorizationStatus'
+                          : fieldKey === 'insurance_policy_holder_name'
+                            ? 'insurancePolicyHolderName'
+                            : fieldKey === 'insurance_policy_holder_dob'
+                              ? 'insurancePolicyHolderDob'
+                              : fieldKey ===
+                                  'insurance_policy_holder_relationship'
+                                ? 'insurancePolicyHolderRelationship'
+                                : fieldKey === 'insurance_plan_type'
+                                  ? 'insurancePlanType'
+                                  : null;
     let value: string | Date =
       altKey !== null || fieldKey === 'referral_source'
         ? getDisplayValue(fieldKey, altKey)
@@ -1474,10 +1835,13 @@ export function LeadProfileModal({
     }
 
     return (
-      <div className="flex items-start gap-2 py-2">
-        {icon && <div className="mt-2 text-muted-foreground">{icon}</div>}
-        <div className="flex-1 min-w-0">
-          <Label htmlFor={fieldKey} className="text-sm font-medium text-muted-foreground">
+      <div className='flex items-start gap-2 py-2'>
+        {icon && <div className='mt-2 text-muted-foreground'>{icon}</div>}
+        <div className='flex-1 min-w-0'>
+          <Label
+            htmlFor={fieldKey}
+            className='text-sm font-medium text-muted-foreground'
+          >
             {label}
           </Label>
           {type === 'textarea' ? (
@@ -1486,30 +1850,34 @@ export function LeadProfileModal({
                 id={fieldKey}
                 value={String(value)}
                 onChange={(e) => {
-                  const updates: Record<string, string> = { [fieldKey]: e.target.value };
+                  const updates: Record<string, string> = {
+                    [fieldKey]: e.target.value,
+                  };
                   if (altKey) updates[altKey] = e.target.value;
-                  setEditedData(prev => ({ ...prev, ...updates }));
+                  setEditedData((prev) => ({ ...prev, ...updates }));
                 }}
-                className="mt-1"
+                className='mt-1'
                 rows={textareaRows}
               />
             ) : (
-              <div className="mt-1 px-3 py-2 border rounded-md bg-muted/50 text-sm min-h-[72px] whitespace-pre-wrap">
+              <div className='mt-1 px-3 py-2 border rounded-md bg-muted/50 text-sm min-h-[72px] whitespace-pre-wrap'>
                 {String(value || 'Not provided')}
               </div>
             )
           ) : type === 'select' && options ? (
             isEditing ? (
               <select
-                className="mt-1 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                className='mt-1 flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50'
                 value={String(value || '')}
                 onChange={(e) => {
-                  const updates: Record<string, string> = { [fieldKey]: e.target.value };
+                  const updates: Record<string, string> = {
+                    [fieldKey]: e.target.value,
+                  };
                   if (altKey) updates[altKey] = e.target.value;
-                  setEditedData(prev => ({ ...prev, ...updates }));
+                  setEditedData((prev) => ({ ...prev, ...updates }));
                 }}
               >
-                <option value="">Select...</option>
+                <option value=''>Select...</option>
                 {options.map((option) => (
                   <option key={option} value={option}>
                     {option}
@@ -1517,13 +1885,13 @@ export function LeadProfileModal({
                 ))}
               </select>
             ) : (
-              <div className="mt-1 px-3 py-2 border rounded-md bg-muted/50 text-sm">
+              <div className='mt-1 px-3 py-2 border rounded-md bg-muted/50 text-sm'>
                 {String(value || 'Not provided')}
               </div>
             )
           ) : type === 'multiselect' && options ? (
-            <div className="mt-1">
-              <div className="flex flex-wrap gap-2">
+            <div className='mt-1'>
+              <div className='flex flex-wrap gap-2'>
                 {options.map((option) => {
                   const multiValue =
                     fieldKey === 'home_type'
@@ -1535,9 +1903,9 @@ export function LeadProfileModal({
                   return (
                     <Button
                       key={option}
-                      type="button"
-                      variant={isSelected ? "default" : "outline"}
-                      size="sm"
+                      type='button'
+                      variant={isSelected ? 'default' : 'outline'}
+                      size='sm'
                       onClick={() => {
                         if (!isEditing) return;
                         const currentArray =
@@ -1564,7 +1932,10 @@ export function LeadProfileModal({
                           }));
                           return;
                         }
-                        setEditedData((prev) => ({ ...prev, [fieldKey]: newArray }));
+                        setEditedData((prev) => ({
+                          ...prev,
+                          [fieldKey]: newArray,
+                        }));
                       }}
                       disabled={!isEditing}
                       className={`text-xs ${!isEditing ? 'cursor-default' : ''}`}
@@ -1578,35 +1949,43 @@ export function LeadProfileModal({
                 (fieldKey === 'home_type'
                   ? normalizeHomeTypeFromApi(value).length === 0
                   : !value || (Array.isArray(value) && value.length === 0)) && (
-                <div className="text-sm text-muted-foreground mt-2">No options selected</div>
-              )}
+                  <div className='text-sm text-muted-foreground mt-2'>
+                    No options selected
+                  </div>
+                )}
             </div>
           ) : type === 'date' ? (
             isEditing ? (
-              <div className="flex gap-2 mt-1">
+              <div className='flex gap-2 mt-1'>
                 <Popover>
                   <PopoverTrigger asChild>
                     <Button
-                      variant="outline"
+                      variant='outline'
                       className={cn(
-                        "flex-1 justify-start text-left font-normal",
-                        !value && "text-muted-foreground"
+                        'flex-1 justify-start text-left font-normal',
+                        !value && 'text-muted-foreground'
                       )}
                     >
-                      <CalendarIcon className="mr-2 h-4 w-4" />
-                      {value ? format(new Date(value), "PPP") : "Pick a date"}
+                      <CalendarIcon className='mr-2 h-4 w-4' />
+                      {value ? format(new Date(value), 'PPP') : 'Pick a date'}
                     </Button>
                   </PopoverTrigger>
-                  <PopoverContent className="w-auto p-0" align="start">
+                  <PopoverContent className='w-auto p-0' align='start'>
                     <Calendar
-                      mode="single"
+                      mode='single'
                       selected={value ? new Date(value) : undefined}
                       onSelect={(date) => {
                         if (date) {
-                          setEditedData(prev => ({ ...prev, [fieldKey]: date.toISOString().split('T')[0] }));
+                          setEditedData((prev) => ({
+                            ...prev,
+                            [fieldKey]: date.toISOString().split('T')[0],
+                          }));
                         } else {
                           // Clear the date when user deselects
-                          setEditedData(prev => ({ ...prev, [fieldKey]: null }));
+                          setEditedData((prev) => ({
+                            ...prev,
+                            [fieldKey]: null,
+                          }));
                         }
                       }}
                       initialFocus
@@ -1615,57 +1994,59 @@ export function LeadProfileModal({
                 </Popover>
                 {value && (
                   <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setEditedData(prev => ({ ...prev, [fieldKey]: null }))}
-                    className="px-2"
+                    variant='outline'
+                    size='sm'
+                    onClick={() =>
+                      setEditedData((prev) => ({ ...prev, [fieldKey]: null }))
+                    }
+                    className='px-2'
                   >
                     Clear
                   </Button>
                 )}
               </div>
             ) : (
-              <div className="mt-1 px-3 py-2 border rounded-md bg-muted/50 text-sm">
-                {value ? format(new Date(value), "PPP") : 'Not provided'}
+              <div className='mt-1 px-3 py-2 border rounded-md bg-muted/50 text-sm'>
+                {value ? format(new Date(value), 'PPP') : 'Not provided'}
               </div>
             )
+          ) : (fieldKey === 'phoneNumber' && type === 'tel') || isEditing ? (
+            (() => {
+              // Use getDisplayValue which has correct priority: editedData > detailSource > client
+              let inputValue = getDisplayValue(fieldKey, altKey);
+              if (inputValue === '[redacted]') inputValue = '';
+              if (fieldKey === 'phoneNumber') {
+                console.log('📱 [Input] Phone input render:', {
+                  fieldKey,
+                  altKey,
+                  inputValue,
+                  'editedData.phoneNumber': editedData.phoneNumber,
+                  'editedData.phone_number': (editedData as any).phone_number,
+                  'detailSource?.phoneNumber': detailSource?.phoneNumber,
+                });
+              }
+              return (
+                <Input
+                  id={fieldKey}
+                  type={type}
+                  value={inputValue}
+                  onChange={(e) => {
+                    const updates: Record<string, string> = {
+                      [fieldKey]: e.target.value,
+                    };
+                    // Keep both key variants in sync so inputValue reads the latest value
+                    if (altKey) updates[altKey] = e.target.value;
+                    setEditedData((prev) => ({ ...prev, ...updates }));
+                  }}
+                  className='mt-1'
+                  placeholder='Not provided'
+                />
+              );
+            })()
           ) : (
-            (fieldKey === 'phoneNumber' && type === 'tel') || isEditing ? (
-              (() => {
-                // Use getDisplayValue which has correct priority: editedData > detailSource > client
-                let inputValue = getDisplayValue(fieldKey, altKey);
-                if (inputValue === '[redacted]') inputValue = '';
-                if (fieldKey === 'phoneNumber') {
-                  console.log('📱 [Input] Phone input render:', {
-                    fieldKey,
-                    altKey,
-                    inputValue,
-                    'editedData.phoneNumber': editedData.phoneNumber,
-                    'editedData.phone_number': (editedData as any).phone_number,
-                    'detailSource?.phoneNumber': detailSource?.phoneNumber,
-                  });
-                }
-                return (
-              <Input
-                id={fieldKey}
-                type={type}
-                value={inputValue}
-                onChange={(e) => {
-                  const updates: Record<string, string> = { [fieldKey]: e.target.value };
-                  // Keep both key variants in sync so inputValue reads the latest value
-                  if (altKey) updates[altKey] = e.target.value;
-                  setEditedData(prev => ({ ...prev, ...updates }));
-                }}
-                className="mt-1"
-                placeholder="Not provided"
-              />
-                );
-              })()
-            ) : (
-              <div className="mt-1 px-3 py-2 border rounded-md bg-muted/50 text-sm">
-                {String(value || 'Not provided')}
-              </div>
-            )
+            <div className='mt-1 px-3 py-2 border rounded-md bg-muted/50 text-sm'>
+              {String(value || 'Not provided')}
+            </div>
           )}
         </div>
       </div>
@@ -1684,19 +2065,26 @@ export function LeadProfileModal({
       <Collapsible
         open={isOpen}
         onOpenChange={(nextOpen) => setSectionOpen(sectionId, nextOpen)}
-        className="border rounded-lg mb-3"
+        className='border rounded-lg mb-3'
       >
         <CollapsibleTrigger asChild>
-          <Button variant="ghost" className="w-full justify-between p-3 h-auto hover:bg-muted/50">
-            <div className="flex items-center gap-2">
+          <Button
+            variant='ghost'
+            className='w-full justify-between p-3 h-auto hover:bg-muted/50'
+          >
+            <div className='flex items-center gap-2'>
               {icon}
-              <span className="font-semibold">{title}</span>
+              <span className='font-semibold'>{title}</span>
             </div>
-            {isOpen ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+            {isOpen ? (
+              <ChevronDown className='h-4 w-4' />
+            ) : (
+              <ChevronRight className='h-4 w-4' />
+            )}
           </Button>
         </CollapsibleTrigger>
-        <CollapsibleContent className="px-3 pb-3">
-          <div className="space-y-2">{children}</div>
+        <CollapsibleContent className='px-3 pb-3'>
+          <div className='space-y-2'>{children}</div>
         </CollapsibleContent>
       </Collapsible>
     );
@@ -1737,34 +2125,53 @@ export function LeadProfileModal({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="left-0 top-0 h-[100dvh] max-h-[100dvh] w-full max-w-full translate-x-0 translate-y-0 overflow-y-auto rounded-none sm:left-[50%] sm:top-[50%] sm:h-auto sm:max-h-[90vh] sm:max-w-4xl sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg"
+        className='left-0 top-0 h-[100dvh] max-h-[100dvh] w-full max-w-full translate-x-0 translate-y-0 overflow-y-auto rounded-none sm:left-[50%] sm:top-[50%] sm:h-auto sm:max-h-[90vh] sm:max-w-4xl sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg'
         data-testid={`lead-profile-dialog-${String(client.id)}`}
       >
-        <DialogHeader className="pb-4">
-          <div className="flex flex-col gap-3 pr-8 sm:flex-row sm:items-center sm:justify-between">
-            <DialogTitle className="flex min-w-0 items-center gap-2">
-              <User className="h-5 w-5" />
+        <DialogHeader className='pb-4'>
+          <div className='flex flex-col gap-3 pr-8 sm:flex-row sm:items-center sm:justify-between'>
+            <DialogTitle className='flex min-w-0 items-center gap-2'>
+              <User className='h-5 w-5' />
               {(() => {
                 const c = detailSource ?? (client as Record<string, unknown>);
-                const first = (c.firstname ?? c.first_name ?? c.firstName) as string;
-                const last = (c.lastname ?? c.last_name ?? c.lastName) as string;
-                const title = first && last ? `${first} ${last}` : (c.email || `Client ${c.id}` || 'Client');
+                const first = (c.firstname ??
+                  c.first_name ??
+                  c.firstName) as string;
+                const last = (c.lastname ??
+                  c.last_name ??
+                  c.lastName) as string;
+                const title =
+                  first && last
+                    ? `${first} ${last}`
+                    : c.email || `Client ${c.id}` || 'Client';
                 return title as React.ReactNode;
               })()}
             </DialogTitle>
-            <div className="flex items-center gap-2">
+            <div className='flex items-center gap-2'>
               {isEditing ? (
                 <>
-                  <Button onClick={handleCancelEdit} variant="outline" size="sm">
+                  <Button
+                    onClick={handleCancelEdit}
+                    variant='outline'
+                    size='sm'
+                  >
                     Cancel
                   </Button>
-                  <Button onClick={handleSaveChanges} size="sm" disabled={isSaving}>
-                    <Save className="h-4 w-4 mr-1" />
+                  <Button
+                    onClick={handleSaveChanges}
+                    size='sm'
+                    disabled={isSaving}
+                  >
+                    <Save className='h-4 w-4 mr-1' />
                     {isSaving ? 'Saving...' : 'Save Changes'}
                   </Button>
                 </>
               ) : (
-                <Button onClick={() => setIsEditing(true)} variant="outline" size="sm">
+                <Button
+                  onClick={() => setIsEditing(true)}
+                  variant='outline'
+                  size='sm'
+                >
                   Edit
                 </Button>
               )}
@@ -1773,32 +2180,63 @@ export function LeadProfileModal({
         </DialogHeader>
 
         {detailedClient != null ? (
-          <div className="space-y-3">
+          <div className='space-y-3'>
             {/* Contact & Basic Info */}
             {renderCollapsibleSection(
               'contact',
               'Contact Information',
               <>
-                {(getDisplayValue('clientNumber', 'client_number') || getDisplayValue('client_number', 'clientNumber')) && (
-                  <div className="flex items-start gap-2 py-2">
-                    <div className="flex-1 min-w-0">
-                      <Label className="text-sm font-medium text-muted-foreground">Client #</Label>
-                      <div className="mt-1 px-3 py-2 border rounded-md bg-muted/50 text-sm font-mono">
-                        {getDisplayValue('clientNumber', 'client_number') || getDisplayValue('client_number', 'clientNumber')}
+                {(getDisplayValue('clientNumber', 'client_number') ||
+                  getDisplayValue('client_number', 'clientNumber')) && (
+                  <div className='flex items-start gap-2 py-2'>
+                    <div className='flex-1 min-w-0'>
+                      <Label className='text-sm font-medium text-muted-foreground'>
+                        Client #
+                      </Label>
+                      <div className='mt-1 px-3 py-2 border rounded-md bg-muted/50 text-sm font-mono'>
+                        {getDisplayValue('clientNumber', 'client_number') ||
+                          getDisplayValue('client_number', 'clientNumber')}
                       </div>
                     </div>
                   </div>
                 )}
                 {renderEditableField('First Name', 'firstname')}
                 {renderEditableField('Last Name', 'lastname')}
-                {renderEditableField('Email', 'email', <Mail className="h-4 w-4" />, 'email')}
-                {renderEditableField('Phone Number', 'phoneNumber', <Phone className="h-4 w-4" />, 'tel')}
-                {renderEditableField('Preferred Contact Method', 'preferred_contact_method', undefined, 'select', PREFERRED_CONTACT_OPTIONS)}
+                {renderEditableField(
+                  'Email',
+                  'email',
+                  <Mail className='h-4 w-4' />,
+                  'email'
+                )}
+                {renderEditableField(
+                  'Phone Number',
+                  'phoneNumber',
+                  <Phone className='h-4 w-4' />,
+                  'tel'
+                )}
+                {renderEditableField(
+                  'Preferred Contact Method',
+                  'preferred_contact_method',
+                  undefined,
+                  'select',
+                  PREFERRED_CONTACT_OPTIONS
+                )}
                 {renderEditableField('Preferred Name', 'preferred_name')}
                 {renderEditableField('Age', 'age', undefined, 'number')}
-                {renderEditableField('Pronouns', 'pronouns', undefined, 'select', PRONOUNS_OPTIONS)}
+                {renderEditableField(
+                  'Pronouns',
+                  'pronouns',
+                  undefined,
+                  'select',
+                  PRONOUNS_OPTIONS
+                )}
                 {renderEditableField('Children Expected', 'children_expected')}
-                {renderEditableField('Address', 'address', <MapPin className="h-4 w-4" />, 'textarea')}
+                {renderEditableField(
+                  'Address',
+                  'address',
+                  <MapPin className='h-4 w-4' />,
+                  'textarea'
+                )}
                 {renderEditableField('City', 'city')}
                 {renderEditableField('State', 'state')}
                 {renderEditableField('ZIP Code', 'zip_code')}
@@ -1811,7 +2249,8 @@ export function LeadProfileModal({
                 )}
                 {normalizeHomeTypeFromApi(editedData.home_type).includes(
                   HOME_TYPE_OTHER_VALUE
-                ) && renderEditableField('Home Type (Other)', 'home_type_other')}
+                ) &&
+                  renderEditableField('Home Type (Other)', 'home_type_other')}
                 {renderEditableField('Home Access', 'home_access')}
                 {renderEditableField('Pets/Animals in Home', 'pets')}
                 {renderEditableField(
@@ -1829,7 +2268,7 @@ export function LeadProfileModal({
                   [...HOME_PEOPLE_COUNT_OPTIONS]
                 )}
               </>,
-              <User className="h-5 w-5" />
+              <User className='h-5 w-5' />
             )}
 
             {/* Services Requested */}
@@ -1837,25 +2276,59 @@ export function LeadProfileModal({
               'services',
               'Services Requested',
               <>
-                {renderEditableField('Services Interested', 'services_interested', undefined, 'multiselect', SERVICES_OPTIONS)}
-                {renderEditableField('Service Support Details', 'service_support_details', undefined, 'textarea')}
-                {renderEditableField('Service Needed', 'service_needed', undefined, 'textarea')}
-                {renderEditableField('Service Specifics', 'service_specifics', undefined, 'textarea')}
-                {renderEditableField('Annual Income', 'annual_income', undefined, 'select', ANNUAL_INCOME_OPTIONS)}
+                {renderEditableField(
+                  'Services Interested',
+                  'services_interested',
+                  undefined,
+                  'multiselect',
+                  SERVICES_OPTIONS
+                )}
+                {renderEditableField(
+                  'Service Support Details',
+                  'service_support_details',
+                  undefined,
+                  'textarea'
+                )}
+                {renderEditableField(
+                  'Service Needed',
+                  'service_needed',
+                  undefined,
+                  'textarea'
+                )}
+                {renderEditableField(
+                  'Service Specifics',
+                  'service_specifics',
+                  undefined,
+                  'textarea'
+                )}
+                {renderEditableField(
+                  'Annual Income',
+                  'annual_income',
+                  undefined,
+                  'select',
+                  ANNUAL_INCOME_OPTIONS
+                )}
               </>,
-              <FileText className="h-5 w-5" />
+              <FileText className='h-5 w-5' />
             )}
 
             {/* Billing */}
             {renderCollapsibleSection(
               'billing',
               (() => {
-                const pm = String(getDisplayValue('payment_method', 'paymentMethod') || '');
+                const pm = String(
+                  getDisplayValue('payment_method', 'paymentMethod') || ''
+                );
                 const authStatus = String(
-                  getDisplayValue('payment_authorization_status', 'paymentAuthorizationStatus') || ''
+                  getDisplayValue(
+                    'payment_authorization_status',
+                    'paymentAuthorizationStatus'
+                  ) || ''
                 ) as PaymentAuthorizationStatus | '';
                 const statusLabel = authStatus
-                  ? (PAYMENT_AUTHORIZATION_STATUS_LABELS[authStatus as PaymentAuthorizationStatus] ?? authStatus)
+                  ? (PAYMENT_AUTHORIZATION_STATUS_LABELS[
+                      authStatus as PaymentAuthorizationStatus
+                    ] ?? authStatus)
                   : null;
                 const statusColors: Record<string, string> = {
                   not_required: 'bg-green-100 text-green-800',
@@ -1864,15 +2337,17 @@ export function LeadProfileModal({
                   failed: 'bg-red-100 text-red-800',
                 };
                 return (
-                  <div className="flex items-center gap-2">
+                  <div className='flex items-center gap-2'>
                     <span>Billing Information</span>
                     {pm && (
-                      <Badge variant="outline" className="text-xs font-normal">
+                      <Badge variant='outline' className='text-xs font-normal'>
                         {pm}
                       </Badge>
                     )}
                     {statusLabel && (
-                      <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${statusColors[authStatus] ?? 'bg-muted text-muted-foreground'}`}>
+                      <span
+                        className={`text-xs px-2 py-0.5 rounded-full font-medium ${statusColors[authStatus] ?? 'bg-muted text-muted-foreground'}`}
+                      >
                         {statusLabel}
                       </span>
                     )}
@@ -1880,35 +2355,63 @@ export function LeadProfileModal({
                 );
               })(),
               <>
-                <div className="rounded-lg border bg-muted/30 p-4 space-y-3">
-                  <p className="text-sm font-medium text-foreground">Portal onboarding readiness</p>
-                  <div className="grid gap-2 sm:grid-cols-2 text-sm">
-                    <div className="flex justify-between gap-2">
-                      <span className="text-muted-foreground">Contract signed</span>
-                      <span>{formatYesNo(readinessSummary.contractSigned)}</span>
+                <div className='rounded-lg border bg-muted/30 p-4 space-y-3'>
+                  <p className='text-sm font-medium text-foreground'>
+                    Portal onboarding readiness
+                  </p>
+                  <div className='grid gap-2 sm:grid-cols-2 text-sm'>
+                    <div className='flex justify-between gap-2'>
+                      <span className='text-muted-foreground'>
+                        Contract signed
+                      </span>
+                      <span>
+                        {formatYesNo(readinessSummary.contractSigned)}
+                      </span>
                     </div>
-                    <div className="flex justify-between gap-2">
-                      <span className="text-muted-foreground">Deposit paid</span>
+                    <div className='flex justify-between gap-2'>
+                      <span className='text-muted-foreground'>
+                        Deposit paid
+                      </span>
                       <span>{formatYesNo(readinessSummary.depositPaid)}</span>
                     </div>
-                    <div className="flex justify-between gap-2">
-                      <span className="text-muted-foreground">Billing path</span>
-                      <span>{getBillingPathLabel(readinessSummary.billingPath)}</span>
+                    <div className='flex justify-between gap-2'>
+                      <span className='text-muted-foreground'>
+                        Billing path
+                      </span>
+                      <span>
+                        {getBillingPathLabel(readinessSummary.billingPath)}
+                      </span>
                     </div>
-                    <div className="flex justify-between gap-2">
-                      <span className="text-muted-foreground">Payment authorization required</span>
-                      <span>{formatYesNo(readinessSummary.paymentAuthorizationRequired)}</span>
+                    <div className='flex justify-between gap-2'>
+                      <span className='text-muted-foreground'>
+                        Payment authorization required
+                      </span>
+                      <span>
+                        {formatYesNo(
+                          readinessSummary.paymentAuthorizationRequired
+                        )}
+                      </span>
                     </div>
-                    <div className="flex justify-between gap-2">
-                      <span className="text-muted-foreground">Payment authorization satisfied</span>
-                      <span>{formatYesNo(readinessSummary.paymentAuthorizationSatisfied)}</span>
+                    <div className='flex justify-between gap-2'>
+                      <span className='text-muted-foreground'>
+                        Payment authorization satisfied
+                      </span>
+                      <span>
+                        {formatYesNo(
+                          readinessSummary.paymentAuthorizationSatisfied
+                        )}
+                      </span>
                     </div>
-                    <div className="flex justify-between gap-2">
-                      <span className="text-muted-foreground">Card on file</span>
+                    <div className='flex justify-between gap-2'>
+                      <span className='text-muted-foreground'>
+                        Card on file
+                      </span>
                       <span>{formatYesNo(readinessSummary.cardOnFile)}</span>
                     </div>
-                    <div className="flex justify-between gap-2">
-                      <span className="text-muted-foreground">Portal eligibility</span>
+                    <div className='flex justify-between gap-2'>
+                      <span className='text-muted-foreground'>
+                        Portal eligibility
+                      </span>
                       <span>
                         {readinessSummary.portalEligibility === 'eligible'
                           ? 'Eligible'
@@ -1918,94 +2421,258 @@ export function LeadProfileModal({
                       </span>
                     </div>
                     {readinessSummary.primaryBlocker ? (
-                      <div className="flex justify-between gap-2 sm:col-span-2">
-                        <span className="text-muted-foreground">Primary blocker</span>
-                        <span>{getPortalBlockerLabel(readinessSummary.primaryBlocker)}</span>
+                      <div className='flex justify-between gap-2 sm:col-span-2'>
+                        <span className='text-muted-foreground'>
+                          Primary blocker
+                        </span>
+                        <span>
+                          {getPortalBlockerLabel(
+                            readinessSummary.primaryBlocker
+                          )}
+                        </span>
                       </div>
                     ) : null}
                   </div>
                   {readinessSummary.primaryBlocker ? (
-                    <p className="text-xs text-muted-foreground">
-                      {getPortalBlockerDescription(readinessSummary.primaryBlocker)}
+                    <p className='text-xs text-muted-foreground'>
+                      {getPortalBlockerDescription(
+                        readinessSummary.primaryBlocker
+                      )}
                     </p>
                   ) : null}
                 </div>
-                <div className="rounded-lg border p-4 space-y-3" aria-label="Card on file status">
-                  <p className="text-sm font-medium">Card on file: {cardStatus ? cardStatus.status.replace('_', ' ').replace(/^./, c => c.toUpperCase()) : '—'}</p>
+                <div
+                  className='rounded-lg border p-4 space-y-3'
+                  aria-label='Card on file status'
+                >
+                  <p className='text-sm font-medium'>
+                    Card on file:{' '}
+                    {cardStatus
+                      ? cardStatus.status
+                          .replace('_', ' ')
+                          .replace(/^./, (c) => c.toUpperCase())
+                      : '—'}
+                  </p>
                   {cardStatus?.status === 'active' && cardStatus.last4 ? (
-                    <div className="text-sm text-muted-foreground">
-                      <p>{cardStatus.card_brand || 'Card'} ending in {cardStatus.last4}</p>
-                      {cardStatus.exp_month && cardStatus.exp_year ? <p>Expires {String(cardStatus.exp_month).padStart(2, '0')}/{cardStatus.exp_year}</p> : null}
+                    <div className='text-sm text-muted-foreground'>
+                      <p>
+                        {cardStatus.card_brand || 'Card'} ending in{' '}
+                        {cardStatus.last4}
+                      </p>
+                      {cardStatus.exp_month && cardStatus.exp_year ? (
+                        <p>
+                          Expires{' '}
+                          {String(cardStatus.exp_month).padStart(2, '0')}/
+                          {cardStatus.exp_year}
+                        </p>
+                      ) : null}
                     </div>
                   ) : null}
                 </div>
-                <div className="rounded-lg border p-4 space-y-3" aria-label="Payment Schedule">
-                  <p className="text-sm font-medium">Payment Schedule</p>
-                  {billingLoading ? <p className="text-sm text-muted-foreground flex items-center gap-2"><Loader2 className="h-4 w-4 animate-spin" />Loading payment schedule…</p> : null}
-                  {billingError ? <p role="alert" className="text-sm text-destructive">{billingError}</p> : null}
-                  {!billingLoading && !billingError && installments.length === 0 ? <p className="text-sm text-muted-foreground">No payment schedule has been created for this client.</p> : null}
-                  {!billingLoading && !billingError && installments.length > 0 ? (
-                    <div className="space-y-3">
-                      {installments.map(item => {
-                          const label = item.payment_type === 'deposit' ? 'Deposit' : `Installment ${item.installment_number}`;
-                          const detail = (name: string, value: React.ReactNode) => (
-                            <div className="min-w-0">
-                              <dt className="text-xs font-medium text-muted-foreground">{name}</dt>
-                              <dd className="mt-0.5 break-words text-sm text-foreground">{value || '—'}</dd>
+                <div
+                  className='rounded-lg border p-4 space-y-3'
+                  aria-label='Payment Schedule'
+                >
+                  <p className='text-sm font-medium'>Payment Schedule</p>
+                  {billingLoading ? (
+                    <p className='text-sm text-muted-foreground flex items-center gap-2'>
+                      <Loader2 className='h-4 w-4 animate-spin' />
+                      Loading payment schedule…
+                    </p>
+                  ) : null}
+                  {billingError ? (
+                    <p role='alert' className='text-sm text-destructive'>
+                      {billingError}
+                    </p>
+                  ) : null}
+                  {!billingLoading &&
+                  !billingError &&
+                  installments.length === 0 ? (
+                    <p className='text-sm text-muted-foreground'>
+                      No payment schedule has been created for this client.
+                    </p>
+                  ) : null}
+                  {!billingLoading &&
+                  !billingError &&
+                  installments.length > 0 ? (
+                    <div className='space-y-3'>
+                      {installments.map((item) => {
+                        const label =
+                          item.payment_type === 'deposit'
+                            ? 'Deposit'
+                            : `Installment ${item.installment_number}`;
+                        const detail = (
+                          name: string,
+                          value: React.ReactNode
+                        ) => (
+                          <div className='min-w-0'>
+                            <dt className='text-xs font-medium text-muted-foreground'>
+                              {name}
+                            </dt>
+                            <dd className='mt-0.5 break-words text-sm text-foreground'>
+                              {value || '—'}
+                            </dd>
+                          </div>
+                        );
+                        return (
+                          <article
+                            key={item.id}
+                            className='rounded-lg border bg-background p-4'
+                          >
+                            <div className='flex flex-wrap items-start justify-between gap-3 border-b pb-3'>
+                              <div>
+                                <h4 className='font-medium text-foreground'>
+                                  {label}
+                                </h4>
+                                <p className='mt-1 break-all font-mono text-xs text-muted-foreground'>
+                                  {item.id}
+                                </p>
+                              </div>
+                              <div className='text-right'>
+                                <p className='text-lg font-semibold text-foreground'>
+                                  {new Intl.NumberFormat('en-US', {
+                                    style: 'currency',
+                                    currency: 'USD',
+                                  }).format(item.amount)}
+                                </p>
+                                <Badge
+                                  variant='outline'
+                                  className='mt-1 capitalize'
+                                >
+                                  {item.payment_status}
+                                </Badge>
+                              </div>
                             </div>
-                          );
-                          return (
-                            <article key={item.id} className="rounded-lg border bg-background p-4">
-                              <div className="flex flex-wrap items-start justify-between gap-3 border-b pb-3">
-                                <div>
-                                  <h4 className="font-medium text-foreground">{label}</h4>
-                                  <p className="mt-1 break-all font-mono text-xs text-muted-foreground">{item.id}</p>
-                                </div>
-                                <div className="text-right">
-                                  <p className="text-lg font-semibold text-foreground">{new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(item.amount)}</p>
-                                  <Badge variant="outline" className="mt-1 capitalize">{item.payment_status}</Badge>
-                                </div>
-                              </div>
-                              <dl className="grid grid-cols-2 gap-x-5 gap-y-3 py-4 sm:grid-cols-3 lg:grid-cols-4">
-                                {detail('Payment type', <span className="capitalize">{item.payment_type}</span>)}
-                                {detail('Due date', item.due_date ? format(parseISO(item.due_date), 'MMM d, yyyy') : '—')}
-                                {detail('Paid date', item.paid_date ? format(parseISO(item.paid_date), 'MMM d, yyyy') : '—')}
-                                {detail('Overdue', item.is_overdue ? 'Yes' : 'No')}
-                                {detail('QBO status', item.qbo_invoice_status || '—')}
-                                {detail('QBO invoice ID', item.qbo_invoice_id || '—')}
-                                {detail('Payment link', item.payment_link ? <a href={item.payment_link} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-primary underline underline-offset-2">Open invoice <ExternalLink className="h-3 w-3" /></a> : '—')}
-                              </dl>
-                              <div className="flex flex-col items-start gap-2 border-t pt-3 sm:flex-row sm:items-center sm:justify-between">
-                                {!item.available_action.enabled && item.available_action.reason ? <p className="text-xs text-muted-foreground">{item.available_action.reason}</p> : <span />}
-                                <Button className="w-full sm:w-auto" type="button" size="sm" disabled={!item.available_action.enabled || isGeneratingInvoice} title={item.available_action.reason || undefined} onClick={() => void handleGenerateInstallmentInvoice(item)}>{isGeneratingInvoice ? 'Generating…' : 'Generate Next Installment Invoice'}</Button>
-                              </div>
-                            </article>
-                          );
-                        })}
+                            <dl className='grid grid-cols-2 gap-x-5 gap-y-3 py-4 sm:grid-cols-3 lg:grid-cols-4'>
+                              {detail(
+                                'Payment type',
+                                <span className='capitalize'>
+                                  {item.payment_type}
+                                </span>
+                              )}
+                              {detail(
+                                'Due date',
+                                item.due_date
+                                  ? format(
+                                      parseISO(item.due_date),
+                                      'MMM d, yyyy'
+                                    )
+                                  : '—'
+                              )}
+                              {detail(
+                                'Paid date',
+                                item.paid_date
+                                  ? format(
+                                      parseISO(item.paid_date),
+                                      'MMM d, yyyy'
+                                    )
+                                  : '—'
+                              )}
+                              {detail(
+                                'Overdue',
+                                item.is_overdue ? 'Yes' : 'No'
+                              )}
+                              {detail(
+                                'QBO status',
+                                item.qbo_invoice_status || '—'
+                              )}
+                              {detail(
+                                'QBO invoice ID',
+                                item.qbo_invoice_id || '—'
+                              )}
+                              {detail(
+                                'Payment link',
+                                item.payment_link ? (
+                                  <a
+                                    href={item.payment_link}
+                                    target='_blank'
+                                    rel='noopener noreferrer'
+                                    className='inline-flex items-center gap-1 text-primary underline underline-offset-2'
+                                  >
+                                    Open invoice{' '}
+                                    <ExternalLink className='h-3 w-3' />
+                                  </a>
+                                ) : (
+                                  '—'
+                                )
+                              )}
+                            </dl>
+                            <div className='flex flex-col items-start gap-2 border-t pt-3 sm:flex-row sm:items-center sm:justify-between'>
+                              {!item.available_action.enabled &&
+                              item.available_action.reason ? (
+                                <p className='text-xs text-muted-foreground'>
+                                  {item.available_action.reason}
+                                </p>
+                              ) : (
+                                <span />
+                              )}
+                              <Button
+                                className='w-full sm:w-auto'
+                                type='button'
+                                size='sm'
+                                disabled={
+                                  !item.available_action.enabled ||
+                                  isGeneratingInvoice
+                                }
+                                title={
+                                  item.available_action.reason || undefined
+                                }
+                                onClick={() =>
+                                  void handleGenerateInstallmentInvoice(item)
+                                }
+                              >
+                                {isGeneratingInvoice
+                                  ? 'Generating…'
+                                  : 'Generate Next Installment Invoice'}
+                              </Button>
+                            </div>
+                          </article>
+                        );
+                      })}
                     </div>
                   ) : null}
-                  {generatedInvoiceLink ? <a href={generatedInvoiceLink} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-sm text-primary underline">Open invoice <ExternalLink className="h-3 w-3" /></a> : null}
+                  {generatedInvoiceLink ? (
+                    <a
+                      href={generatedInvoiceLink}
+                      target='_blank'
+                      rel='noopener noreferrer'
+                      className='inline-flex items-center gap-1 text-sm text-primary underline'
+                    >
+                      Open invoice <ExternalLink className='h-3 w-3' />
+                    </a>
+                  ) : null}
                 </div>
                 {(() => {
                   const legacyAuth = String(
-                    getDisplayValue('payment_authorization_status', 'paymentAuthorizationStatus') || ''
+                    getDisplayValue(
+                      'payment_authorization_status',
+                      'paymentAuthorizationStatus'
+                    ) || ''
                   ).trim();
                   if (!legacyAuth) return null;
                   return (
-                    <div className="rounded-lg border border-dashed px-3 py-2 text-xs text-muted-foreground">
+                    <div className='rounded-lg border border-dashed px-3 py-2 text-xs text-muted-foreground'>
                       Legacy PDF authorization status:{' '}
-                      <span className="font-medium text-foreground">
+                      <span className='font-medium text-foreground'>
                         {PAYMENT_AUTHORIZATION_STATUS_LABELS[
                           legacyAuth as PaymentAuthorizationStatus
                         ] ?? legacyAuth}
-                      </span>
-                      {' '}(historical display only)
+                      </span>{' '}
+                      (historical display only)
                     </div>
                   );
                 })()}
-                {renderEditableField('Payment Method', 'payment_method', undefined, 'select', [...ALL_PAYMENT_METHOD_OPTIONS])}
+                {renderEditableField(
+                  'Payment Method',
+                  'payment_method',
+                  undefined,
+                  'select',
+                  [...ALL_PAYMENT_METHOD_OPTIONS]
+                )}
                 {(() => {
-                  const pm = String(getDisplayValue('payment_method', 'paymentMethod') || '');
+                  const pm = String(
+                    getDisplayValue('payment_method', 'paymentMethod') || ''
+                  );
                   const msg = getPaymentMethodMessage(pm);
                   if (!msg) return null;
                   const colors =
@@ -2013,56 +2680,82 @@ export function LeadProfileModal({
                       ? 'bg-green-50 border-green-200 text-green-800'
                       : 'bg-blue-50 border-blue-200 text-blue-800';
                   return (
-                    <div className={`rounded-lg border px-4 py-3 text-sm ${colors}`}>
+                    <div
+                      className={`rounded-lg border px-4 py-3 text-sm ${colors}`}
+                    >
                       {msg.text}
                     </div>
                   );
                 })()}
                 {(() => {
-                  const pmForStaff = String(getDisplayValue('payment_method', 'paymentMethod') || '');
+                  const pmForStaff = String(
+                    getDisplayValue('payment_method', 'paymentMethod') || ''
+                  );
                   const authForStaff = String(
-                    getDisplayValue('payment_authorization_status', 'paymentAuthorizationStatus') || ''
+                    getDisplayValue(
+                      'payment_authorization_status',
+                      'paymentAuthorizationStatus'
+                    ) || ''
                   )
                     .trim()
                     .toLowerCase();
-                  const needsAuthOnFile = requiresPaymentMethodOnFile(pmForStaff);
+                  const needsAuthOnFile =
+                    requiresPaymentMethodOnFile(pmForStaff);
                   const alreadyOnFile = authForStaff === 'on_file';
-                  const atRaw = getDisplayValue('authorized_at', 'authorizedAt');
+                  const atRaw = getDisplayValue(
+                    'authorized_at',
+                    'authorizedAt'
+                  );
                   let atLabel = '';
                   if (atRaw) {
                     const parsed = parseISO(atRaw);
-                    atLabel = isValid(parsed) ? format(parsed, 'MMM d, yyyy · h:mm a') : atRaw;
+                    atLabel = isValid(parsed)
+                      ? format(parsed, 'MMM d, yyyy · h:mm a')
+                      : atRaw;
                   }
                   if (!needsAuthOnFile) return null;
                   return (
-                    <div className="rounded-lg border border-dashed border-primary/35 bg-muted/40 p-3 space-y-2">
-                      <p className="text-sm font-medium text-foreground">Staff: payment authorization</p>
-                      <p className="text-xs text-muted-foreground leading-snug">
-                        When you receive a signed payment authorization form (or equivalent), record it here so
-                        status shows <strong>On file</strong> in this profile and the Clients list.
+                    <div className='rounded-lg border border-dashed border-primary/35 bg-muted/40 p-3 space-y-2'>
+                      <p className='text-sm font-medium text-foreground'>
+                        Staff: payment authorization
+                      </p>
+                      <p className='text-xs text-muted-foreground leading-snug'>
+                        When you receive a signed payment authorization form (or
+                        equivalent), record it here so status shows{' '}
+                        <strong>On file</strong> in this profile and the Clients
+                        list.
                       </p>
                       {alreadyOnFile ? (
-                        <div className="flex flex-wrap items-center gap-2 text-sm">
-                          <Badge variant="outline" className="bg-blue-50 text-blue-900 border-blue-200">
+                        <div className='flex flex-wrap items-center gap-2 text-sm'>
+                          <Badge
+                            variant='outline'
+                            className='bg-blue-50 text-blue-900 border-blue-200'
+                          >
                             On file
                           </Badge>
                           {atLabel ? (
-                            <span className="text-muted-foreground text-xs">Recorded {atLabel}</span>
+                            <span className='text-muted-foreground text-xs'>
+                              Recorded {atLabel}
+                            </span>
                           ) : (
-                            <span className="text-muted-foreground text-xs">Date not stored</span>
+                            <span className='text-muted-foreground text-xs'>
+                              Date not stored
+                            </span>
                           )}
                         </div>
                       ) : (
                         <Button
-                          type="button"
-                          size="sm"
-                          onClick={() => void handleRecordPaymentAuthorization()}
+                          type='button'
+                          size='sm'
+                          onClick={() =>
+                            void handleRecordPaymentAuthorization()
+                          }
                           disabled={isRecordingPaymentAuth}
-                          className="w-fit"
+                          className='w-fit'
                         >
                           {isRecordingPaymentAuth ? (
                             <>
-                              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                              <Loader2 className='mr-2 h-4 w-4 animate-spin' />
                               Saving…
                             </>
                           ) : (
@@ -2073,11 +2766,14 @@ export function LeadProfileModal({
                     </div>
                   );
                 })()}
-                {requiresInsuranceDetails(String(getDisplayValue('payment_method', 'paymentMethod') || '')) ||
-                hasInsuranceDetails ? (
+                {requiresInsuranceDetails(
+                  String(
+                    getDisplayValue('payment_method', 'paymentMethod') || ''
+                  )
+                ) || hasInsuranceDetails ? (
                   <>
-                    <div className="rounded-lg border p-3 space-y-3">
-                      <div className="grid gap-3 lg:grid-cols-2">
+                    <div className='rounded-lg border p-3 space-y-3'>
+                      <div className='grid gap-3 lg:grid-cols-2'>
                         {[
                           {
                             side: 'front' as const,
@@ -2090,10 +2786,15 @@ export function LeadProfileModal({
                             document: backInsuranceCard,
                           },
                         ].map((slot) => (
-                          <div key={slot.side} className="rounded-lg border border-dashed p-3 space-y-3">
+                          <div
+                            key={slot.side}
+                            className='rounded-lg border border-dashed p-3 space-y-3'
+                          >
                             <div>
-                              <p className="font-medium">Insurance {slot.label.toLowerCase()}</p>
-                              <p className="text-sm text-muted-foreground">
+                              <p className='font-medium'>
+                                Insurance {slot.label.toLowerCase()}
+                              </p>
+                              <p className='text-sm text-muted-foreground'>
                                 {slot.document
                                   ? 'Uploaded files are shown below. Image files are previewed inline.'
                                   : `No ${slot.label.toLowerCase()} uploaded yet.`}
@@ -2101,8 +2802,8 @@ export function LeadProfileModal({
                             </div>
 
                             {documentsLoading ? (
-                              <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                                <Loader2 className="h-4 w-4 animate-spin" />
+                              <div className='flex items-center gap-2 text-sm text-muted-foreground'>
+                                <Loader2 className='h-4 w-4 animate-spin' />
                                 Loading uploaded documents...
                               </div>
                             ) : slot.document ? (
@@ -2112,8 +2813,16 @@ export function LeadProfileModal({
                         ))}
                       </div>
                     </div>
-                    {renderEditableField('Policy Holder Name', 'insurance_policy_holder_name')}
-                    {renderEditableField('Policy Holder Date of Birth', 'insurance_policy_holder_dob', undefined, 'date')}
+                    {renderEditableField(
+                      'Policy Holder Name',
+                      'insurance_policy_holder_name'
+                    )}
+                    {renderEditableField(
+                      'Policy Holder Date of Birth',
+                      'insurance_policy_holder_dob',
+                      undefined,
+                      'date'
+                    )}
                     {renderEditableField(
                       'Policy Holder Relationship to Client',
                       'insurance_policy_holder_relationship',
@@ -2121,9 +2830,18 @@ export function LeadProfileModal({
                       'select',
                       [...INSURANCE_POLICY_HOLDER_RELATIONSHIP_OPTIONS]
                     )}
-                    {renderEditableField('Insurance Company Name', 'insurance_provider')}
-                    {renderEditableField('Member ID / Subscriber ID', 'insurance_member_id')}
-                    {renderEditableField('Group Number (optional)', 'policy_number')}
+                    {renderEditableField(
+                      'Insurance Company Name',
+                      'insurance_provider'
+                    )}
+                    {renderEditableField(
+                      'Member ID / Subscriber ID',
+                      'insurance_member_id'
+                    )}
+                    {renderEditableField(
+                      'Group Number (optional)',
+                      'policy_number'
+                    )}
                     {renderEditableField(
                       'Plan Type',
                       'insurance_plan_type',
@@ -2131,18 +2849,31 @@ export function LeadProfileModal({
                       'select',
                       [...INSURANCE_PLAN_TYPE_OPTIONS]
                     )}
-                    {renderEditableField('Insurance Phone Number', 'insurance_phone_number')}
-                    <div className="py-2">
-                      <Label className="text-sm font-medium text-muted-foreground">Secondary Insurance</Label>
-                      <div className="text-sm text-foreground mt-1">
-                        {String(getDisplayValue('has_secondary_insurance', 'hasSecondaryInsurance') || '')
-                          .toLowerCase() === 'true'
+                    {renderEditableField(
+                      'Insurance Phone Number',
+                      'insurance_phone_number'
+                    )}
+                    <div className='py-2'>
+                      <Label className='text-sm font-medium text-muted-foreground'>
+                        Secondary Insurance
+                      </Label>
+                      <div className='text-sm text-foreground mt-1'>
+                        {String(
+                          getDisplayValue(
+                            'has_secondary_insurance',
+                            'hasSecondaryInsurance'
+                          ) || ''
+                        ).toLowerCase() === 'true'
                           ? 'Yes'
                           : 'No'}
                       </div>
                     </div>
-                    {String(getDisplayValue('has_secondary_insurance', 'hasSecondaryInsurance') || '')
-                      .toLowerCase() === 'true' ? (
+                    {String(
+                      getDisplayValue(
+                        'has_secondary_insurance',
+                        'hasSecondaryInsurance'
+                      ) || ''
+                    ).toLowerCase() === 'true' ? (
                       <>
                         {renderEditableField(
                           'Secondary Insurance Provider',
@@ -2161,7 +2892,7 @@ export function LeadProfileModal({
                   </>
                 ) : null}
               </>,
-              <FileText className="h-5 w-5" />
+              <FileText className='h-5 w-5' />
             )}
 
             {/* Family Information */}
@@ -2169,16 +2900,43 @@ export function LeadProfileModal({
               'family',
               'Family Information',
               <>
-                {renderEditableField('Relationship Status', 'relationship_status', undefined, 'select', RELATIONSHIP_OPTIONS)}
+                {renderEditableField(
+                  'Relationship Status',
+                  'relationship_status',
+                  undefined,
+                  'select',
+                  RELATIONSHIP_OPTIONS
+                )}
                 {renderEditableField('Family First Name', 'first_name')}
                 {renderEditableField('Family Last Name', 'last_name')}
                 {renderEditableField('Family Middle Name', 'middle_name')}
-                {renderEditableField('Family Pronouns', 'family_pronouns', undefined, 'select', FAMILY_PRONOUNS_OPTIONS)}
-                {renderEditableField('Family Email', 'family_email', <Mail className="h-4 w-4" />, 'email')}
-                {renderEditableField('Family Mobile Phone', 'mobile_phone', <Phone className="h-4 w-4" />, 'tel')}
-                {renderEditableField('Family Work Phone', 'work_phone', <Phone className="h-4 w-4" />, 'tel')}
+                {renderEditableField(
+                  'Family Pronouns',
+                  'family_pronouns',
+                  undefined,
+                  'select',
+                  FAMILY_PRONOUNS_OPTIONS
+                )}
+                {renderEditableField(
+                  'Family Email',
+                  'family_email',
+                  <Mail className='h-4 w-4' />,
+                  'email'
+                )}
+                {renderEditableField(
+                  'Family Mobile Phone',
+                  'mobile_phone',
+                  <Phone className='h-4 w-4' />,
+                  'tel'
+                )}
+                {renderEditableField(
+                  'Family Work Phone',
+                  'work_phone',
+                  <Phone className='h-4 w-4' />,
+                  'tel'
+                )}
               </>,
-              <Users className="h-5 w-5" />
+              <Users className='h-5 w-5' />
             )}
 
             {/* Referral Information */}
@@ -2191,19 +2949,25 @@ export function LeadProfileModal({
                   'referral_source',
                   undefined,
                   'select',
-                  [...REFERRAL_SOURCE_OPTIONS],
+                  [...REFERRAL_SOURCE_OPTIONS]
                 )}
-                {getDisplayValue('referral_source', null) === REFERRAL_SOURCE_OTHER_VALUE &&
+                {getDisplayValue('referral_source', null) ===
+                  REFERRAL_SOURCE_OTHER_VALUE &&
                   renderEditableField(
                     'How they heard about Sokana (other)',
                     'referral_source_other',
                     undefined,
-                    'textarea',
+                    'textarea'
                   )}
                 {renderEditableField('Referral Name', 'referral_name')}
-                {renderEditableField('Referral Email', 'referral_email', <Mail className="h-4 w-4" />, 'email')}
+                {renderEditableField(
+                  'Referral Email',
+                  'referral_email',
+                  <Mail className='h-4 w-4' />,
+                  'email'
+                )}
               </>,
-              <Users className="h-5 w-5" />
+              <Users className='h-5 w-5' />
             )}
 
             {/* Pregnancy & Health */}
@@ -2211,29 +2975,57 @@ export function LeadProfileModal({
               'health',
               'Pregnancy & Health Information',
               <>
-                {renderEditableField('Due Date', 'due_date', <CalendarIcon className="h-4 w-4" />, 'date')}
-                {renderEditableField('Birth Location', 'birth_location', undefined, 'select', BIRTH_LOCATION_OPTIONS)}
+                {renderEditableField(
+                  'Due Date',
+                  'due_date',
+                  <CalendarIcon className='h-4 w-4' />,
+                  'date'
+                )}
+                {renderEditableField(
+                  'Birth Location',
+                  'birth_location',
+                  undefined,
+                  'select',
+                  BIRTH_LOCATION_OPTIONS
+                )}
                 {renderEditableField('Birth Hospital', 'birth_hospital')}
-                {renderEditableField('Number of Babies', 'number_of_babies', undefined, 'select', NUMBER_OF_BABIES_OPTIONS)}
+                {renderEditableField(
+                  'Number of Babies',
+                  'number_of_babies',
+                  undefined,
+                  'select',
+                  NUMBER_OF_BABIES_OPTIONS
+                )}
                 {renderEditableField('Baby Name', 'baby_name')}
-                {renderEditableField('Provider Type', 'provider_type', undefined, 'select', PROVIDER_TYPE_OPTIONS)}
+                {renderEditableField(
+                  'Provider Type',
+                  'provider_type',
+                  undefined,
+                  'select',
+                  PROVIDER_TYPE_OPTIONS
+                )}
                 {renderEditableField('Pregnancy Number', 'pregnancy_number')}
-                {renderEditableField('Allergies', 'allergies', undefined, 'textarea')}
+                {renderEditableField(
+                  'Allergies',
+                  'allergies',
+                  undefined,
+                  'textarea'
+                )}
                 {renderEditableField(
                   PREGNANCY_BABY_POSTPARTUM_QUESTION_LABEL,
                   'health_history',
                   undefined,
-                  'textarea',
+                  'textarea'
                 )}
                 {String((editedData as any).health_notes ?? '').trim() !== '' &&
                   renderEditableField(
                     'Health notes (previous intake)',
                     'health_notes',
                     undefined,
-                    'textarea',
+                    'textarea'
                   )}
               </>,
-              <Baby className="h-5 w-5" />
+              <Baby className='h-5 w-5' />
             )}
 
             {/* Past Pregnancies */}
@@ -2241,17 +3033,32 @@ export function LeadProfileModal({
               'past-pregnancies',
               'Past Pregnancies',
               <>
-                <div className="py-2">
-                  <Label className="text-sm font-medium text-muted-foreground">Had Previous Pregnancies</Label>
-                  <div className="text-sm text-foreground mt-1">
-                    {(editedData as any).had_previous_pregnancies ? 'Yes' : 'No'}
+                <div className='py-2'>
+                  <Label className='text-sm font-medium text-muted-foreground'>
+                    Had Previous Pregnancies
+                  </Label>
+                  <div className='text-sm text-foreground mt-1'>
+                    {(editedData as any).had_previous_pregnancies
+                      ? 'Yes'
+                      : 'No'}
                   </div>
                 </div>
-                {renderEditableField('Previous Pregnancies Count', 'previous_pregnancies_count')}
-                {renderEditableField('Living Children Count', 'living_children_count')}
-                {renderEditableField('Past Pregnancy Experience', 'past_pregnancy_experience', undefined, 'textarea')}
+                {renderEditableField(
+                  'Previous Pregnancies Count',
+                  'previous_pregnancies_count'
+                )}
+                {renderEditableField(
+                  'Living Children Count',
+                  'living_children_count'
+                )}
+                {renderEditableField(
+                  'Past Pregnancy Experience',
+                  'past_pregnancy_experience',
+                  undefined,
+                  'textarea'
+                )}
               </>,
-              <Baby className="h-5 w-5" />
+              <Baby className='h-5 w-5' />
             )}
 
             {/* Demographics */}
@@ -2259,14 +3066,50 @@ export function LeadProfileModal({
               'demographics',
               'Demographics (Optional)',
               <>
-                {renderEditableField('Race/Ethnicity', 'race_ethnicity', undefined, 'select', RACE_OPTIONS)}
-                {renderEditableField('Primary Language', 'primary_language', undefined, 'select', LANGUAGE_OPTIONS)}
-                {renderEditableField('Client Age Range', 'client_age_range', undefined, 'select', AGE_OPTIONS)}
-                {renderEditableField('Insurance', 'insurance', undefined, 'select', INSURANCE_OPTIONS)}
-                {renderEditableField('Demographics Multi', 'demographics_multi', undefined, 'multiselect', DEMOGRAPHICS_MULTI_OPTIONS)}
-                {renderEditableField('Demographics Annual Income', 'demographics_annual_income', undefined, 'select', DEMOGRAPHICS_INCOME_OPTIONS)}
+                {renderEditableField(
+                  'Race/Ethnicity',
+                  'race_ethnicity',
+                  undefined,
+                  'select',
+                  RACE_OPTIONS
+                )}
+                {renderEditableField(
+                  'Primary Language',
+                  'primary_language',
+                  undefined,
+                  'select',
+                  LANGUAGE_OPTIONS
+                )}
+                {renderEditableField(
+                  'Client Age Range',
+                  'client_age_range',
+                  undefined,
+                  'select',
+                  AGE_OPTIONS
+                )}
+                {renderEditableField(
+                  'Insurance',
+                  'insurance',
+                  undefined,
+                  'select',
+                  INSURANCE_OPTIONS
+                )}
+                {renderEditableField(
+                  'Demographics Multi',
+                  'demographics_multi',
+                  undefined,
+                  'multiselect',
+                  DEMOGRAPHICS_MULTI_OPTIONS
+                )}
+                {renderEditableField(
+                  'Demographics Annual Income',
+                  'demographics_annual_income',
+                  undefined,
+                  'select',
+                  DEMOGRAPHICS_INCOME_OPTIONS
+                )}
               </>,
-              <Users className="h-5 w-5" />
+              <Users className='h-5 w-5' />
             )}
 
             {/* Account Information */}
@@ -2274,21 +3117,37 @@ export function LeadProfileModal({
               'account',
               'Account Information',
               <>
-                {renderEditableField('Client Status', 'status', undefined, 'select', CLIENT_STATUS_OPTIONS)}
-                <div className="py-2">
-                  <Label className="text-sm font-medium text-muted-foreground">Created At</Label>
-                  <div className="text-sm text-foreground mt-1">
-                    {(detailedClient as any).created_at ? new Date((detailedClient as any).created_at).toLocaleDateString() : 'Not provided'}
+                {renderEditableField(
+                  'Client Status',
+                  'status',
+                  undefined,
+                  'select',
+                  CLIENT_STATUS_OPTIONS
+                )}
+                <div className='py-2'>
+                  <Label className='text-sm font-medium text-muted-foreground'>
+                    Created At
+                  </Label>
+                  <div className='text-sm text-foreground mt-1'>
+                    {(detailedClient as any).created_at
+                      ? new Date(
+                          (detailedClient as any).created_at
+                        ).toLocaleDateString()
+                      : 'Not provided'}
                   </div>
                 </div>
-                <div className="py-2">
-                  <Label className="text-sm font-medium text-muted-foreground">Updated At</Label>
-                  <div className="text-sm text-foreground mt-1">
-                    {detailedClient.updatedAt ? new Date(detailedClient.updatedAt).toLocaleDateString() : 'Not provided'}
+                <div className='py-2'>
+                  <Label className='text-sm font-medium text-muted-foreground'>
+                    Updated At
+                  </Label>
+                  <div className='text-sm text-foreground mt-1'>
+                    {detailedClient.updatedAt
+                      ? new Date(detailedClient.updatedAt).toLocaleDateString()
+                      : 'Not provided'}
                   </div>
                 </div>
               </>,
-              <Users className="h-5 w-5" />
+              <Users className='h-5 w-5' />
             )}
 
             {/* Doula Assignment Section */}
@@ -2299,28 +3158,29 @@ export function LeadProfileModal({
                 clientId={String(client.id)}
                 canAssign={user?.role === 'admin'}
               />,
-              <Users className="h-5 w-5" />
+              <Users className='h-5 w-5' />
             )}
 
             {/* Birth outcomes — free-text narrative (doula); placed near Admin Notes */}
             {renderCollapsibleSection(
               'birth-outcomes',
-              <div className="flex items-center gap-2">
+              <div className='flex items-center gap-2'>
                 <span>Birth Outcomes</span>
                 {birthOutcomesHistory.length > 0 && (
-                  <span className="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded-full">
+                  <span className='text-xs bg-primary/10 text-primary px-2 py-0.5 rounded-full'>
                     {birthOutcomesHistory.length}
                   </span>
                 )}
               </div>,
               <>
-                <p className="text-sm text-muted-foreground -mt-1 mb-1">
-                  Structured birth outcomes for reporting. All fields are required.
+                <p className='text-sm text-muted-foreground -mt-1 mb-1'>
+                  Structured birth outcomes for reporting. All fields are
+                  required.
                 </p>
-                <div className="rounded-lg border p-3 space-y-3">
-                  <div className="space-y-2">
-                    <Label className="text-sm font-medium text-muted-foreground">
-                      Induction <span className="text-destructive">*</span>
+                <div className='rounded-lg border p-3 space-y-3'>
+                  <div className='space-y-2'>
+                    <Label className='text-sm font-medium text-muted-foreground'>
+                      Induction <span className='text-destructive'>*</span>
                     </Label>
                     {isEditing ? (
                       <Select
@@ -2344,16 +3204,16 @@ export function LeadProfileModal({
                           }));
                         }}
                       >
-                        <SelectTrigger className="mt-1">
-                          <SelectValue placeholder="Select..." />
+                        <SelectTrigger className='mt-1'>
+                          <SelectValue placeholder='Select...' />
                         </SelectTrigger>
                         <SelectContent>
-                          <SelectItem value="true">Yes</SelectItem>
-                          <SelectItem value="false">No</SelectItem>
+                          <SelectItem value='true'>Yes</SelectItem>
+                          <SelectItem value='false'>No</SelectItem>
                         </SelectContent>
                       </Select>
                     ) : (
-                      <div className="mt-1 px-3 py-2 border rounded-md bg-muted/50 text-sm">
+                      <div className='mt-1 px-3 py-2 border rounded-md bg-muted/50 text-sm'>
                         {(() => {
                           const v = getDisplayValue(
                             'birth_outcomes_induction',
@@ -2366,9 +3226,9 @@ export function LeadProfileModal({
                     )}
                   </div>
 
-                  <div className="space-y-2">
-                    <Label className="text-sm font-medium text-muted-foreground">
-                      Delivery type <span className="text-destructive">*</span>
+                  <div className='space-y-2'>
+                    <Label className='text-sm font-medium text-muted-foreground'>
+                      Delivery type <span className='text-destructive'>*</span>
                     </Label>
                     {isEditing ? (
                       <Select
@@ -2386,8 +3246,8 @@ export function LeadProfileModal({
                           }));
                         }}
                       >
-                        <SelectTrigger className="mt-1">
-                          <SelectValue placeholder="Select..." />
+                        <SelectTrigger className='mt-1'>
+                          <SelectValue placeholder='Select...' />
                         </SelectTrigger>
                         <SelectContent>
                           {BIRTH_OUTCOMES_DELIVERY_TYPE_OPTIONS.map((opt) => (
@@ -2398,7 +3258,7 @@ export function LeadProfileModal({
                         </SelectContent>
                       </Select>
                     ) : (
-                      <div className="mt-1 px-3 py-2 border rounded-md bg-muted/50 text-sm">
+                      <div className='mt-1 px-3 py-2 border rounded-md bg-muted/50 text-sm'>
                         {String(
                           getDisplayValue(
                             'birth_outcomes_delivery_type',
@@ -2409,21 +3269,25 @@ export function LeadProfileModal({
                     )}
                   </div>
 
-                  <div className="space-y-2">
-                    <Label className="text-sm font-medium text-muted-foreground">
-                      Medications used <span className="text-destructive">*</span>
+                  <div className='space-y-2'>
+                    <Label className='text-sm font-medium text-muted-foreground'>
+                      Medications used{' '}
+                      <span className='text-destructive'>*</span>
                     </Label>
                     {(() => {
                       const raw =
                         (editedData as any).birth_outcomes_medications_used ??
                         (editedData as any).birthOutcomesMedicationsUsed ??
-                        (detailSource as any)?.birth_outcomes_medications_used ??
+                        (detailSource as any)
+                          ?.birth_outcomes_medications_used ??
                         (detailSource as any)?.birthOutcomesMedicationsUsed ??
                         (client as any)?.birth_outcomes_medications_used ??
                         (client as any)?.birthOutcomesMedicationsUsed ??
                         [];
                       const current = Array.isArray(raw)
-                        ? (raw as unknown[]).map((v) => String(v)).filter(Boolean)
+                        ? (raw as unknown[])
+                            .map((v) => String(v))
+                            .filter(Boolean)
                         : [];
 
                       const toggle = (opt: string) => {
@@ -2439,16 +3303,18 @@ export function LeadProfileModal({
 
                       if (!isEditing) {
                         return (
-                          <div className="mt-1 px-3 py-2 border rounded-md bg-muted/50 text-sm">
-                            {current.length > 0 ? current.join(', ') : 'Not provided'}
+                          <div className='mt-1 px-3 py-2 border rounded-md bg-muted/50 text-sm'>
+                            {current.length > 0
+                              ? current.join(', ')
+                              : 'Not provided'}
                           </div>
                         );
                       }
 
                       return (
-                        <div className="mt-1 grid gap-2 sm:grid-cols-2">
+                        <div className='mt-1 grid gap-2 sm:grid-cols-2'>
                           {BIRTH_OUTCOMES_MEDICATION_OPTIONS.map((opt) => (
-                            <div key={opt} className="flex items-center gap-2">
+                            <div key={opt} className='flex items-center gap-2'>
                               <Checkbox
                                 id={`birth-outcomes-med-${opt}`}
                                 checked={current.includes(opt)}
@@ -2456,7 +3322,7 @@ export function LeadProfileModal({
                               />
                               <Label
                                 htmlFor={`birth-outcomes-med-${opt}`}
-                                className="text-sm font-normal"
+                                className='text-sm font-normal'
                               >
                                 {opt}
                               </Label>
@@ -2471,32 +3337,36 @@ export function LeadProfileModal({
                 {String(
                   getDisplayValue('birth_outcomes', 'birthOutcomes') || ''
                 ).trim() ? (
-                  <div className="pt-3">
-                    <Label className="text-sm font-medium text-muted-foreground">
+                  <div className='pt-3'>
+                    <Label className='text-sm font-medium text-muted-foreground'>
                       Legacy Birth Outcomes (read-only)
                     </Label>
-                    <div className="mt-1 px-3 py-2 border rounded-md bg-muted/50 text-sm min-h-[72px] whitespace-pre-wrap">
-                      {String(getDisplayValue('birth_outcomes', 'birthOutcomes') || '')}
+                    <div className='mt-1 px-3 py-2 border rounded-md bg-muted/50 text-sm min-h-[72px] whitespace-pre-wrap'>
+                      {String(
+                        getDisplayValue('birth_outcomes', 'birthOutcomes') || ''
+                      )}
                     </div>
                   </div>
                 ) : null}
                 {isEditing && (
-                  <div className="flex justify-end pt-1">
+                  <div className='flex justify-end pt-1'>
                     <Button
                       onClick={handleSaveBirthOutcomes}
-                      size="sm"
+                      size='sm'
                       disabled={isSavingBirthOutcomes}
                     >
-                      {isSavingBirthOutcomes ? 'Saving...' : 'Save Birth Outcomes'}
+                      {isSavingBirthOutcomes
+                        ? 'Saving...'
+                        : 'Save Birth Outcomes'}
                     </Button>
                   </div>
                 )}
-                <div className="space-y-2 pt-2">
-                  <h4 className="text-sm font-medium text-muted-foreground">
+                <div className='space-y-2 pt-2'>
+                  <h4 className='text-sm font-medium text-muted-foreground'>
                     Birth Outcomes History
                   </h4>
                   {birthOutcomesHistory.length === 0 ? (
-                    <div className="text-sm text-muted-foreground py-2">
+                    <div className='text-sm text-muted-foreground py-2'>
                       No birth outcomes records yet.
                     </div>
                   ) : (
@@ -2512,18 +3382,20 @@ export function LeadProfileModal({
                       return (
                         <div
                           key={`birth-outcomes-${note.id}`}
-                          className="bg-background border rounded-lg p-3 space-y-2"
+                          className='bg-background border rounded-lg p-3 space-y-2'
                         >
-                          <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                            <span className="font-medium">
-                              {formatDistanceToNow(noteDate, { addSuffix: true })}
+                          <div className='flex items-center gap-1.5 text-xs text-muted-foreground'>
+                            <span className='font-medium'>
+                              {formatDistanceToNow(noteDate, {
+                                addSuffix: true,
+                              })}
                             </span>
-                            <span className="text-muted-foreground/50">•</span>
-                            <span className="text-muted-foreground/70">
+                            <span className='text-muted-foreground/50'>•</span>
+                            <span className='text-muted-foreground/70'>
                               {format(noteDate, 'MMM dd, yyyy h:mm a')}
                             </span>
                           </div>
-                          <p className="text-sm leading-relaxed whitespace-pre-wrap">
+                          <p className='text-sm leading-relaxed whitespace-pre-wrap'>
                             {note.description}
                           </p>
                         </div>
@@ -2532,56 +3404,64 @@ export function LeadProfileModal({
                   )}
                 </div>
               </>,
-              <Baby className="h-5 w-5" />
+              <Baby className='h-5 w-5' />
             )}
 
             {/* Notes Section */}
             <Collapsible
               open={openSections.has('notes')}
               onOpenChange={(nextOpen) => setSectionOpen('notes', nextOpen)}
-              className="border rounded-lg mb-3"
+              className='border rounded-lg mb-3'
             >
               <CollapsibleTrigger asChild>
                 <Button
-                  variant="ghost"
-                  className="w-full justify-between p-3 h-auto hover:bg-muted/50"
-                  data-testid="admin-notes-collapsible-trigger"
+                  variant='ghost'
+                  className='w-full justify-between p-3 h-auto hover:bg-muted/50'
+                  data-testid='admin-notes-collapsible-trigger'
                 >
-                  <div className="flex items-center gap-2">
-                    <MessageSquare className="h-5 w-5" />
-                    <span className="font-semibold">Admin Notes</span>
+                  <div className='flex items-center gap-2'>
+                    <MessageSquare className='h-5 w-5' />
+                    <span className='font-semibold'>Admin Notes</span>
                     {notes.length > 0 && (
-                      <span className="text-xs bg-primary/10 text-primary px-2 py-0.5 rounded-full">
+                      <span className='text-xs bg-primary/10 text-primary px-2 py-0.5 rounded-full'>
                         {notes.length}
                       </span>
                     )}
                   </div>
-                  {openSections.has('notes') ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+                  {openSections.has('notes') ? (
+                    <ChevronDown className='h-4 w-4' />
+                  ) : (
+                    <ChevronRight className='h-4 w-4' />
+                  )}
                 </Button>
               </CollapsibleTrigger>
-              <CollapsibleContent className="px-3 pb-3">
-                <div className="space-y-3">
+              <CollapsibleContent className='px-3 pb-3'>
+                <div className='space-y-3'>
                   {/* Add New Note */}
-                  <div className="space-y-2 bg-muted/30 p-3 rounded-lg">
-                    <label className="text-sm font-medium">Add New Note</label>
+                  <div className='space-y-2 bg-muted/30 p-3 rounded-lg'>
+                    <label className='text-sm font-medium'>Add New Note</label>
                     <Textarea
-                      placeholder="Enter note description..."
+                      placeholder='Enter note description...'
                       value={newNote}
                       onChange={(e) => setNewNote(e.target.value)}
                       rows={3}
                       disabled={savingNote}
-                      className="resize-none"
+                      className='resize-none'
                     />
-                    <div className="flex items-center gap-2">
+                    <div className='flex items-center gap-2'>
                       <select
-                        data-testid="admin-note-category-trigger"
+                        data-testid='admin-note-category-trigger'
                         value={noteCategory}
                         onChange={(e) => setNoteCategory(e.target.value)}
                         disabled={savingNote}
-                        className="h-9 w-[180px] rounded-md border border-input bg-background px-3 py-1 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                        className='h-9 w-[180px] rounded-md border border-input bg-background px-3 py-1 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50'
                       >
                         {NOTE_CATEGORIES.map((category) => (
-                          <option key={category} value={category} data-testid={`admin-note-option-${category}`}>
+                          <option
+                            key={category}
+                            value={category}
+                            data-testid={`admin-note-option-${category}`}
+                          >
                             {category}
                           </option>
                         ))}
@@ -2589,27 +3469,32 @@ export function LeadProfileModal({
                       <Button
                         onClick={handleSaveNote}
                         disabled={savingNote || !newNote.trim()}
-                        size="sm"
+                        size='sm'
                       >
                         {savingNote ? 'Adding...' : 'Add Note'}
                       </Button>
                     </div>
                     {notesError && (
-                      <div className="text-sm text-destructive">{notesError}</div>
+                      <div className='text-sm text-destructive'>
+                        {notesError}
+                      </div>
                     )}
                   </div>
 
                   {/* Existing Notes */}
-                  <div className="space-y-2">
-                    <h4 className="text-sm font-medium text-muted-foreground">
-                      Notes History {loadingNotes && <span className="text-xs">(Loading...)</span>}
+                  <div className='space-y-2'>
+                    <h4 className='text-sm font-medium text-muted-foreground'>
+                      Notes History{' '}
+                      {loadingNotes && (
+                        <span className='text-xs'>(Loading...)</span>
+                      )}
                     </h4>
                     {loadingNotes && notes.length === 0 ? (
-                      <div className="text-sm text-muted-foreground py-4 text-center">
+                      <div className='text-sm text-muted-foreground py-4 text-center'>
                         Loading notes...
                       </div>
                     ) : notes.length === 0 ? (
-                      <div className="text-sm text-muted-foreground py-4 text-center">
+                      <div className='text-sm text-muted-foreground py-4 text-center'>
                         No notes yet. Add the first note above.
                       </div>
                     ) : (
@@ -2624,27 +3509,38 @@ export function LeadProfileModal({
                           // Backend is sending local time as UTC, so we need to correct it
                           // Get the timestamp value and add back the timezone offset
                           const offsetMinutes = noteDate.getTimezoneOffset();
-                          noteDate = new Date(noteDate.getTime() + (offsetMinutes * 60 * 1000));
+                          noteDate = new Date(
+                            noteDate.getTime() + offsetMinutes * 60 * 1000
+                          );
                         }
 
                         return (
-                          <div key={note.id} className="bg-background border rounded-lg p-3 space-y-2">
-                            <div className="flex items-center justify-between">
-                              <span className="text-xs font-medium capitalize bg-primary/10 text-primary px-2 py-1 rounded">
+                          <div
+                            key={note.id}
+                            className='bg-background border rounded-lg p-3 space-y-2'
+                          >
+                            <div className='flex items-center justify-between'>
+                              <span className='text-xs font-medium capitalize bg-primary/10 text-primary px-2 py-1 rounded'>
                                 {note.metadata?.category || 'general'}
                               </span>
-                              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                                <span className="font-medium">
-                                  {formatDistanceToNow(noteDate, { addSuffix: true })}
+                              <div className='flex items-center gap-1.5 text-xs text-muted-foreground'>
+                                <span className='font-medium'>
+                                  {formatDistanceToNow(noteDate, {
+                                    addSuffix: true,
+                                  })}
                                 </span>
-                                <span className="text-muted-foreground/50">•</span>
-                                <span className="text-muted-foreground/70">
+                                <span className='text-muted-foreground/50'>
+                                  •
+                                </span>
+                                <span className='text-muted-foreground/70'>
                                   {format(noteDate, 'MMM dd, yyyy h:mm a')}
                                 </span>
                               </div>
                             </div>
-                            <p className="text-sm leading-relaxed">{note.description}</p>
-                            <p className="text-xs text-muted-foreground">
+                            <p className='text-sm leading-relaxed'>
+                              {note.description}
+                            </p>
+                            <p className='text-xs text-muted-foreground'>
                               Added by {note.createdBy || 'Unknown'}
                             </p>
                           </div>
@@ -2658,7 +3554,7 @@ export function LeadProfileModal({
           </div>
         ) : null}
 
-        <DialogFooter className="pt-4">
+        <DialogFooter className='pt-4'>
           <Button onClick={() => onOpenChange(false)}>Close</Button>
         </DialogFooter>
       </DialogContent>

--- a/src/features/clients/components/dialog/LeadProfileModal.tsx
+++ b/src/features/clients/components/dialog/LeadProfileModal.tsx
@@ -1705,7 +1705,7 @@ export function LeadProfileModal({
   if (!client) {
     return (
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className='max-w-lg'>
+        <DialogContent className='max-h-[100dvh] w-full max-w-full translate-x-0 translate-y-0 left-0 top-0 h-[100dvh] rounded-none overflow-y-auto sm:left-[50%] sm:top-[50%] sm:h-auto sm:max-h-[90vh] sm:max-w-lg sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg'>
           <DialogHeader>
             <DialogTitle>Client Not Found</DialogTitle>
           </DialogHeader>
@@ -1737,12 +1737,12 @@ export function LeadProfileModal({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
-        className="max-w-4xl max-h-[90vh] overflow-y-auto"
+        className="left-0 top-0 h-[100dvh] max-h-[100dvh] w-full max-w-full translate-x-0 translate-y-0 overflow-y-auto rounded-none sm:left-[50%] sm:top-[50%] sm:h-auto sm:max-h-[90vh] sm:max-w-4xl sm:translate-x-[-50%] sm:translate-y-[-50%] sm:rounded-lg"
         data-testid={`lead-profile-dialog-${String(client.id)}`}
       >
         <DialogHeader className="pb-4">
-          <div className="flex items-center justify-between">
-            <DialogTitle className="flex items-center gap-2">
+          <div className="flex flex-col gap-3 pr-8 sm:flex-row sm:items-center sm:justify-between">
+            <DialogTitle className="flex min-w-0 items-center gap-2">
               <User className="h-5 w-5" />
               {(() => {
                 const c = detailSource ?? (client as Record<string, unknown>);

--- a/src/features/clients/components/users-table.tsx
+++ b/src/features/clients/components/users-table.tsx
@@ -42,7 +42,12 @@ interface DataTableProps {
   viewMode?: 'leads' | 'customers';
 }
 
-export function UsersTable({ columns, data, clients, viewMode = 'leads' }: DataTableProps) {
+export function UsersTable({
+  columns,
+  data,
+  clients,
+  viewMode = 'leads',
+}: DataTableProps) {
   const { setCurrentRow, setOpen } = useUsers();
   const [rowSelection, setRowSelection] = useState({});
   const [columnVisibility, setColumnVisibility] = useState<VisibilityState>({});
@@ -99,9 +104,9 @@ export function UsersTable({ columns, data, clients, viewMode = 'leads' }: DataT
                       {header.isPlaceholder
                         ? null
                         : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext()
-                        )}
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
                     </TableHead>
                   );
                 })}

--- a/src/features/clients/components/users-table.tsx
+++ b/src/features/clients/components/users-table.tsx
@@ -84,8 +84,8 @@ export function UsersTable({ columns, data, clients, viewMode = 'leads' }: DataT
   return (
     <div className='space-y-4'>
       <DataTableToolbar table={table} clients={clients} viewMode={viewMode} />
-      <div className='rounded-md border'>
-        <Table className='table-fixed w-full'>
+      <div className='min-w-0 overflow-x-auto rounded-md border'>
+        <Table className='w-full min-w-[720px]'>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id} className='group/row'>

--- a/src/features/contracts/components/dialog/EditTemplateDialog.tsx
+++ b/src/features/contracts/components/dialog/EditTemplateDialog.tsx
@@ -71,14 +71,12 @@ export function EditTemplateDialog({
             formData.append('fee', feeInput.value);
             if (file) formData.append('contract', file);
 
-
             try {
               const res = await fetchWithAuth(
                 buildUrl(`/contracts/templates/${templateName}`),
                 {
                   method: 'PUT',
-                  headers: {
-                  },
+                  headers: {},
                   body: formData,
                 }
               );

--- a/src/features/contracts/components/dialog/EditTemplateDialog.tsx
+++ b/src/features/contracts/components/dialog/EditTemplateDialog.tsx
@@ -111,7 +111,7 @@ export function EditTemplateDialog({
             <Input type='file' name='file' id='file' accept='.docx' />
           </div>
 
-          <div className='flex gap-4'>
+          <div className='flex flex-col gap-4 sm:flex-row'>
             <div className='flex-1 space-y-2'>
               <Label htmlFor='deposit'>Deposit Fee</Label>
               <Input

--- a/src/features/contracts/components/dialog/NewTemplateDialog.tsx
+++ b/src/features/contracts/components/dialog/NewTemplateDialog.tsx
@@ -97,7 +97,7 @@ export function NewTemplateDialog({ onUploadSuccess }: Props) {
             <Input type='file' name='file' id='file' accept='.docx' required />
           </div>
 
-          <div className='flex gap-4'>
+          <div className='flex flex-col gap-4 sm:flex-row'>
             <div className='flex-1 space-y-2'>
               <Label htmlFor='deposit'>Deposit Fee</Label>
               <Input name='deposit' id='deposit' type='number' required />

--- a/src/features/contracts/components/dialog/NewTemplateDialog.tsx
+++ b/src/features/contracts/components/dialog/NewTemplateDialog.tsx
@@ -43,17 +43,12 @@ export function NewTemplateDialog({ onUploadSuccess }: Props) {
     formData.append('deposit', depositInput.value);
     formData.append('fee', feeInput.value);
 
-
     try {
-      const res = await fetchWithAuth(
-        buildUrl('/contracts/templates'),
-        {
-          method: 'POST',
-          headers: {
-          },
-          body: formData,
-        }
-      );
+      const res = await fetchWithAuth(buildUrl('/contracts/templates'), {
+        method: 'POST',
+        headers: {},
+        body: formData,
+      });
 
       if (!res.ok) throw new Error('Upload failed.');
 

--- a/src/features/dashboard-home/Home.jsx
+++ b/src/features/dashboard-home/Home.jsx
@@ -10,7 +10,8 @@ const QUICKBOOKS_CONNECTED_KEY = 'quickbooks_just_connected';
 
 export default function Home() {
   const { user, isLoading: isUserLoading } = useUser();
-  const { isClientPortalUser, isLoading: isPortalLoading } = useIsClientPortalUser();
+  const { isClientPortalUser, isLoading: isPortalLoading } =
+    useIsClientPortalUser();
   const [searchParams, setSearchParams] = useSearchParams();
   const isDoula = user?.role === 'doula';
   const displayFirstName =

--- a/src/features/dashboard-home/Home.jsx
+++ b/src/features/dashboard-home/Home.jsx
@@ -52,9 +52,9 @@ export default function Home() {
 
   // Show regular dashboard for admin/doula users
   return (
-    <div className='h-full p-6 space-y-8 overflow-y-auto'>
-      <div className='space-y-2'>
-        <h1 className='text-3xl font-bold tracking-tight'>
+    <div className='h-full min-w-0 space-y-8 overflow-y-auto p-4 sm:p-6'>
+      <div className='min-w-0 space-y-2'>
+        <h1 className='text-2xl font-bold tracking-tight sm:text-3xl'>
           Welcome back, {displayFirstName}!
         </h1>
         <p className='text-muted-foreground'>

--- a/src/features/dashboard-home/components/CalendarWidget.tsx
+++ b/src/features/dashboard-home/components/CalendarWidget.tsx
@@ -1,6 +1,9 @@
 // src/features/dashboard-home/components/CalendarWidget.tsx
 import { useState, useMemo } from 'react';
-import { useDueDateCalendar, DueDateEvent } from '@/common/hooks/dashboard/useDueDateCalendar';
+import {
+  useDueDateCalendar,
+  DueDateEvent,
+} from '@/common/hooks/dashboard/useDueDateCalendar';
 import { DueDatePopover } from './DueDatePopover';
 import { Button } from '@/common/components/ui/button';
 import { ChevronLeft, ChevronRight, AlertCircle } from 'lucide-react';
@@ -18,7 +21,6 @@ import {
   isSameMonth,
   isSameDay,
   isToday,
-  parseISO,
 } from 'date-fns';
 
 /**
@@ -28,13 +30,13 @@ export function CalendarWidget() {
   const [currentMonth, setCurrentMonth] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState<Date | null>(null);
   const [popoverOpen, setPopoverOpen] = useState(false);
-  
+
   const { events, loading, error } = useDueDateCalendar();
 
   // Group events by date for quick lookup
   const eventsByDate = useMemo(() => {
     const map = new Map<string, DueDateEvent[]>();
-    
+
     events.forEach((event) => {
       const dateKey = event.date; // Already in YYYY-MM-DD format
       if (!map.has(dateKey)) {
@@ -42,7 +44,7 @@ export function CalendarWidget() {
       }
       map.get(dateKey)!.push(event);
     });
-    
+
     return map;
   }, [events]);
 
@@ -75,7 +77,7 @@ export function CalendarWidget() {
   const handleDateClick = (date: Date) => {
     const dateKey = format(date, 'yyyy-MM-dd');
     const dayEvents = eventsByDate.get(dateKey) || [];
-    
+
     if (dayEvents.length > 0) {
       setSelectedDate(date);
       setPopoverOpen(true);
@@ -100,12 +102,12 @@ export function CalendarWidget() {
   // Error state
   if (error) {
     return (
-      <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
-        <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100">
+      <div className='rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900'>
+        <h2 className='mb-4 text-lg font-semibold text-gray-900 dark:text-gray-100'>
           Due Date Calendar
         </h2>
-        <Alert variant="destructive">
-          <AlertCircle className="h-4 w-4" />
+        <Alert variant='destructive'>
+          <AlertCircle className='h-4 w-4' />
           <AlertDescription>
             Failed to load calendar events. Please try again later.
           </AlertDescription>
@@ -115,41 +117,41 @@ export function CalendarWidget() {
   }
 
   return (
-    <div className="min-w-0 rounded-lg border border-gray-200 bg-white p-3 shadow-sm dark:border-gray-800 dark:bg-gray-900 sm:p-6">
+    <div className='min-w-0 rounded-lg border border-gray-200 bg-white p-3 shadow-sm dark:border-gray-800 dark:bg-gray-900 sm:p-6'>
       {/* Header */}
-      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-        <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
+      <div className='mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between'>
+        <h2 className='text-lg font-semibold text-gray-900 dark:text-gray-100'>
           Due Date Calendar
         </h2>
-        <div className="flex items-center justify-between gap-2 sm:justify-end">
+        <div className='flex items-center justify-between gap-2 sm:justify-end'>
           <Button
-            variant="outline"
-            size="icon"
+            variant='outline'
+            size='icon'
             onClick={handlePrevMonth}
             disabled={loading}
-            className="h-11 w-11 sm:h-8 sm:w-8"
+            className='h-11 w-11 sm:h-8 sm:w-8'
           >
-            <ChevronLeft className="h-4 w-4" />
+            <ChevronLeft className='h-4 w-4' />
           </Button>
-          <span className="min-w-0 flex-1 text-center text-sm font-medium text-gray-700 dark:text-gray-300 sm:min-w-[140px] sm:flex-none">
+          <span className='min-w-0 flex-1 text-center text-sm font-medium text-gray-700 dark:text-gray-300 sm:min-w-[140px] sm:flex-none'>
             {format(currentMonth, 'MMMM yyyy')}
           </span>
           <Button
-            variant="outline"
-            size="icon"
+            variant='outline'
+            size='icon'
             onClick={handleNextMonth}
             disabled={loading}
-            className="h-11 w-11 sm:h-8 sm:w-8"
+            className='h-11 w-11 sm:h-8 sm:w-8'
           >
-            <ChevronRight className="h-4 w-4" />
+            <ChevronRight className='h-4 w-4' />
           </Button>
         </div>
       </div>
 
       {/* Loading state */}
       {loading && (
-        <div className="flex h-64 items-center justify-center">
-          <div className="text-sm text-gray-500 dark:text-gray-400">
+        <div className='flex h-64 items-center justify-center'>
+          <div className='text-sm text-gray-500 dark:text-gray-400'>
             Loading calendar...
           </div>
         </div>
@@ -157,28 +159,30 @@ export function CalendarWidget() {
 
       {/* Calendar grid */}
       {!loading && (
-        <div className="min-w-0 overflow-hidden">
+        <div className='min-w-0 overflow-hidden'>
           {/* Week day headers */}
-          <div className="mb-2 grid grid-cols-7 gap-1 [grid-template-columns:repeat(7,minmax(0,1fr))]">
+          <div className='mb-2 grid grid-cols-7 gap-1 [grid-template-columns:repeat(7,minmax(0,1fr))]'>
             {weekDays.map((day, index) => (
               <div
                 key={`${day.long}-${index}`}
-                className="min-w-0 truncate py-2 text-center text-xs font-medium text-gray-600 dark:text-gray-400"
+                className='min-w-0 truncate py-2 text-center text-xs font-medium text-gray-600 dark:text-gray-400'
               >
-                <span className="sm:hidden">{day.short}</span>
-                <span className="hidden sm:inline">{day.long}</span>
+                <span className='sm:hidden'>{day.short}</span>
+                <span className='hidden sm:inline'>{day.long}</span>
               </div>
             ))}
           </div>
 
           {/* Calendar days */}
-          <div className="grid grid-cols-7 gap-1 [grid-template-columns:repeat(7,minmax(0,1fr))]">
+          <div className='grid grid-cols-7 gap-1 [grid-template-columns:repeat(7,minmax(0,1fr))]'>
             {calendarDays.map((day, index) => {
               const dayEvents = getDayEvents(day);
               const hasEvents = dayEvents.length > 0;
               const isCurrentMonth = isSameMonth(day, currentMonth);
               const isTodayDate = isToday(day);
-              const isSelected = selectedDate ? isSameDay(day, selectedDate) : false;
+              const isSelected = selectedDate
+                ? isSameDay(day, selectedDate)
+                : false;
 
               const dayContent = (
                 <button
@@ -202,30 +206,36 @@ export function CalendarWidget() {
                     !hasEvents && 'cursor-default'
                   )}
                 >
-                  <span className={cn(isTodayDate && 'text-blue-600 dark:text-blue-400')}>
+                  <span
+                    className={cn(
+                      isTodayDate && 'text-blue-600 dark:text-blue-400'
+                    )}
+                  >
                     {format(day, 'd')}
                   </span>
-                  
+
                   {/* Event indicator - green dot */}
                   {hasEvents && (
-                    <div className="mt-0.5 flex gap-0.5">
+                    <div className='mt-0.5 flex gap-0.5'>
                       {dayEvents.length <= 3 ? (
                         // Show individual dots for 1-3 events
                         dayEvents.map((event, idx) => (
                           <div
                             key={idx}
-                            className="h-1.5 w-1.5 rounded-full"
-                            style={{ backgroundColor: event.color || '#34A853' }}
+                            className='h-1.5 w-1.5 rounded-full'
+                            style={{
+                              backgroundColor: event.color || '#34A853',
+                            }}
                           />
                         ))
                       ) : (
                         // Show "+N" for more than 3 events
                         <>
                           <div
-                            className="h-1.5 w-1.5 shrink-0 rounded-full"
+                            className='h-1.5 w-1.5 shrink-0 rounded-full'
                             style={{ backgroundColor: '#34A853' }}
                           />
-                          <span className="hidden text-[10px] font-medium text-green-600 dark:text-green-400 sm:inline">
+                          <span className='hidden text-[10px] font-medium text-green-600 dark:text-green-400 sm:inline'>
                             +{dayEvents.length - 1}
                           </span>
                         </>
@@ -255,9 +265,9 @@ export function CalendarWidget() {
           </div>
 
           {/* Legend */}
-          <div className="mt-4 flex items-center justify-center gap-2 text-xs text-gray-600 dark:text-gray-400">
-            <div className="flex items-center gap-1.5">
-              <div className="h-2 w-2 rounded-full bg-[#34A853]" />
+          <div className='mt-4 flex items-center justify-center gap-2 text-xs text-gray-600 dark:text-gray-400'>
+            <div className='flex items-center gap-1.5'>
+              <div className='h-2 w-2 rounded-full bg-[#34A853]' />
               <span>Due Date</span>
             </div>
           </div>
@@ -266,4 +276,3 @@ export function CalendarWidget() {
     </div>
   );
 }
-

--- a/src/features/dashboard-home/components/CalendarWidget.tsx
+++ b/src/features/dashboard-home/components/CalendarWidget.tsx
@@ -87,7 +87,15 @@ export function CalendarWidget() {
     return eventsByDate.get(dateKey) || [];
   };
 
-  const weekDays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  const weekDays = [
+    { short: 'S', long: 'Sun' },
+    { short: 'M', long: 'Mon' },
+    { short: 'T', long: 'Tue' },
+    { short: 'W', long: 'Wed' },
+    { short: 'T', long: 'Thu' },
+    { short: 'F', long: 'Fri' },
+    { short: 'S', long: 'Sat' },
+  ];
 
   // Error state
   if (error) {
@@ -107,23 +115,23 @@ export function CalendarWidget() {
   }
 
   return (
-    <div className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-800 dark:bg-gray-900">
+    <div className="min-w-0 rounded-lg border border-gray-200 bg-white p-3 shadow-sm dark:border-gray-800 dark:bg-gray-900 sm:p-6">
       {/* Header */}
-      <div className="mb-4 flex items-center justify-between">
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
         <h2 className="text-lg font-semibold text-gray-900 dark:text-gray-100">
           Due Date Calendar
         </h2>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center justify-between gap-2 sm:justify-end">
           <Button
             variant="outline"
             size="icon"
             onClick={handlePrevMonth}
             disabled={loading}
-            className="h-8 w-8"
+            className="h-11 w-11 sm:h-8 sm:w-8"
           >
             <ChevronLeft className="h-4 w-4" />
           </Button>
-          <span className="min-w-[140px] text-center text-sm font-medium text-gray-700 dark:text-gray-300">
+          <span className="min-w-0 flex-1 text-center text-sm font-medium text-gray-700 dark:text-gray-300 sm:min-w-[140px] sm:flex-none">
             {format(currentMonth, 'MMMM yyyy')}
           </span>
           <Button
@@ -131,7 +139,7 @@ export function CalendarWidget() {
             size="icon"
             onClick={handleNextMonth}
             disabled={loading}
-            className="h-8 w-8"
+            className="h-11 w-11 sm:h-8 sm:w-8"
           >
             <ChevronRight className="h-4 w-4" />
           </Button>
@@ -149,21 +157,22 @@ export function CalendarWidget() {
 
       {/* Calendar grid */}
       {!loading && (
-        <div className="overflow-hidden">
+        <div className="min-w-0 overflow-hidden">
           {/* Week day headers */}
-          <div className="mb-2 grid grid-cols-7 gap-1">
-            {weekDays.map((day) => (
+          <div className="mb-2 grid grid-cols-7 gap-1 [grid-template-columns:repeat(7,minmax(0,1fr))]">
+            {weekDays.map((day, index) => (
               <div
-                key={day}
-                className="py-2 text-center text-xs font-medium text-gray-600 dark:text-gray-400"
+                key={`${day.long}-${index}`}
+                className="min-w-0 truncate py-2 text-center text-xs font-medium text-gray-600 dark:text-gray-400"
               >
-                {day}
+                <span className="sm:hidden">{day.short}</span>
+                <span className="hidden sm:inline">{day.long}</span>
               </div>
             ))}
           </div>
 
           {/* Calendar days */}
-          <div className="grid grid-cols-7 gap-1">
+          <div className="grid grid-cols-7 gap-1 [grid-template-columns:repeat(7,minmax(0,1fr))]">
             {calendarDays.map((day, index) => {
               const dayEvents = getDayEvents(day);
               const hasEvents = dayEvents.length > 0;
@@ -177,7 +186,7 @@ export function CalendarWidget() {
                   onClick={() => handleDateClick(day)}
                   disabled={!hasEvents}
                   className={cn(
-                    'relative flex h-12 w-full flex-col items-center justify-center rounded-md text-sm transition-colors',
+                    'relative flex h-11 w-full min-w-0 flex-col items-center justify-center overflow-hidden rounded-md text-sm transition-colors sm:h-12',
                     // Base styles
                     'hover:bg-gray-100 dark:hover:bg-gray-800',
                     // Current month vs other months
@@ -213,10 +222,10 @@ export function CalendarWidget() {
                         // Show "+N" for more than 3 events
                         <>
                           <div
-                            className="h-1.5 w-1.5 rounded-full"
+                            className="h-1.5 w-1.5 shrink-0 rounded-full"
                             style={{ backgroundColor: '#34A853' }}
                           />
-                          <span className="text-[10px] font-medium text-green-600 dark:text-green-400">
+                          <span className="hidden text-[10px] font-medium text-green-600 dark:text-green-400 sm:inline">
                             +{dayEvents.length - 1}
                           </span>
                         </>

--- a/src/features/dashboard-home/components/StatsOverview.tsx
+++ b/src/features/dashboard-home/components/StatsOverview.tsx
@@ -110,7 +110,7 @@ export function StatsOverview() {
           <h2 className="text-2xl font-bold tracking-tight">Dashboard Overview</h2>
           <p className="text-muted-foreground">Key metrics and statistics at a glance</p>
         </div>
-        <div className="grid grid-cols-3 gap-4">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {Array.from({ length: 6 }).map((_, i) => (
             <StatsCardSkeleton key={i} />
           ))}
@@ -131,7 +131,7 @@ export function StatsOverview() {
         <h2 className="text-2xl font-bold tracking-tight">Dashboard Overview</h2>
         <p className="text-muted-foreground">Key metrics and statistics at a glance</p>
       </div>
-      <div className="grid grid-cols-3 gap-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {visibleStats.map((config) => (
           <StatsCard
             key={config.key}

--- a/src/features/dashboard-home/components/StatsOverview.tsx
+++ b/src/features/dashboard-home/components/StatsOverview.tsx
@@ -1,23 +1,31 @@
 // src/features/dashboard-home/components/StatsOverview.tsx
 import { useDashboardStats } from '@/common/hooks/dashboard/useDashboardStats';
 import { StatsCard, StatsCardSkeleton, StatsVariant } from './StatsCard';
-import { 
-  Users, 
-  UserCheck, 
-  FileText, 
-  AlertCircle, 
-  CheckSquare, 
-  DollarSign 
+import {
+  Users,
+  UserCheck,
+  FileText,
+  AlertCircle,
+  CheckSquare,
+  DollarSign,
 } from 'lucide-react';
-import { Alert, AlertDescription, AlertTitle } from '@/common/components/ui/alert';
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from '@/common/components/ui/alert';
 
 interface StatConfig {
   key: string;
   label: string;
   variant: StatsVariant;
   icon: typeof Users;
-  getValue: (stats: ReturnType<typeof useDashboardStats>['stats']) => number | string;
-  shouldHide?: (stats: ReturnType<typeof useDashboardStats>['stats']) => boolean;
+  getValue: (
+    stats: ReturnType<typeof useDashboardStats>['stats']
+  ) => number | string;
+  shouldHide?: (
+    stats: ReturnType<typeof useDashboardStats>['stats']
+  ) => boolean;
 }
 
 // Configuration for each stat card
@@ -63,7 +71,10 @@ const statsConfig: Record<string, StatConfig> = {
     variant: 'success',
     icon: DollarSign,
     getValue: (stats) => {
-      if (stats?.monthlyRevenue === null || stats?.monthlyRevenue === undefined) {
+      if (
+        stats?.monthlyRevenue === null ||
+        stats?.monthlyRevenue === undefined
+      ) {
         return 'N/A';
       }
       return new Intl.NumberFormat('en-US', {
@@ -74,7 +85,8 @@ const statsConfig: Record<string, StatConfig> = {
       }).format(stats.monthlyRevenue);
     },
     // Hide the card entirely if revenue is null
-    shouldHide: (stats) => stats?.monthlyRevenue === null || stats?.monthlyRevenue === undefined,
+    shouldHide: (stats) =>
+      stats?.monthlyRevenue === null || stats?.monthlyRevenue === undefined,
   },
 };
 
@@ -88,14 +100,17 @@ export function StatsOverview() {
   // Error State
   if (error) {
     return (
-      <div className="w-full">
-        <Alert variant="destructive">
-          <AlertCircle className="h-4 w-4" />
+      <div className='w-full'>
+        <Alert variant='destructive'>
+          <AlertCircle className='h-4 w-4' />
           <AlertTitle>Error Loading Dashboard Statistics</AlertTitle>
           <AlertDescription>
             {error}
             <br />
-            <span className="text-sm">Please try refreshing the page or contact support if the issue persists.</span>
+            <span className='text-sm'>
+              Please try refreshing the page or contact support if the issue
+              persists.
+            </span>
           </AlertDescription>
         </Alert>
       </div>
@@ -105,12 +120,16 @@ export function StatsOverview() {
   // Loading State - Show skeletons
   if (loading || !stats) {
     return (
-      <div className="w-full">
-        <div className="mb-6">
-          <h2 className="text-2xl font-bold tracking-tight">Dashboard Overview</h2>
-          <p className="text-muted-foreground">Key metrics and statistics at a glance</p>
+      <div className='w-full'>
+        <div className='mb-6'>
+          <h2 className='text-2xl font-bold tracking-tight'>
+            Dashboard Overview
+          </h2>
+          <p className='text-muted-foreground'>
+            Key metrics and statistics at a glance
+          </p>
         </div>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'>
           {Array.from({ length: 6 }).map((_, i) => (
             <StatsCardSkeleton key={i} />
           ))}
@@ -126,12 +145,16 @@ export function StatsOverview() {
 
   // Data State - Render stats cards
   return (
-    <div className="w-full">
-      <div className="mb-6">
-        <h2 className="text-2xl font-bold tracking-tight">Dashboard Overview</h2>
-        <p className="text-muted-foreground">Key metrics and statistics at a glance</p>
+    <div className='w-full'>
+      <div className='mb-6'>
+        <h2 className='text-2xl font-bold tracking-tight'>
+          Dashboard Overview
+        </h2>
+        <p className='text-muted-foreground'>
+          Key metrics and statistics at a glance
+        </p>
       </div>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3'>
         {visibleStats.map((config) => (
           <StatsCard
             key={config.key}
@@ -145,4 +168,3 @@ export function StatsOverview() {
     </div>
   );
 }
-

--- a/src/features/financial/FinancialPage.tsx
+++ b/src/features/financial/FinancialPage.tsx
@@ -1,7 +1,13 @@
 import { getPaymentsList, PaymentRow } from '@/api/financial/paymentsApi';
 import { UserContext } from '@/common/contexts/UserContext';
 import { useContext, useEffect, useMemo, useState } from 'react';
-import { ChevronLeft, ChevronRight, Filter, Loader2, Search } from 'lucide-react';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Filter,
+  Loader2,
+  Search,
+} from 'lucide-react';
 import { Button } from '@/common/components/ui/button';
 import {
   Select,
@@ -25,7 +31,8 @@ function formatAmount(n: number): string {
 
 function getDisplayStatus(p: PaymentRow): string {
   const s = (p.status || '').toLowerCase();
-  if (s === 'succeeded' || s === 'completed' || s === 'paid') return 'succeeded';
+  if (s === 'succeeded' || s === 'completed' || s === 'paid')
+    return 'succeeded';
   if (s === 'pending' || s === 'processing') return 'pending';
   if (s === 'failed' || s === 'cancelled') return 'failed';
   if (s === 'refunded') return 'refunded';
@@ -38,7 +45,12 @@ function getDisplayType(p: PaymentRow): string {
 }
 
 function getClientName(p: PaymentRow): string {
-  return (p.client_name || p.customer_name || (p as Record<string, unknown>).client_name as string) || '—';
+  return (
+    p.client_name ||
+    p.customer_name ||
+    ((p as Record<string, unknown>).client_name as string) ||
+    '—'
+  );
 }
 
 export default function FinancialPage() {
@@ -68,8 +80,10 @@ export default function FinancialPage() {
       list = list.filter(
         (p) =>
           getClientName(p).toLowerCase().includes(term) ||
-          (p.description && String(p.description).toLowerCase().includes(term)) ||
-          (p.contract_id && String(p.contract_id).toLowerCase().includes(term)) ||
+          (p.description &&
+            String(p.description).toLowerCase().includes(term)) ||
+          (p.contract_id &&
+            String(p.contract_id).toLowerCase().includes(term)) ||
           (p.invoice && String(p.invoice).toLowerCase().includes(term)) ||
           (p.invoice_id && String(p.invoice_id).toLowerCase().includes(term))
       );
@@ -106,86 +120,97 @@ export default function FinancialPage() {
     return Array.from(set).sort();
   }, [payments]);
 
-  const hasActiveFilters = searchTerm.trim() || categoryFilter !== 'all' || typeFilter !== 'all';
+  const hasActiveFilters =
+    searchTerm.trim() || categoryFilter !== 'all' || typeFilter !== 'all';
+
+  const totalAmount = useMemo(() => {
+    const sum = filtered.reduce((acc, p) => acc + (Number(p.amount) || 0), 0);
+    return sum;
+  }, [filtered]);
 
   if (!authLoading && user?.role !== 'admin') {
     return (
-      <div className="p-6">
-        <p className="text-destructive">You do not have permission to view this page.</p>
+      <div className='p-6'>
+        <p className='text-destructive'>
+          You do not have permission to view this page.
+        </p>
       </div>
     );
   }
 
-  const totalAmount = useMemo(() => {
-    const sum = filtered.reduce(
-      (acc, p) => acc + (Number(p.amount) || 0),
-      0
-    );
-    return sum;
-  }, [filtered]);
-
   return (
-    <div className="flex flex-col p-4 min-h-0 overflow-auto">
-      <div className="mb-4 flex min-w-0 shrink-0 items-center justify-between">
+    <div className='flex flex-col p-4 min-h-0 overflow-auto'>
+      <div className='mb-4 flex min-w-0 shrink-0 items-center justify-between'>
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Payments</h1>
-          <p className="text-muted-foreground mt-1">
+          <h1 className='text-2xl font-bold tracking-tight'>Payments</h1>
+          <p className='text-muted-foreground mt-1'>
             Payments by status and category from the payments table
           </p>
         </div>
       </div>
 
       {/* Summary stats at top */}
-      <div className="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <div className="rounded-lg border bg-card p-4 shadow-sm">
-          <p className="text-xs font-medium text-muted-foreground">Total amount</p>
-          <p className="text-xl font-semibold mt-1">{formatAmount(totalAmount)}</p>
+      <div className='mb-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4'>
+        <div className='rounded-lg border bg-card p-4 shadow-sm'>
+          <p className='text-xs font-medium text-muted-foreground'>
+            Total amount
+          </p>
+          <p className='text-xl font-semibold mt-1'>
+            {formatAmount(totalAmount)}
+          </p>
         </div>
-        <div className="rounded-lg border bg-card p-4 shadow-sm">
-          <p className="text-xs font-medium text-muted-foreground">Payment count</p>
-          <p className="text-xl font-semibold mt-1">{filtered.length}</p>
+        <div className='rounded-lg border bg-card p-4 shadow-sm'>
+          <p className='text-xs font-medium text-muted-foreground'>
+            Payment count
+          </p>
+          <p className='text-xl font-semibold mt-1'>{filtered.length}</p>
         </div>
       </div>
 
       {/* Filters bar */}
-      <div className="shrink-0 mb-4 rounded-lg border bg-card p-4 shadow-sm">
-        <div className="flex flex-wrap items-end gap-3">
-          <div className="flex items-center gap-2 min-w-[200px] flex-1">
-            <Filter className="h-4 w-4 text-muted-foreground shrink-0" />
-            <div className="relative flex-1 max-w-md">
-              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+      <div className='shrink-0 mb-4 rounded-lg border bg-card p-4 shadow-sm'>
+        <div className='flex flex-wrap items-end gap-3'>
+          <div className='flex items-center gap-2 min-w-[200px] flex-1'>
+            <Filter className='h-4 w-4 text-muted-foreground shrink-0' />
+            <div className='relative flex-1 max-w-md'>
+              <Search className='absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground' />
               <Input
-                type="text"
-                placeholder="Search by name, description, contract, or invoice..."
-                className="pl-9 h-9"
+                type='text'
+                placeholder='Search by name, description, contract, or invoice...'
+                className='pl-9 h-9'
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
               />
             </div>
           </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <Select value={categoryFilter} onValueChange={(v) => setCategoryFilter(v)}>
-              <SelectTrigger className="w-[160px] h-9">
-                <SelectValue placeholder="Status" />
+          <div className='flex flex-wrap items-center gap-2'>
+            <Select
+              value={categoryFilter}
+              onValueChange={(v) => setCategoryFilter(v)}
+            >
+              <SelectTrigger className='w-[160px] h-9'>
+                <SelectValue placeholder='Status' />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">All statuses</SelectItem>
-                <SelectItem value="succeeded">Succeeded / Paid</SelectItem>
-                <SelectItem value="pending">Pending</SelectItem>
-                <SelectItem value="failed">Failed</SelectItem>
-                <SelectItem value="refunded">Refunded</SelectItem>
-                <SelectItem value="other">Other</SelectItem>
+                <SelectItem value='all'>All statuses</SelectItem>
+                <SelectItem value='succeeded'>Succeeded / Paid</SelectItem>
+                <SelectItem value='pending'>Pending</SelectItem>
+                <SelectItem value='failed'>Failed</SelectItem>
+                <SelectItem value='refunded'>Refunded</SelectItem>
+                <SelectItem value='other'>Other</SelectItem>
               </SelectContent>
             </Select>
             <Select value={typeFilter} onValueChange={(v) => setTypeFilter(v)}>
-              <SelectTrigger className="w-[140px] h-9">
-                <SelectValue placeholder="Type" />
+              <SelectTrigger className='w-[140px] h-9'>
+                <SelectValue placeholder='Type' />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="all">All types</SelectItem>
+                <SelectItem value='all'>All types</SelectItem>
                 {uniqueTypes.map((t) => (
                   <SelectItem key={t} value={t}>
-                    {t.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())}
+                    {t
+                      .replace(/_/g, ' ')
+                      .replace(/\b\w/g, (c) => c.toUpperCase())}
                   </SelectItem>
                 ))}
               </SelectContent>
@@ -194,8 +219,8 @@ export default function FinancialPage() {
               value={String(pageSize)}
               onValueChange={(v) => setPageSize(Number(v))}
             >
-              <SelectTrigger className="w-[100px] h-9">
-                <SelectValue placeholder="Per page" />
+              <SelectTrigger className='w-[100px] h-9'>
+                <SelectValue placeholder='Per page' />
               </SelectTrigger>
               <SelectContent>
                 {PAGE_SIZES.map((n) => (
@@ -207,10 +232,10 @@ export default function FinancialPage() {
             </Select>
             {hasActiveFilters && (
               <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="h-9"
+                type='button'
+                variant='outline'
+                size='sm'
+                className='h-9'
                 onClick={() => {
                   setSearchTerm('');
                   setCategoryFilter('all');
@@ -222,68 +247,82 @@ export default function FinancialPage() {
             )}
           </div>
         </div>
-        <p className="mt-2 text-sm text-muted-foreground">
+        <p className='mt-2 text-sm text-muted-foreground'>
           {filtered.length === 0
             ? 'No payments match your filters.'
             : `${filtered.length} payment${filtered.length === 1 ? '' : 's'} total`}
-          {payments.length !== filtered.length && hasActiveFilters && ` (filtered from ${payments.length})`}
+          {payments.length !== filtered.length &&
+            hasActiveFilters &&
+            ` (filtered from ${payments.length})`}
         </p>
       </div>
 
       {/* Table + Pagination */}
-      <div className="flex flex-col flex-1 min-h-0 rounded-xl border bg-card shadow-sm overflow-hidden">
+      <div className='flex flex-col flex-1 min-h-0 rounded-xl border bg-card shadow-sm overflow-hidden'>
         {loadingPayments ? (
-          <div className="flex-1 flex flex-col items-center justify-center gap-3 p-8 text-muted-foreground">
-            <Loader2 className="h-8 w-8 animate-spin" aria-hidden />
-            <p className="text-sm font-medium">Loading financial data…</p>
-            <p className="text-xs">This may take a moment.</p>
+          <div className='flex-1 flex flex-col items-center justify-center gap-3 p-8 text-muted-foreground'>
+            <Loader2 className='h-8 w-8 animate-spin' aria-hidden />
+            <p className='text-sm font-medium'>Loading financial data…</p>
+            <p className='text-xs'>This may take a moment.</p>
           </div>
         ) : filtered.length === 0 ? (
-          <div className="flex-1 flex items-center justify-center p-8 text-muted-foreground">
+          <div className='flex-1 flex items-center justify-center p-8 text-muted-foreground'>
             {payments.length === 0
               ? 'No payment data yet. Data will appear when the payments table API is available.'
               : 'No payments match your filters.'}
           </div>
         ) : (
           <>
-            <div className="overflow-auto flex-1 min-h-0">
-              <table className="min-w-full text-sm">
-                <thead className="sticky top-0 bg-muted/80 backdrop-blur z-10">
-                  <tr className="border-b">
-                    <th className="px-4 py-3 text-left font-semibold">Date</th>
-                    <th className="px-4 py-3 text-left font-semibold">Client / Customer</th>
-                    <th className="px-4 py-3 text-left font-semibold">Type</th>
-                    <th className="px-4 py-3 text-right font-semibold">Amount</th>
-                    <th className="px-4 py-3 text-left font-semibold">Description</th>
-                    <th className="px-4 py-3 text-left font-semibold">Invoice</th>
-                    <th className="px-4 py-3 text-left font-semibold">Contract</th>
+            <div className='overflow-auto flex-1 min-h-0'>
+              <table className='min-w-full text-sm'>
+                <thead className='sticky top-0 bg-muted/80 backdrop-blur z-10'>
+                  <tr className='border-b'>
+                    <th className='px-4 py-3 text-left font-semibold'>Date</th>
+                    <th className='px-4 py-3 text-left font-semibold'>
+                      Client / Customer
+                    </th>
+                    <th className='px-4 py-3 text-left font-semibold'>Type</th>
+                    <th className='px-4 py-3 text-right font-semibold'>
+                      Amount
+                    </th>
+                    <th className='px-4 py-3 text-left font-semibold'>
+                      Description
+                    </th>
+                    <th className='px-4 py-3 text-left font-semibold'>
+                      Invoice
+                    </th>
+                    <th className='px-4 py-3 text-left font-semibold'>
+                      Contract
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
                   {paginatedItems.map((p) => (
                     <tr
                       key={String(p.id)}
-                      className="border-b border-border/50 last:border-0 hover:bg-muted/30"
+                      className='border-b border-border/50 last:border-0 hover:bg-muted/30'
                     >
-                      <td className="px-4 py-3 text-muted-foreground">
+                      <td className='px-4 py-3 text-muted-foreground'>
                         {p.created_at
                           ? new Date(p.created_at).toLocaleDateString()
                           : '—'}
                       </td>
-                      <td className="px-4 py-3 font-medium">{getClientName(p)}</td>
-                      <td className="px-4 py-3 text-muted-foreground">
+                      <td className='px-4 py-3 font-medium'>
+                        {getClientName(p)}
+                      </td>
+                      <td className='px-4 py-3 text-muted-foreground'>
                         {getDisplayType(p).replace(/_/g, ' ')}
                       </td>
-                      <td className="px-4 py-3 text-right font-medium">
+                      <td className='px-4 py-3 text-right font-medium'>
                         ${Number(p.amount || 0).toFixed(2)}
                       </td>
-                      <td className="px-4 py-3 text-muted-foreground max-w-[200px] truncate">
+                      <td className='px-4 py-3 text-muted-foreground max-w-[200px] truncate'>
                         {p.description || '—'}
                       </td>
-                      <td className="px-4 py-3 text-muted-foreground">
+                      <td className='px-4 py-3 text-muted-foreground'>
                         {p.invoice ?? p.invoice_id ?? '—'}
                       </td>
-                      <td className="px-4 py-3 text-muted-foreground">
+                      <td className='px-4 py-3 text-muted-foreground'>
                         {p.contract_id || '—'}
                       </td>
                     </tr>
@@ -293,31 +332,35 @@ export default function FinancialPage() {
             </div>
 
             {/* Pagination bar - always visible at bottom of card */}
-            <div className="shrink-0 flex items-center justify-between gap-4 px-4 py-3 border-t bg-muted/30">
-              <p className="text-sm text-muted-foreground">
-                Showing {startItem + 1}–{Math.min(startItem + pageSize, filtered.length)} of {filtered.length}
+            <div className='shrink-0 flex items-center justify-between gap-4 px-4 py-3 border-t bg-muted/30'>
+              <p className='text-sm text-muted-foreground'>
+                Showing {startItem + 1}–
+                {Math.min(startItem + pageSize, filtered.length)} of{' '}
+                {filtered.length}
               </p>
-              <div className="flex items-center gap-2">
+              <div className='flex items-center gap-2'>
                 <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-8 w-8 p-0"
+                  variant='outline'
+                  size='sm'
+                  className='h-8 w-8 p-0'
                   disabled={currentPage <= 1}
                   onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
                 >
-                  <ChevronLeft className="h-4 w-4" />
+                  <ChevronLeft className='h-4 w-4' />
                 </Button>
-                <span className="text-sm font-medium min-w-[80px] text-center">
+                <span className='text-sm font-medium min-w-[80px] text-center'>
                   Page {currentPage} of {totalPages}
                 </span>
                 <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-8 w-8 p-0"
+                  variant='outline'
+                  size='sm'
+                  className='h-8 w-8 p-0'
                   disabled={currentPage >= totalPages}
-                  onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+                  onClick={() =>
+                    setCurrentPage((p) => Math.min(totalPages, p + 1))
+                  }
                 >
-                  <ChevronRight className="h-4 w-4" />
+                  <ChevronRight className='h-4 w-4' />
                 </Button>
               </div>
             </div>

--- a/src/features/financial/FinancialPage.tsx
+++ b/src/features/financial/FinancialPage.tsx
@@ -126,7 +126,7 @@ export default function FinancialPage() {
 
   return (
     <div className="flex flex-col p-4 min-h-0 overflow-auto">
-      <div className="mb-4 flex items-center justify-between shrink-0">
+      <div className="mb-4 flex min-w-0 shrink-0 items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold tracking-tight">Payments</h1>
           <p className="text-muted-foreground mt-1">
@@ -136,7 +136,7 @@ export default function FinancialPage() {
       </div>
 
       {/* Summary stats at top */}
-      <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-4">
+      <div className="mb-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <div className="rounded-lg border bg-card p-4 shadow-sm">
           <p className="text-xs font-medium text-muted-foreground">Total amount</p>
           <p className="text-xl font-semibold mt-1">{formatAmount(totalAmount)}</p>

--- a/src/features/financial/ReconciliationPage.tsx
+++ b/src/features/financial/ReconciliationPage.tsx
@@ -16,7 +16,15 @@ import {
 } from '@/common/components/ui/select';
 import { Input } from '@/common/components/ui/input';
 import { useCallback, useContext, useEffect, useMemo, useState } from 'react';
-import { ChevronDown, ChevronLeft, ChevronRight, ChevronUp, Download, Filter, Loader2 } from 'lucide-react';
+import {
+  ChevronDown,
+  ChevronLeft,
+  ChevronRight,
+  ChevronUp,
+  Download,
+  Filter,
+  Loader2,
+} from 'lucide-react';
 
 const LIMIT_OPTIONS = [100, 500, 1000];
 const PAGE_SIZES = [10, 25, 50, 100];
@@ -42,13 +50,20 @@ function formatAmount(n: number): string {
   }).format(n);
 }
 
-function MatchTypeBadge({ matchType }: { matchType: ReconciliationRow['match_type'] }) {
-  const label = matchType === 'amount_and_customer' ? 'Amount + customer' : 'Amount only';
+function MatchTypeBadge({
+  matchType,
+}: {
+  matchType: ReconciliationRow['match_type'];
+}) {
+  const label =
+    matchType === 'amount_and_customer' ? 'Amount + customer' : 'Amount only';
   const variant = matchType === 'amount_and_customer' ? 'default' : 'secondary';
   return (
     <span
       className={`inline-flex items-center rounded-md px-2 py-0.5 text-xs font-medium ${
-        variant === 'default' ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'
+        variant === 'default'
+          ? 'bg-primary text-primary-foreground'
+          : 'bg-muted text-muted-foreground'
       }`}
     >
       {label}
@@ -58,30 +73,46 @@ function MatchTypeBadge({ matchType }: { matchType: ReconciliationRow['match_typ
 
 function SummaryBlock({ summary }: { summary: ReconciliationSummary }) {
   return (
-    <div className="mb-4">
-      <h2 className="text-sm font-semibold text-muted-foreground mb-2">Invoice totals</h2>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
-        <div className="rounded-lg border bg-card p-4 shadow-sm">
-          <p className="text-xs font-medium text-muted-foreground">Pending amount</p>
-          <p className="text-xl font-semibold mt-1">
-            {summary.total_pending_amount != null ? formatAmount(summary.total_pending_amount) : '—'}
+    <div className='mb-4'>
+      <h2 className='text-sm font-semibold text-muted-foreground mb-2'>
+        Invoice totals
+      </h2>
+      <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4'>
+        <div className='rounded-lg border bg-card p-4 shadow-sm'>
+          <p className='text-xs font-medium text-muted-foreground'>
+            Pending amount
+          </p>
+          <p className='text-xl font-semibold mt-1'>
+            {summary.total_pending_amount != null
+              ? formatAmount(summary.total_pending_amount)
+              : '—'}
           </p>
         </div>
-        <div className="rounded-lg border bg-card p-4 shadow-sm">
-          <p className="text-xs font-medium text-muted-foreground">Paid amount</p>
-          <p className="text-xl font-semibold mt-1">
-            {summary.total_paid_amount != null ? formatAmount(summary.total_paid_amount) : '—'}
+        <div className='rounded-lg border bg-card p-4 shadow-sm'>
+          <p className='text-xs font-medium text-muted-foreground'>
+            Paid amount
+          </p>
+          <p className='text-xl font-semibold mt-1'>
+            {summary.total_paid_amount != null
+              ? formatAmount(summary.total_paid_amount)
+              : '—'}
           </p>
         </div>
-        <div className="rounded-lg border bg-card p-4 shadow-sm">
-          <p className="text-xs font-medium text-muted-foreground">Pending count</p>
-          <p className="text-xl font-semibold mt-1">
-            {summary.total_pending_count != null ? summary.total_pending_count : '—'}
+        <div className='rounded-lg border bg-card p-4 shadow-sm'>
+          <p className='text-xs font-medium text-muted-foreground'>
+            Pending count
+          </p>
+          <p className='text-xl font-semibold mt-1'>
+            {summary.total_pending_count != null
+              ? summary.total_pending_count
+              : '—'}
           </p>
         </div>
-        <div className="rounded-lg border bg-card p-4 shadow-sm">
-          <p className="text-xs font-medium text-muted-foreground">Paid count</p>
-          <p className="text-xl font-semibold mt-1">
+        <div className='rounded-lg border bg-card p-4 shadow-sm'>
+          <p className='text-xs font-medium text-muted-foreground'>
+            Paid count
+          </p>
+          <p className='text-xl font-semibold mt-1'>
             {summary.total_paid_count != null ? summary.total_paid_count : '—'}
           </p>
         </div>
@@ -93,7 +124,7 @@ function SummaryBlock({ summary }: { summary: ReconciliationSummary }) {
 function MatchedPaymentsCell({ row }: { row: ReconciliationRow }) {
   const [expanded, setExpanded] = useState(false);
   const count = row.payment_ids.length;
-  if (count === 0) return <span className="text-muted-foreground">—</span>;
+  if (count === 0) return <span className='text-muted-foreground'>—</span>;
   const lines = row.payment_ids.map((id, i) => ({
     id,
     customer: row.payment_customers[i] ?? '—',
@@ -101,20 +132,25 @@ function MatchedPaymentsCell({ row }: { row: ReconciliationRow }) {
     date: formatDate(row.payment_created_dates[i]),
   }));
   return (
-    <div className="min-w-[140px]">
+    <div className='min-w-[140px]'>
       <button
-        type="button"
+        type='button'
         onClick={() => setExpanded((e) => !e)}
-        className="flex items-center gap-1 text-left text-sm font-medium text-primary hover:underline"
+        className='flex items-center gap-1 text-left text-sm font-medium text-primary hover:underline'
       >
         {count} payment{count !== 1 ? 's' : ''}
-        {expanded ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+        {expanded ? (
+          <ChevronUp className='h-4 w-4' />
+        ) : (
+          <ChevronDown className='h-4 w-4' />
+        )}
       </button>
       {expanded && (
-        <ul className="mt-2 space-y-1 text-xs text-muted-foreground border-l-2 pl-2">
+        <ul className='mt-2 space-y-1 text-xs text-muted-foreground border-l-2 pl-2'>
           {lines.map((l) => (
             <li key={l.id}>
-              <span className="font-mono">{l.id}</span> · {l.customer} · {formatAmount(l.amount)} · {l.date}
+              <span className='font-mono'>{l.id}</span> · {l.customer} ·{' '}
+              {formatAmount(l.amount)} · {l.date}
             </li>
           ))}
         </ul>
@@ -140,7 +176,9 @@ export default function ReconciliationPage() {
 
   const params: ReconciliationParams = {
     limit,
-    ...(invoiceStatus && { invoice_status: invoiceStatus.trim().toLowerCase() }),
+    ...(invoiceStatus && {
+      invoice_status: invoiceStatus.trim().toLowerCase(),
+    }),
     ...(dateFrom && { date_from: dateFrom }),
     ...(dateTo && { date_to: dateTo }),
   };
@@ -153,7 +191,9 @@ export default function ReconciliationPage() {
       setData(res.data);
       setSummary(res.summary);
     } catch (e) {
-      setError(e instanceof Error ? e.message : 'Failed to load reconciliation');
+      setError(
+        e instanceof Error ? e.message : 'Failed to load reconciliation'
+      );
       setData([]);
       setSummary(null);
     } finally {
@@ -173,8 +213,14 @@ export default function ReconciliationPage() {
     if (invoiceStatus) {
       const statusNorm = invoiceStatus.trim().toUpperCase();
       list = list.filter((row) => {
-        const raw = (row.invoice_status_raw ?? '').toString().trim().toUpperCase();
-        const normalized = (row.invoice_status ?? '').toString().trim().toUpperCase();
+        const raw = (row.invoice_status_raw ?? '')
+          .toString()
+          .trim()
+          .toUpperCase();
+        const normalized = (row.invoice_status ?? '')
+          .toString()
+          .trim()
+          .toUpperCase();
         if (raw) return raw === statusNorm;
         return normalized === statusNorm;
       });
@@ -230,31 +276,34 @@ export default function ReconciliationPage() {
 
   if (!authLoading && user?.role !== 'admin' && user?.role !== 'doula') {
     return (
-      <div className="p-6">
-        <p className="text-destructive">You do not have permission to view this page.</p>
+      <div className='p-6'>
+        <p className='text-destructive'>
+          You do not have permission to view this page.
+        </p>
       </div>
     );
   }
 
   return (
-    <div className="flex flex-col h-full min-h-0 overflow-hidden p-4">
-      <div className="mb-4 flex items-center justify-between shrink-0">
+    <div className='flex flex-col h-full min-h-0 overflow-hidden p-4'>
+      <div className='mb-4 flex items-center justify-between shrink-0'>
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">Reconciliation</h1>
-          <p className="text-muted-foreground mt-1">
-            Invoices ↔ payments by amount. Suggestions only; confirm and apply in a future step.
+          <h1 className='text-2xl font-bold tracking-tight'>Reconciliation</h1>
+          <p className='text-muted-foreground mt-1'>
+            Invoices ↔ payments by amount. Suggestions only; confirm and apply
+            in a future step.
           </p>
         </div>
         <Button
-          variant="outline"
-          size="sm"
+          variant='outline'
+          size='sm'
           onClick={handleDownloadCsv}
           disabled={csvLoading}
         >
           {csvLoading ? (
-            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            <Loader2 className='h-4 w-4 mr-2 animate-spin' />
           ) : (
-            <Download className="h-4 w-4 mr-2" />
+            <Download className='h-4 w-4 mr-2' />
           )}
           Download CSV
         </Button>
@@ -263,20 +312,23 @@ export default function ReconciliationPage() {
       {summary != null && <SummaryBlock summary={summary} />}
 
       {/* Filters bar - same layout as Financial page (Filter + left block, then dropdowns) */}
-      <div className="shrink-0 mb-4 rounded-lg border bg-card p-4 shadow-sm">
-        <div className="flex flex-wrap items-end gap-3">
-          <div className="flex items-center gap-2 min-w-[200px] flex-1">
-            <Filter className="h-4 w-4 text-muted-foreground shrink-0" />
-            <div className="flex-1 max-w-md flex items-center h-9 text-sm text-muted-foreground">
+      <div className='shrink-0 mb-4 rounded-lg border bg-card p-4 shadow-sm'>
+        <div className='flex flex-wrap items-end gap-3'>
+          <div className='flex items-center gap-2 min-w-[200px] flex-1'>
+            <Filter className='h-4 w-4 text-muted-foreground shrink-0' />
+            <div className='flex-1 max-w-md flex items-center h-9 text-sm text-muted-foreground'>
               {filtered.length === 0
                 ? 'No invoice–payment matches for the current filters.'
                 : `${filtered.length} match${filtered.length === 1 ? '' : 'es'} total`}
             </div>
           </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <Select value={String(limit)} onValueChange={(v) => setLimit(Number(v))}>
-              <SelectTrigger className="w-[100px] h-9">
-                <SelectValue placeholder="Limit" />
+          <div className='flex flex-wrap items-center gap-2'>
+            <Select
+              value={String(limit)}
+              onValueChange={(v) => setLimit(Number(v))}
+            >
+              <SelectTrigger className='w-[100px] h-9'>
+                <SelectValue placeholder='Limit' />
               </SelectTrigger>
               <SelectContent>
                 {LIMIT_OPTIONS.map((n) => (
@@ -286,9 +338,12 @@ export default function ReconciliationPage() {
                 ))}
               </SelectContent>
             </Select>
-            <Select value={invoiceStatus || 'all'} onValueChange={(v) => setInvoiceStatus(v === 'all' ? '' : v)}>
-              <SelectTrigger className="w-[160px] h-9">
-                <SelectValue placeholder="Invoice status" />
+            <Select
+              value={invoiceStatus || 'all'}
+              onValueChange={(v) => setInvoiceStatus(v === 'all' ? '' : v)}
+            >
+              <SelectTrigger className='w-[160px] h-9'>
+                <SelectValue placeholder='Invoice status' />
               </SelectTrigger>
               <SelectContent>
                 {STATUS_OPTIONS.map((o) => (
@@ -299,25 +354,25 @@ export default function ReconciliationPage() {
               </SelectContent>
             </Select>
             <Input
-              type="date"
-              className="h-9 w-[140px]"
+              type='date'
+              className='h-9 w-[140px]'
               value={dateFrom}
               onChange={(e) => setDateFrom(e.target.value)}
-              title="Date from"
+              title='Date from'
             />
             <Input
-              type="date"
-              className="h-9 w-[140px]"
+              type='date'
+              className='h-9 w-[140px]'
               value={dateTo}
               onChange={(e) => setDateTo(e.target.value)}
-              title="Date to"
+              title='Date to'
             />
             <Select
               value={String(pageSize)}
               onValueChange={(v) => setPageSize(Number(v))}
             >
-              <SelectTrigger className="w-[110px] h-9 min-w-[110px]">
-                <SelectValue placeholder="Per page" />
+              <SelectTrigger className='w-[110px] h-9 min-w-[110px]'>
+                <SelectValue placeholder='Per page' />
               </SelectTrigger>
               <SelectContent>
                 {PAGE_SIZES.map((n) => (
@@ -329,10 +384,10 @@ export default function ReconciliationPage() {
             </Select>
             {hasActiveFilters && (
               <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="h-9"
+                type='button'
+                variant='outline'
+                size='sm'
+                className='h-9'
                 onClick={() => {
                   setInvoiceStatus('');
                   setDateFrom('');
@@ -347,70 +402,98 @@ export default function ReconciliationPage() {
       </div>
 
       {error && (
-        <div className="mb-4 rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive">
-          <p className="font-medium">Error</p>
-          <p className="text-sm mt-1">{error}</p>
-          <Button variant="outline" size="sm" className="mt-2" onClick={fetchData}>
+        <div className='mb-4 rounded-lg border border-destructive/50 bg-destructive/10 p-4 text-destructive'>
+          <p className='font-medium'>Error</p>
+          <p className='text-sm mt-1'>{error}</p>
+          <Button
+            variant='outline'
+            size='sm'
+            className='mt-2'
+            onClick={fetchData}
+          >
             Retry
           </Button>
         </div>
       )}
 
-      <div className="flex flex-col flex-1 min-h-0 rounded-xl border bg-card shadow-sm overflow-hidden">
+      <div className='flex flex-col flex-1 min-h-0 rounded-xl border bg-card shadow-sm overflow-hidden'>
         {loading ? (
-          <div className="flex-1 flex flex-col items-center justify-center gap-3 p-8 text-muted-foreground">
-            <Loader2 className="h-8 w-8 animate-spin" aria-hidden />
-            <p className="text-sm font-medium">Loading reconciliation…</p>
+          <div className='flex-1 flex flex-col items-center justify-center gap-3 p-8 text-muted-foreground'>
+            <Loader2 className='h-8 w-8 animate-spin' aria-hidden />
+            <p className='text-sm font-medium'>Loading reconciliation…</p>
           </div>
         ) : filtered.length === 0 ? (
-          <div className="flex-1 flex items-center justify-center p-8 text-muted-foreground">
+          <div className='flex-1 flex items-center justify-center p-8 text-muted-foreground'>
             No invoice–payment matches for the current filters.
           </div>
         ) : (
           <>
-            <div className="overflow-auto flex-1 min-h-0">
-              <table className="min-w-full text-sm">
-                <thead className="sticky top-0 bg-muted/80 backdrop-blur z-10">
-                  <tr className="border-b">
-                    <th className="px-4 py-3 text-left font-semibold">Invoice</th>
-                    <th className="px-4 py-3 text-left font-semibold">Customer</th>
-                    <th className="px-4 py-3 text-right font-semibold">Amount</th>
-                    <th className="px-4 py-3 text-left font-semibold">Status</th>
-                    <th className="px-4 py-3 text-left font-semibold">Invoice date</th>
-                    <th className="px-4 py-3 text-left font-semibold">Due date</th>
-                    <th className="px-4 py-3 text-left font-semibold">Match type</th>
-                    <th className="px-4 py-3 text-left font-semibold">Matched payments</th>
+            <div className='overflow-auto flex-1 min-h-0'>
+              <table className='min-w-full text-sm'>
+                <thead className='sticky top-0 bg-muted/80 backdrop-blur z-10'>
+                  <tr className='border-b'>
+                    <th className='px-4 py-3 text-left font-semibold'>
+                      Invoice
+                    </th>
+                    <th className='px-4 py-3 text-left font-semibold'>
+                      Customer
+                    </th>
+                    <th className='px-4 py-3 text-right font-semibold'>
+                      Amount
+                    </th>
+                    <th className='px-4 py-3 text-left font-semibold'>
+                      Status
+                    </th>
+                    <th className='px-4 py-3 text-left font-semibold'>
+                      Invoice date
+                    </th>
+                    <th className='px-4 py-3 text-left font-semibold'>
+                      Due date
+                    </th>
+                    <th className='px-4 py-3 text-left font-semibold'>
+                      Match type
+                    </th>
+                    <th className='px-4 py-3 text-left font-semibold'>
+                      Matched payments
+                    </th>
                   </tr>
                 </thead>
                 <tbody>
                   {paginatedItems.map((row) => (
                     <tr
                       key={row.invoice_id}
-                      className="border-b border-border/50 last:border-0 hover:bg-muted/30"
+                      className='border-b border-border/50 last:border-0 hover:bg-muted/30'
                     >
-                      <td className="px-4 py-3">
-                        <span className="font-medium">{row.invoice_number}</span>
-                        <span className="text-muted-foreground text-xs block">{row.invoice_id}</span>
+                      <td className='px-4 py-3'>
+                        <span className='font-medium'>
+                          {row.invoice_number}
+                        </span>
+                        <span className='text-muted-foreground text-xs block'>
+                          {row.invoice_id}
+                        </span>
                       </td>
-                      <td className="px-4 py-3 font-medium">{row.invoice_customer || '—'}</td>
-                      <td className="px-4 py-3 text-right font-medium">
+                      <td className='px-4 py-3 font-medium'>
+                        {row.invoice_customer || '—'}
+                      </td>
+                      <td className='px-4 py-3 text-right font-medium'>
                         {formatAmount(row.invoice_amount)}
                       </td>
-                      <td className="px-4 py-3 text-muted-foreground">
-                        {row.invoice_status_raw != null && row.invoice_status_raw !== ''
+                      <td className='px-4 py-3 text-muted-foreground'>
+                        {row.invoice_status_raw != null &&
+                        row.invoice_status_raw !== ''
                           ? row.invoice_status_raw
                           : (row.invoice_status || '—').toLowerCase()}
                       </td>
-                      <td className="px-4 py-3 text-muted-foreground">
+                      <td className='px-4 py-3 text-muted-foreground'>
                         {formatDate(row.invoice_created_at)}
                       </td>
-                      <td className="px-4 py-3 text-muted-foreground">
+                      <td className='px-4 py-3 text-muted-foreground'>
                         {formatDate(row.invoice_due_date)}
                       </td>
-                      <td className="px-4 py-3">
+                      <td className='px-4 py-3'>
                         <MatchTypeBadge matchType={row.match_type} />
                       </td>
-                      <td className="px-4 py-3">
+                      <td className='px-4 py-3'>
                         <MatchedPaymentsCell row={row} />
                       </td>
                     </tr>
@@ -420,31 +503,35 @@ export default function ReconciliationPage() {
             </div>
 
             {/* Pagination bar - same as Financial page */}
-            <div className="shrink-0 flex items-center justify-between gap-4 px-4 py-3 border-t bg-muted/30">
-              <p className="text-sm text-muted-foreground">
-                Showing {startItem + 1}–{Math.min(startItem + pageSize, filtered.length)} of {filtered.length}
+            <div className='shrink-0 flex items-center justify-between gap-4 px-4 py-3 border-t bg-muted/30'>
+              <p className='text-sm text-muted-foreground'>
+                Showing {startItem + 1}–
+                {Math.min(startItem + pageSize, filtered.length)} of{' '}
+                {filtered.length}
               </p>
-              <div className="flex items-center gap-2">
+              <div className='flex items-center gap-2'>
                 <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-8 w-8 p-0"
+                  variant='outline'
+                  size='sm'
+                  className='h-8 w-8 p-0'
                   disabled={currentPage <= 1}
                   onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
                 >
-                  <ChevronLeft className="h-4 w-4" />
+                  <ChevronLeft className='h-4 w-4' />
                 </Button>
-                <span className="text-sm font-medium min-w-[80px] text-center">
+                <span className='text-sm font-medium min-w-[80px] text-center'>
                   Page {currentPage} of {totalPages}
                 </span>
                 <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-8 w-8 p-0"
+                  variant='outline'
+                  size='sm'
+                  className='h-8 w-8 p-0'
                   disabled={currentPage >= totalPages}
-                  onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+                  onClick={() =>
+                    setCurrentPage((p) => Math.min(totalPages, p + 1))
+                  }
                 >
-                  <ChevronRight className="h-4 w-4" />
+                  <ChevronRight className='h-4 w-4' />
                 </Button>
               </div>
             </div>
@@ -452,8 +539,9 @@ export default function ReconciliationPage() {
         )}
       </div>
 
-      <p className="text-xs text-muted-foreground mt-4 shrink-0">
-        Data is from the backend reconciliation API (suggestions only). Confirm and apply to payments will be available in a future update.
+      <p className='text-xs text-muted-foreground mt-4 shrink-0'>
+        Data is from the backend reconciliation API (suggestions only). Confirm
+        and apply to payments will be available in a future update.
       </p>
     </div>
   );

--- a/src/features/financial/ReconciliationPage.tsx
+++ b/src/features/financial/ReconciliationPage.tsx
@@ -60,7 +60,7 @@ function SummaryBlock({ summary }: { summary: ReconciliationSummary }) {
   return (
     <div className="mb-4">
       <h2 className="text-sm font-semibold text-muted-foreground mb-2">Invoice totals</h2>
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-4">
         <div className="rounded-lg border bg-card p-4 shadow-sm">
           <p className="text-xs font-medium text-muted-foreground">Pending amount</p>
           <p className="text-xl font-semibold mt-1">

--- a/src/features/hours/components/DoulaDetailPage.tsx
+++ b/src/features/hours/components/DoulaDetailPage.tsx
@@ -346,7 +346,7 @@ export default function DoulaDetailPage() {
       </Header>
 
       <Main>
-        <div className='flex-1 overflow-auto p-6'>
+        <div className='min-w-0 flex-1 overflow-auto p-4 sm:p-6'>
           {/* Back Button */}
           <Button
             variant='ghost'

--- a/src/features/hours/components/DoulaDetailPage.tsx
+++ b/src/features/hours/components/DoulaDetailPage.tsx
@@ -88,15 +88,12 @@ export default function DoulaDetailPage() {
     try {
       // For now, fetch from team members API (replace with real doula endpoints when available)
 
-      const response = await fetchWithAuth(
-        buildUrl('/clients/team/all'),
-        {
-          method: 'GET',
-          headers: {
-            'Content-Type': 'application/json',
-          },
-        }
-      );
+      const response = await fetchWithAuth(buildUrl('/clients/team/all'), {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      });
 
       if (!response.ok) {
         throw new Error('Failed to fetch doula');

--- a/src/features/hours/components/data-table-pagination.tsx
+++ b/src/features/hours/components/data-table-pagination.tsx
@@ -22,9 +22,7 @@ export function DataTablePagination<TData>({
   table,
 }: DataTablePaginationProps<TData>) {
   return (
-    <div
-      className='flex flex-wrap items-center justify-between gap-2 px-2'
-    >
+    <div className='flex flex-wrap items-center justify-between gap-2 px-2'>
       <div className='hidden flex-1 text-sm text-muted-foreground sm:block'>
         {table.getFilteredSelectedRowModel().rows.length} of{' '}
         {table.getFilteredRowModel().rows.length} row(s) selected.

--- a/src/features/hours/components/data-table-pagination.tsx
+++ b/src/features/hours/components/data-table-pagination.tsx
@@ -23,8 +23,7 @@ export function DataTablePagination<TData>({
 }: DataTablePaginationProps<TData>) {
   return (
     <div
-      className='flex items-center justify-between overflow-clip px-2'
-      style={{ overflowClipMargin: 1 }}
+      className='flex flex-wrap items-center justify-between gap-2 px-2'
     >
       <div className='hidden flex-1 text-sm text-muted-foreground sm:block'>
         {table.getFilteredSelectedRowModel().rows.length} of{' '}

--- a/src/features/hours/components/users-table.tsx
+++ b/src/features/hours/components/users-table.tsx
@@ -94,7 +94,7 @@ export function UsersTable({ columns, data }: DataTableProps) {
         </div>
         <UsersPrimaryButtons />
       </div>
-      <div className='rounded-md border'>
+      <div className='min-w-0 overflow-x-auto rounded-md border'>
         <Table>
           <TableHeader>
             {table.getHeaderGroups().map((headerGroup) => (

--- a/src/features/hours/components/users-table.tsx
+++ b/src/features/hours/components/users-table.tsx
@@ -23,7 +23,13 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import { useState } from 'react';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/common/components/ui/select';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/common/components/ui/select';
 import { hourTypeOptions } from '@/features/hours/data/hour-types';
 import { DataTablePagination } from './data-table-pagination';
 import { UsersPrimaryButtons } from './users-primary-buttons';
@@ -73,9 +79,13 @@ export function UsersTable({ columns, data }: DataTableProps) {
         <div className='flex items-center gap-2'>
           <span className='text-sm text-muted-foreground'>Filter by type</span>
           <Select
-            value={(table.getColumn('type')?.getFilterValue() as string) ?? 'all'}
+            value={
+              (table.getColumn('type')?.getFilterValue() as string) ?? 'all'
+            }
             onValueChange={(value) =>
-              table.getColumn('type')?.setFilterValue(value === 'all' ? undefined : value)
+              table
+                .getColumn('type')
+                ?.setFilterValue(value === 'all' ? undefined : value)
             }
           >
             <SelectTrigger className='w-[180px]'>
@@ -109,9 +119,9 @@ export function UsersTable({ columns, data }: DataTableProps) {
                       {header.isPlaceholder
                         ? null
                         : flexRender(
-                          header.column.columnDef.header,
-                          header.getContext()
-                        )}
+                            header.column.columnDef.header,
+                            header.getContext()
+                          )}
                     </TableHead>
                   );
                 })}

--- a/src/features/integrations/QuickBooksConnect.tsx
+++ b/src/features/integrations/QuickBooksConnect.tsx
@@ -1,7 +1,10 @@
 import { API_CONFIG } from '@/api/config';
 import { fetchWithAuth } from '@/api/http';
 import { apiBaseUrl } from '@/config/env';
-import { getQuickBooksStatus, type QuickBooksCompany } from '@/api/quickbooks/auth/qbo';
+import {
+  getQuickBooksStatus,
+  type QuickBooksCompany,
+} from '@/api/quickbooks/auth/qbo';
 import { withTokenRefresh } from '@/api/quickbooks/auth/utils';
 import SubmitButton from '@/common/components/form/SubmitButton';
 import { Card, CardContent } from '@/common/components/ui/card';
@@ -31,7 +34,8 @@ export default function QuickBooksConnectPage() {
   const { connectQuickBooks, isLoading, error } = useQuickBooksConnect();
   const [connected, setConnected] = useState<boolean | null>(null);
   const [company, setCompany] = useState<QuickBooksCompany | null>(null);
-  const [companyDetailsUnavailable, setCompanyDetailsUnavailable] = useState(false);
+  const [companyDetailsUnavailable, setCompanyDetailsUnavailable] =
+    useState(false);
   const [isRefreshing, setIsRefreshing] = useState(false);
   const { user, isLoading: authLoading } = useContext(UserContext);
   const navigate = useNavigate();
@@ -94,7 +98,8 @@ export default function QuickBooksConnectPage() {
         import.meta.env.VITE_APP_FRONTEND_URL || window.location.origin
       ).origin;
       const backendOrigin = new URL(apiBaseUrl).origin;
-      if (event.origin !== frontendOrigin && event.origin !== backendOrigin) return;
+      if (event.origin !== frontendOrigin && event.origin !== backendOrigin)
+        return;
       if (event.data?.success) {
         if (successHandledRef.current) return;
         successHandledRef.current = true;
@@ -115,18 +120,26 @@ export default function QuickBooksConnectPage() {
       return;
     }
     try {
-      const response = await fetchWithAuth(`${API_BASE}/quickbooks/disconnect`, {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-      });
-      if (!response.ok) throw new Error((await response.text()) || 'Disconnect failed');
+      const response = await fetchWithAuth(
+        `${API_BASE}/quickbooks/disconnect`,
+        {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'Content-Type': 'application/json' },
+        }
+      );
+      if (!response.ok)
+        throw new Error((await response.text()) || 'Disconnect failed');
       setConnected(false);
       setCompany(null);
       toast.info('QuickBooks disconnected');
     } catch (disconnectError) {
       console.error('Disconnect error:', disconnectError);
-      toast.error(disconnectError instanceof Error ? disconnectError.message : 'Could not disconnect QuickBooks');
+      toast.error(
+        disconnectError instanceof Error
+          ? disconnectError.message
+          : 'Could not disconnect QuickBooks'
+      );
     }
   }, [connectQuickBooks, connected, isLoading]);
 
@@ -139,7 +152,9 @@ export default function QuickBooksConnectPage() {
           </div>
           <div>
             <p className='font-semibold text-slate-900'>Checking QuickBooks</p>
-            <p className='mt-1 text-sm text-slate-500'>Loading your connection details…</p>
+            <p className='mt-1 text-sm text-slate-500'>
+              Loading your connection details…
+            </p>
           </div>
         </div>
       </div>
@@ -160,9 +175,12 @@ export default function QuickBooksConnectPage() {
             <div className='mb-2 flex items-center gap-2 text-sm font-medium text-slate-500'>
               <Link2 className='h-4 w-4' /> Integrations
             </div>
-            <h1 className='text-3xl font-bold tracking-tight text-slate-950'>QuickBooks</h1>
+            <h1 className='text-3xl font-bold tracking-tight text-slate-950'>
+              QuickBooks
+            </h1>
             <p className='mt-2 max-w-2xl text-sm leading-6 text-slate-600'>
-              Keep customer and billing information connected to your accounting workspace.
+              Keep customer and billing information connected to your accounting
+              workspace.
             </p>
           </div>
           {connected && (
@@ -172,52 +190,98 @@ export default function QuickBooksConnectPage() {
               disabled={isRefreshing}
               className='inline-flex h-10 items-center justify-center gap-2 rounded-lg border border-slate-200 bg-white px-4 text-sm font-medium text-slate-700 shadow-sm transition hover:bg-slate-50 disabled:opacity-60'
             >
-              <RefreshCw className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`} />
+              <RefreshCw
+                className={`h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`}
+              />
               Refresh connection
             </button>
           )}
         </div>
 
         <Card className='overflow-hidden border-slate-200 shadow-sm'>
-          <div className={`h-1.5 ${connected ? 'bg-[#2ca01c]' : 'bg-slate-300'}`} />
+          <div
+            className={`h-1.5 ${connected ? 'bg-[#2ca01c]' : 'bg-slate-300'}`}
+          />
           <CardContent className='p-0'>
             <div className='grid min-w-0 lg:grid-cols-[1.35fr_0.65fr]'>
               <div className='p-6 sm:p-8'>
                 <div className='flex flex-col gap-5 sm:flex-row sm:items-start'>
-                  <div className='flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl bg-[#2ca01c] text-2xl font-bold text-white shadow-sm'>qb</div>
+                  <div className='flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl bg-[#2ca01c] text-2xl font-bold text-white shadow-sm'>
+                    qb
+                  </div>
                   <div className='min-w-0 flex-1'>
                     <div className='flex flex-wrap items-center gap-3'>
-                      <h2 className='text-xl font-semibold text-slate-950'>QuickBooks Online</h2>
-                      <span className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ring-inset ${connected ? 'bg-emerald-50 text-emerald-700 ring-emerald-200' : 'bg-slate-100 text-slate-600 ring-slate-200'}`}>
-                        {connected ? <CheckCircle2 className='h-3.5 w-3.5' /> : <Unplug className='h-3.5 w-3.5' />}
+                      <h2 className='text-xl font-semibold text-slate-950'>
+                        QuickBooks Online
+                      </h2>
+                      <span
+                        className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-semibold ring-1 ring-inset ${connected ? 'bg-emerald-50 text-emerald-700 ring-emerald-200' : 'bg-slate-100 text-slate-600 ring-slate-200'}`}
+                      >
+                        {connected ? (
+                          <CheckCircle2 className='h-3.5 w-3.5' />
+                        ) : (
+                          <Unplug className='h-3.5 w-3.5' />
+                        )}
                         {connected ? 'Connected' : 'Not connected'}
                       </span>
                     </div>
                     {connected ? (
                       <div className='mt-5 rounded-xl border border-slate-200 bg-slate-50 p-4'>
                         <div className='flex items-start gap-3'>
-                          <div className='mt-0.5 rounded-lg bg-white p-2 shadow-sm ring-1 ring-slate-200'><Building2 className='h-5 w-5 text-slate-600' /></div>
+                          <div className='mt-0.5 rounded-lg bg-white p-2 shadow-sm ring-1 ring-slate-200'>
+                            <Building2 className='h-5 w-5 text-slate-600' />
+                          </div>
                           <div className='min-w-0'>
-                            <p className='text-xs font-semibold uppercase tracking-wider text-slate-500'>Connected company</p>
-                            <p className='mt-1 truncate text-lg font-semibold text-slate-900'>{company?.name || 'QuickBooks company'}</p>
-                            {company?.legalName && company.legalName !== company.name && <p className='mt-0.5 text-sm text-slate-500'>{company.legalName}</p>}
-                            {(company?.email || company?.country) && <p className='mt-2 text-sm text-slate-500'>{[company.email, company.country].filter(Boolean).join(' · ')}</p>}
+                            <p className='text-xs font-semibold uppercase tracking-wider text-slate-500'>
+                              Connected company
+                            </p>
+                            <p className='mt-1 truncate text-lg font-semibold text-slate-900'>
+                              {company?.name || 'QuickBooks company'}
+                            </p>
+                            {company?.legalName &&
+                              company.legalName !== company.name && (
+                                <p className='mt-0.5 text-sm text-slate-500'>
+                                  {company.legalName}
+                                </p>
+                              )}
+                            {(company?.email || company?.country) && (
+                              <p className='mt-2 text-sm text-slate-500'>
+                                {[company.email, company.country]
+                                  .filter(Boolean)
+                                  .join(' · ')}
+                              </p>
+                            )}
                           </div>
                         </div>
-                        {companyDetailsUnavailable && <div className='mt-3 flex items-center gap-2 text-xs text-amber-700'><AlertCircle className='h-4 w-4' />Company details are temporarily unavailable.</div>}
+                        {companyDetailsUnavailable && (
+                          <div className='mt-3 flex items-center gap-2 text-xs text-amber-700'>
+                            <AlertCircle className='h-4 w-4' />
+                            Company details are temporarily unavailable.
+                          </div>
+                        )}
                       </div>
                     ) : (
-                      <p className='mt-4 max-w-xl text-sm leading-6 text-slate-600'>Connect your organization to verify customer links and keep accounting records aligned with the CRM.</p>
+                      <p className='mt-4 max-w-xl text-sm leading-6 text-slate-600'>
+                        Connect your organization to verify customer links and
+                        keep accounting records aligned with the CRM.
+                      </p>
                     )}
                   </div>
                 </div>
               </div>
               <div className='border-t border-slate-200 bg-slate-50/80 p-6 sm:p-8 lg:border-l lg:border-t-0'>
-                <p className='text-sm font-semibold text-slate-900'>What this connection enables</p>
+                <p className='text-sm font-semibold text-slate-900'>
+                  What this connection enables
+                </p>
                 <ul className='mt-4 space-y-3'>
                   {benefits.map(({ Icon, label }) => (
-                    <li key={label} className='flex items-center gap-3 text-sm text-slate-600'>
-                      <span className='flex h-7 w-7 items-center justify-center rounded-full bg-white ring-1 ring-slate-200'><Icon className='h-4 w-4 text-[#2ca01c]' /></span>
+                    <li
+                      key={label}
+                      className='flex items-center gap-3 text-sm text-slate-600'
+                    >
+                      <span className='flex h-7 w-7 items-center justify-center rounded-full bg-white ring-1 ring-slate-200'>
+                        <Icon className='h-4 w-4 text-[#2ca01c]' />
+                      </span>
                       {label}
                     </li>
                   ))}
@@ -228,9 +292,24 @@ export default function QuickBooksConnectPage() {
         </Card>
 
         <div className='flex flex-col-reverse gap-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between'>
-          <p className='flex items-center gap-2 text-xs text-slate-500'><ShieldCheck className='h-4 w-4' />Your QuickBooks credentials are never displayed or stored in the browser.</p>
+          <p className='flex items-center gap-2 text-xs text-slate-500'>
+            <ShieldCheck className='h-4 w-4' />
+            Your QuickBooks credentials are never displayed or stored in the
+            browser.
+          </p>
           <SubmitButton onClick={handleConnectionAction} disabled={isLoading}>
-            {isLoading ? <span className='inline-flex items-center gap-2'><Loader2 className='h-4 w-4 animate-spin' />Please wait…</span> : connected ? 'Disconnect QuickBooks' : <span className='inline-flex items-center gap-2'>Connect QuickBooks <ArrowRight className='h-4 w-4' /></span>}
+            {isLoading ? (
+              <span className='inline-flex items-center gap-2'>
+                <Loader2 className='h-4 w-4 animate-spin' />
+                Please wait…
+              </span>
+            ) : connected ? (
+              'Disconnect QuickBooks'
+            ) : (
+              <span className='inline-flex items-center gap-2'>
+                Connect QuickBooks <ArrowRight className='h-4 w-4' />
+              </span>
+            )}
           </SubmitButton>
         </div>
       </div>

--- a/src/features/integrations/QuickBooksConnect.tsx
+++ b/src/features/integrations/QuickBooksConnect.tsx
@@ -1,4 +1,5 @@
 import { API_CONFIG } from '@/api/config';
+import { fetchWithAuth } from '@/api/http';
 import { apiBaseUrl } from '@/config/env';
 import { getQuickBooksStatus, type QuickBooksCompany } from '@/api/quickbooks/auth/qbo';
 import { withTokenRefresh } from '@/api/quickbooks/auth/utils';
@@ -114,7 +115,7 @@ export default function QuickBooksConnectPage() {
       return;
     }
     try {
-      const response = await fetch(`${API_BASE}/quickbooks/disconnect`, {
+      const response = await fetchWithAuth(`${API_BASE}/quickbooks/disconnect`, {
         method: 'POST',
         credentials: 'include',
         headers: { 'Content-Type': 'application/json' },
@@ -180,7 +181,7 @@ export default function QuickBooksConnectPage() {
         <Card className='overflow-hidden border-slate-200 shadow-sm'>
           <div className={`h-1.5 ${connected ? 'bg-[#2ca01c]' : 'bg-slate-300'}`} />
           <CardContent className='p-0'>
-            <div className='grid lg:grid-cols-[1.35fr_0.65fr]'>
+            <div className='grid min-w-0 lg:grid-cols-[1.35fr_0.65fr]'>
               <div className='p-6 sm:p-8'>
                 <div className='flex flex-col gap-5 sm:flex-row sm:items-start'>
                   <div className='flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl bg-[#2ca01c] text-2xl font-bold text-white shadow-sm'>qb</div>

--- a/src/features/my-account/components/UpdateAccount.tsx
+++ b/src/features/my-account/components/UpdateAccount.tsx
@@ -23,14 +23,14 @@ import {
   SelectValue,
 } from '@/common/components/ui/select';
 import { Separator } from '@/common/components/ui/separator';
+import { LoadingOverlay } from '@/common/components/loading/LoadingOverlay';
 import { useUser } from '@/common/hooks/user/useUser';
 import { STATES } from '@/common/utils/50States';
-import { useForm } from 'react-hook-form';
-import styled from 'styled-components';
-
-import { LoadingOverlay } from '@/common/components/loading/LoadingOverlay';
 import saveUser from '@/common/utils/saveUser';
 import { Loader2 } from 'lucide-react';
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import styled from 'styled-components';
 import { toast } from 'sonner';
 
 const TwoInputs = styled.div`
@@ -48,8 +48,22 @@ interface AccountFormValues {
   state?: string;
 }
 
+/** Accepts stored "IL" or "Illinois" and returns the Select option code. */
+function normalizeStateCode(raw?: string | null): string {
+  const trimmed = (raw || '').trim();
+  if (!trimmed) return '';
+  const byCode = STATES.find(
+    (s) => s.value.toLowerCase() === trimmed.toLowerCase()
+  );
+  if (byCode) return byCode.value;
+  const byLabel = STATES.find(
+    (s) => s.label.toLowerCase() === trimmed.toLowerCase()
+  );
+  return byLabel?.value || '';
+}
+
 export const Account = () => {
-  const { user, isLoading, checkAuth } = useUser();
+  const { user, isLoading, checkAuth, setUser } = useUser();
 
   const accountForm = useForm<AccountFormValues>({
     defaultValues: {
@@ -58,9 +72,21 @@ export const Account = () => {
       email: '',
       address: '',
       city: '',
-      state: STATES[0].value,
+      state: '',
     },
   });
+
+  useEffect(() => {
+    if (!user) return;
+    accountForm.reset({
+      firstname: user.firstname || '',
+      lastname: user.lastname || '',
+      email: user.email || '',
+      address: user.address || '',
+      city: user.city || '',
+      state: normalizeStateCode(user.state),
+    });
+  }, [user, accountForm]);
 
   const submitAccountForm = async (values: AccountFormValues) => {
     if (!user?.id) return;
@@ -72,14 +98,14 @@ export const Account = () => {
     userFormData.append('email', values.email ?? '');
     userFormData.append('address', values.address ?? '');
     userFormData.append('city', values.city ?? '');
-    userFormData.append('state', values.state ?? '');
+    userFormData.append('state', normalizeStateCode(values.state) || values.state || '');
 
     try {
       const savedUser = await saveUser(userFormData);
-      // console.log("User saved successfully:", savedUser);
       toast.success('Changes saved');
-      await checkAuth();
-      accountForm.reset();
+      setUser((prev) => (prev ? { ...prev, ...savedUser } : savedUser));
+      await checkAuth({ silent: true });
+      accountForm.reset(values);
     } catch (err) {
       console.error('User NOT saved successfully: ', err);
       toast.error(
@@ -180,21 +206,21 @@ export const Account = () => {
                     <FormLabel>State</FormLabel>
                     <Select
                       onValueChange={field.onChange}
-                      defaultValue={field.value}
+                      value={field.value || undefined}
                     >
                       <FormControl>
                         <SelectTrigger className='w-[180px]'>
-                          <SelectValue placeholder={user?.state || ''} />
+                          <SelectValue placeholder='Select state' />
                         </SelectTrigger>
                       </FormControl>
                       <SelectContent>
                         {STATES.map((state) => (
                           <SelectItem
                             key={state.value}
-                            value={state.label}
+                            value={state.value}
                             className='cursor-pointer'
                           >
-                            {state.value}
+                            {state.label}
                           </SelectItem>
                         ))}
                       </SelectContent>

--- a/src/features/my-account/components/UpdateAccount.tsx
+++ b/src/features/my-account/components/UpdateAccount.tsx
@@ -98,7 +98,10 @@ export const Account = () => {
     userFormData.append('email', values.email ?? '');
     userFormData.append('address', values.address ?? '');
     userFormData.append('city', values.city ?? '');
-    userFormData.append('state', normalizeStateCode(values.state) || values.state || '');
+    userFormData.append(
+      'state',
+      normalizeStateCode(values.state) || values.state || ''
+    );
 
     try {
       const savedUser = await saveUser(userFormData);

--- a/src/features/my-account/components/UpdateProfile.tsx
+++ b/src/features/my-account/components/UpdateProfile.tsx
@@ -22,7 +22,7 @@ import UserAvatar from '@/common/components/user/UserAvatar';
 import { useUser } from '@/common/hooks/user/useUser';
 import saveUser from '@/common/utils/saveUser';
 import { Loader2 } from 'lucide-react';
-import { ChangeEvent } from 'react';
+import { ChangeEvent, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 
@@ -32,13 +32,21 @@ interface ProfileFormValues {
 }
 
 export const Profile = () => {
-  const { user, isLoading, checkAuth } = useUser();
+  const { user, isLoading, checkAuth, setUser } = useUser();
 
   const profileForm = useForm<ProfileFormValues>({
     defaultValues: {
       bio: '',
     },
   });
+
+  useEffect(() => {
+    if (!user) return;
+    profileForm.reset({
+      bio: user.bio || '',
+      profile_picture: undefined,
+    });
+  }, [user, profileForm]);
 
   const submitProfileForm = async (values: ProfileFormValues) => {
     if (!user?.id) return;
@@ -50,10 +58,13 @@ export const Profile = () => {
 
     try {
       const savedUser = await saveUser(formData);
-      // console.log("User saved successfully:", savedUser);
       toast.success('Changes saved.');
-      await checkAuth();
-      profileForm.reset();
+      setUser((prev) => (prev ? { ...prev, ...savedUser } : savedUser));
+      await checkAuth({ silent: true });
+      profileForm.reset({
+        bio: values.bio ?? '',
+        profile_picture: undefined,
+      });
     } catch (err) {
       console.error('User NOT saved successfully:', err);
       toast.error(
@@ -121,7 +132,7 @@ export const Profile = () => {
                     <FormLabel className='pb-1'>Bio</FormLabel>
                     <FormControl>
                       <Textarea
-                        placeholder={`Current: ${user?.bio || ''}`}
+                        placeholder='Tell others a bit about yourself'
                         {...field}
                       />
                     </FormControl>

--- a/src/features/request/IntakeHoneypotFields.tsx
+++ b/src/features/request/IntakeHoneypotFields.tsx
@@ -1,0 +1,37 @@
+import {
+  INTAKE_HONEYPOT_FIELDS,
+  intakeHoneypotValues,
+  type IntakeHoneypotField,
+} from './intakeAbuse';
+
+/** Hidden fields matching backend honeypot names. Bots that fill them get a fake 200. */
+export function IntakeHoneypotFields() {
+  return (
+    <div
+      aria-hidden='true'
+      style={{
+        position: 'absolute',
+        left: '-10000px',
+        width: 1,
+        height: 1,
+        overflow: 'hidden',
+      }}
+    >
+      {INTAKE_HONEYPOT_FIELDS.map((name: IntakeHoneypotField) => (
+        <label key={name}>
+          {name}
+          <input
+            type='text'
+            name={name}
+            tabIndex={-1}
+            autoComplete='off'
+            defaultValue=''
+            onChange={(event) => {
+              intakeHoneypotValues[name] = event.target.value;
+            }}
+          />
+        </label>
+      ))}
+    </div>
+  );
+}

--- a/src/features/request/RequestForm.tsx
+++ b/src/features/request/RequestForm.tsx
@@ -1,7 +1,10 @@
 import { Form } from '@/common/components/ui/form';
 import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
-import { RequestFormProvider, useRequestFormContext } from './contexts/RequestFormContext';
+import {
+  RequestFormProvider,
+  useRequestFormContext,
+} from './contexts/RequestFormContext';
 import styles from './RequestForm.module.scss';
 import RequestFormDesktop from './RequestFormDesktop';
 import { Step1Personal } from './Step1Personal';
@@ -27,7 +30,13 @@ import {
   resetIntakeHoneypotValues,
 } from './intakeAbuse';
 
-function RefreshWarningModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
+function RefreshWarningModal({
+  isOpen,
+  onClose,
+}: {
+  isOpen: boolean;
+  onClose: () => void;
+}) {
   if (!isOpen) return null;
 
   return (
@@ -59,8 +68,8 @@ function RefreshWarningModal({ isOpen, onClose }: { isOpen: boolean; onClose: ()
           Unsaved Changes
         </h3>
         <p style={{ marginBottom: 24, color: '#666', lineHeight: 1.5 }}>
-          You have unsaved changes in your form. If you refresh or leave this page,
-          all your progress will be lost.
+          You have unsaved changes in your form. If you refresh or leave this
+          page, all your progress will be lost.
         </p>
         <div style={{ display: 'flex', gap: 12, justifyContent: 'center' }}>
           <button
@@ -98,8 +107,22 @@ function RefreshWarningModal({ isOpen, onClose }: { isOpen: boolean; onClose: ()
 }
 
 function RequestFormContent() {
-  const [isDesktop, setIsDesktop] = useState(() => window.matchMedia('(min-width: 600px)').matches);
-  const { form, step, totalSteps, handleNextStep, handleBack, isSubmitting, submitted, showRefreshWarning, setShowRefreshWarning, fillTestData, stepGateMessage } = useRequestFormContext();
+  const [isDesktop, setIsDesktop] = useState(
+    () => window.matchMedia('(min-width: 600px)').matches
+  );
+  const {
+    form,
+    step,
+    totalSteps,
+    handleNextStep,
+    handleBack,
+    isSubmitting,
+    submitted,
+    showRefreshWarning,
+    setShowRefreshWarning,
+    fillTestData,
+    stepGateMessage,
+  } = useRequestFormContext();
 
   useEffect(() => {
     const mql = window.matchMedia('(min-width: 600px)');
@@ -113,7 +136,10 @@ function RequestFormContent() {
     return (
       <>
         <RequestFormDesktop />
-        <RefreshWarningModal isOpen={showRefreshWarning} onClose={() => setShowRefreshWarning(false)} />
+        <RefreshWarningModal
+          isOpen={showRefreshWarning}
+          onClose={() => setShowRefreshWarning(false)}
+        />
       </>
     );
   }
@@ -247,23 +273,23 @@ function RequestFormContent() {
             you with a doula according to your needs.
           </div>
           {isRequestTestDataEnabled() && (
-          <button
-            type="button"
-            onClick={fillTestData}
-            title="Loads a complete sample (including age, provider type, primary + secondary insurance). Resets the form and returns to the first step. Dev/QA only."
-            style={{
-              marginTop: 10,
-              padding: '5px 10px',
-              fontSize: 11,
-              color: '#009688',
-              background: 'transparent',
-              border: '1px dashed #009688',
-              borderRadius: 4,
-              cursor: 'pointer',
-            }}
-          >
-            Fill with test data
-          </button>
+            <button
+              type='button'
+              onClick={fillTestData}
+              title='Loads a complete sample (including age, provider type, primary + secondary insurance). Resets the form and returns to the first step. Dev/QA only.'
+              style={{
+                marginTop: 10,
+                padding: '5px 10px',
+                fontSize: 11,
+                color: '#009688',
+                background: 'transparent',
+                border: '1px dashed #009688',
+                borderRadius: 4,
+                cursor: 'pointer',
+              }}
+            >
+              Fill with test data
+            </button>
           )}
         </div>
 
@@ -289,11 +315,11 @@ function RequestFormContent() {
               }}
             />
           </div>
-          
+
           {/* Step Navigation */}
           <StepNavigation currentStep={step} isDesktop={false} />
         </div>
-        
+
         {/* Step Header */}
         <StepHeader currentStep={step} totalSteps={totalSteps} />
         {stepGateMessage ? (
@@ -391,7 +417,10 @@ function RequestFormContent() {
           )}
         </Form>
       </div>
-      <RefreshWarningModal isOpen={showRefreshWarning} onClose={() => setShowRefreshWarning(false)} />
+      <RefreshWarningModal
+        isOpen={showRefreshWarning}
+        onClose={() => setShowRefreshWarning(false)}
+      />
     </>
   );
 }

--- a/src/features/request/RequestForm.tsx
+++ b/src/features/request/RequestForm.tsx
@@ -1,5 +1,5 @@
 import { Form } from '@/common/components/ui/form';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { RequestFormProvider, useRequestFormContext } from './contexts/RequestFormContext';
 import styles from './RequestForm.module.scss';
@@ -18,7 +18,14 @@ import {
 import { RequestFormValues } from './useRequestForm';
 import { StepNavigation } from './components/StepNavigation';
 import { StepHeader } from './components/StepHeader';
-import { apiBaseUrl } from '@/config/env';
+import { apiBaseUrl, isRequestTestDataEnabled } from '@/config/env';
+import { IntakeHoneypotFields } from './IntakeHoneypotFields';
+import {
+  createIntakeIdempotencyKey,
+  formatIntakeRateLimitError,
+  intakeHoneypotValues,
+  resetIntakeHoneypotValues,
+} from './intakeAbuse';
 
 function RefreshWarningModal({ isOpen, onClose }: { isOpen: boolean; onClose: () => void }) {
   if (!isOpen) return null;
@@ -239,10 +246,11 @@ function RequestFormContent() {
             Please complete this form as thoroughly as possible so we can match
             you with a doula according to your needs.
           </div>
+          {isRequestTestDataEnabled() && (
           <button
             type="button"
             onClick={fillTestData}
-            title="Loads a complete sample (including age, provider type, primary + secondary insurance). Resets the form and returns to the first step. Test-data submissions are marked to skip email notifications."
+            title="Loads a complete sample (including age, provider type, primary + secondary insurance). Resets the form and returns to the first step. Dev/QA only."
             style={{
               marginTop: 10,
               padding: '5px 10px',
@@ -256,6 +264,7 @@ function RequestFormContent() {
           >
             Fill with test data
           </button>
+          )}
         </div>
 
         {/* Combined Progress and Navigation Section */}
@@ -297,6 +306,7 @@ function RequestFormContent() {
           </div>
         ) : null}
         <Form {...form}>
+          <IntakeHoneypotFields />
           {step === 0 && (
             <Step8ServicesInterested
               form={form}
@@ -387,6 +397,8 @@ function RequestFormContent() {
 }
 
 export default function RequestForm() {
+  const idempotencyKeyRef = useRef(createIntakeIdempotencyKey());
+
   const onSubmit = async (
     formData: RequestFormValues,
     options?: { isUsingTestData: boolean }
@@ -411,10 +423,9 @@ export default function RequestForm() {
           : formData.number_of_babies,
       service_needed:
         servicesSummary || (formData.service_support_details || '').trim(),
-      skip_email_notifications: Boolean(options?.isUsingTestData),
       submission_source: options?.isUsingTestData ? 'test_data' : 'manual',
+      ...intakeHoneypotValues,
     };
-    // Use the same pattern as login endpoint (no /api prefix)
     const backendUrl = apiBaseUrl;
 
     try {
@@ -422,21 +433,39 @@ export default function RequestForm() {
         `${backendUrl}/requestService/requestSubmission`,
         {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          credentials: 'omit',
+          headers: {
+            'Content-Type': 'application/json',
+            'Idempotency-Key': idempotencyKeyRef.current,
+          },
           body: JSON.stringify(payload),
         }
       );
 
-      const responseData = await response.json();
+      const responseData = (await response.json().catch(() => ({}))) as {
+        error?: string;
+        code?: string;
+      };
+
+      const rateLimitMessage = formatIntakeRateLimitError(
+        response.status,
+        responseData,
+        response.headers.get('Retry-After')
+      );
+      if (rateLimitMessage) {
+        throw new Error(rateLimitMessage);
+      }
 
       if (!response.ok || responseData.error) {
         throw new Error(responseData.error || 'Server returned an error.');
       }
+      idempotencyKeyRef.current = createIntakeIdempotencyKey();
+      resetIntakeHoneypotValues();
       toast.success('Request Form Submitted Successfully!');
     } catch (error) {
       console.error('Request submission error:', error);
       toast.error(error instanceof Error ? error.message : 'Submission failed');
-      throw error; // Re-throw to let the context handle the state
+      throw error;
     }
   };
 

--- a/src/features/request/RequestFormDesktop.tsx
+++ b/src/features/request/RequestFormDesktop.tsx
@@ -11,6 +11,8 @@ import {
   Step8ServicesInterested,
   Step9Payment,
 } from './Step3Home';
+import { isRequestTestDataEnabled } from '@/config/env';
+import { IntakeHoneypotFields } from './IntakeHoneypotFields';
 import { useRequestFormContext } from './contexts/RequestFormContext';
 import { StepNavigation } from './components/StepNavigation';
 import { StepHeader } from './components/StepHeader';
@@ -184,10 +186,11 @@ export default function RequestFormDesktop() {
           Please complete this form as thoroughly as possible so we can match
           you with a doula according to your needs.
         </div>
+        {isRequestTestDataEnabled() && (
         <button
           type='button'
           onClick={fillTestData}
-          title='Loads a complete sample (including age, provider type, primary + secondary insurance). Resets the form and returns to the first step.'
+          title='Loads a complete sample (including age, provider type, primary + secondary insurance). Resets the form and returns to the first step. Dev/QA only.'
           style={{
             marginTop: 12,
             padding: '6px 12px',
@@ -201,6 +204,7 @@ export default function RequestFormDesktop() {
         >
           Fill with test data
         </button>
+        )}
       </div>
 
       {/* Combined Progress and Navigation Section */}
@@ -242,6 +246,7 @@ export default function RequestFormDesktop() {
         </div>
       ) : null}
       <Form {...form}>
+        <IntakeHoneypotFields />
         {step === 0 && (
           <Step8ServicesInterested
             form={form}

--- a/src/features/request/RequestFormDesktop.tsx
+++ b/src/features/request/RequestFormDesktop.tsx
@@ -187,23 +187,23 @@ export default function RequestFormDesktop() {
           you with a doula according to your needs.
         </div>
         {isRequestTestDataEnabled() && (
-        <button
-          type='button'
-          onClick={fillTestData}
-          title='Loads a complete sample (including age, provider type, primary + secondary insurance). Resets the form and returns to the first step. Dev/QA only.'
-          style={{
-            marginTop: 12,
-            padding: '6px 12px',
-            fontSize: 12,
-            color: '#009688',
-            background: 'transparent',
-            border: '1px dashed #009688',
-            borderRadius: 4,
-            cursor: 'pointer',
-          }}
-        >
-          Fill with test data
-        </button>
+          <button
+            type='button'
+            onClick={fillTestData}
+            title='Loads a complete sample (including age, provider type, primary + secondary insurance). Resets the form and returns to the first step. Dev/QA only.'
+            style={{
+              marginTop: 12,
+              padding: '6px 12px',
+              fontSize: 12,
+              color: '#009688',
+              background: 'transparent',
+              border: '1px dashed #009688',
+              borderRadius: 4,
+              cursor: 'pointer',
+            }}
+          >
+            Fill with test data
+          </button>
         )}
       </div>
 
@@ -229,13 +229,17 @@ export default function RequestFormDesktop() {
             }}
           />
         </div>
-        
+
         {/* Step Navigation */}
         <StepNavigation currentStep={step} isDesktop={true} />
       </div>
-      
+
       {/* Step Header */}
-      <StepHeader currentStep={step} totalSteps={totalSteps} showProgressText={false} />
+      <StepHeader
+        currentStep={step}
+        totalSteps={totalSteps}
+        showProgressText={false}
+      />
       {stepGateMessage ? (
         <div
           role='alert'

--- a/src/features/request/__tests__/intakeAbuse.test.ts
+++ b/src/features/request/__tests__/intakeAbuse.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { formatIntakeRateLimitError } from '../intakeAbuse';
+
+describe('formatIntakeRateLimitError', () => {
+  it('returns null for non-rate-limit responses', () => {
+    expect(formatIntakeRateLimitError(400, { error: 'bad' }, null)).toBeNull();
+  });
+
+  it('uses Retry-After seconds when present', () => {
+    expect(
+      formatIntakeRateLimitError(429, { code: 'RATE_LIMITED' }, '30')
+    ).toBe('Too many requests. Please try again in 30 seconds.');
+  });
+
+  it('falls back to backend error text', () => {
+    expect(
+      formatIntakeRateLimitError(
+        429,
+        { error: 'Too many requests. Please try again later.', code: 'RATE_LIMITED' },
+        null
+      )
+    ).toBe('Too many requests. Please try again later.');
+  });
+});

--- a/src/features/request/__tests__/intakeAbuse.test.ts
+++ b/src/features/request/__tests__/intakeAbuse.test.ts
@@ -16,7 +16,10 @@ describe('formatIntakeRateLimitError', () => {
     expect(
       formatIntakeRateLimitError(
         429,
-        { error: 'Too many requests. Please try again later.', code: 'RATE_LIMITED' },
+        {
+          error: 'Too many requests. Please try again later.',
+          code: 'RATE_LIMITED',
+        },
         null
       )
     ).toBe('Too many requests. Please try again later.');

--- a/src/features/request/intakeAbuse.ts
+++ b/src/features/request/intakeAbuse.ts
@@ -1,0 +1,44 @@
+export const INTAKE_HONEYPOT_FIELDS = [
+  'website',
+  'company_url',
+  'fax_number',
+  'hp_field',
+] as const;
+
+export type IntakeHoneypotField = (typeof INTAKE_HONEYPOT_FIELDS)[number];
+
+export const intakeHoneypotValues: Record<IntakeHoneypotField, string> = {
+  website: '',
+  company_url: '',
+  fax_number: '',
+  hp_field: '',
+};
+
+export function resetIntakeHoneypotValues(): void {
+  for (const field of INTAKE_HONEYPOT_FIELDS) {
+    intakeHoneypotValues[field] = '';
+  }
+}
+
+export function createIntakeIdempotencyKey(): string {
+  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+    return crypto.randomUUID();
+  }
+  return `intake-${Date.now()}-${Math.random().toString(36).slice(2, 12)}`;
+}
+
+export function formatIntakeRateLimitError(
+  status: number,
+  body: { error?: string; code?: string },
+  retryAfterHeader: string | null
+): string | null {
+  if (status !== 429 && body.code !== 'RATE_LIMITED') return null;
+  const seconds =
+    retryAfterHeader && /^\d+$/.test(retryAfterHeader.trim())
+      ? Number(retryAfterHeader.trim())
+      : null;
+  if (seconds) {
+    return `Too many requests. Please try again in ${seconds} seconds.`;
+  }
+  return body.error || 'Too many requests. Please try again later.';
+}

--- a/src/features/request/intakeAbuse.ts
+++ b/src/features/request/intakeAbuse.ts
@@ -21,7 +21,10 @@ export function resetIntakeHoneypotValues(): void {
 }
 
 export function createIntakeIdempotencyKey(): string {
-  if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.randomUUID === 'function'
+  ) {
     return crypto.randomUUID();
   }
   return `intake-${Date.now()}-${Math.random().toString(36).slice(2, 12)}`;

--- a/src/features/teams/teams.tsx
+++ b/src/features/teams/teams.tsx
@@ -72,7 +72,9 @@ const toTeamMember = (member: any): TeamMember => ({
   firstname: String(member?.firstname ?? member?.first_name ?? '').trim(),
   lastname: String(member?.lastname ?? member?.last_name ?? '').trim(),
   role: normalizeTeamRole(member?.role),
-  email: String(member?.email ?? '').trim().toLowerCase(),
+  email: String(member?.email ?? '')
+    .trim()
+    .toLowerCase(),
   id: String(member?.id ?? member?.user_id ?? member?.email ?? ''),
   bio: String(member?.bio ?? ''),
   address: String(member?.address ?? '').trim(),
@@ -111,10 +113,16 @@ export default function Teams() {
   const [isUpdating, setIsUpdating] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
   const [documentsDialogOpen, setDocumentsDialogOpen] = useState(false);
-  const [documentsMember, setDocumentsMember] = useState<TeamMember | null>(null);
-  const [documentsItems, setDocumentsItems] = useState<DocumentCompletenessItem[]>([]);
+  const [documentsMember, setDocumentsMember] = useState<TeamMember | null>(
+    null
+  );
+  const [documentsItems, setDocumentsItems] = useState<
+    DocumentCompletenessItem[]
+  >([]);
   const [documentsLoading, setDocumentsLoading] = useState(false);
-  const [downloadingDocumentId, setDownloadingDocumentId] = useState<string | null>(null);
+  const [downloadingDocumentId, setDownloadingDocumentId] = useState<
+    string | null
+  >(null);
 
   const fetchTeam = async () => {
     //function to fetch all team members
@@ -238,28 +246,40 @@ export default function Teams() {
     try {
       const data = await getAdminDoulaDocuments(member.id);
       const rawItems = (data.completeness?.items ?? []) as unknown[];
-      const completenessItems: DocumentCompletenessItem[] = rawItems.map((raw) => {
-        const item = (raw ?? {}) as Record<string, unknown>;
-        const documentId = item.document_id ?? item.documentId;
-        const fileName = item.file_name ?? item.fileName;
-        const uploadedAt = item.uploaded_at ?? item.uploadedAt;
-        const rejectionReason = item.rejection_reason ?? item.rejectionReason;
-        return {
-          document_type: String(item.document_type ?? item.documentType ?? ''),
-          status: String(item.status ?? 'missing'),
-          document_id: typeof documentId === 'string' ? documentId : undefined,
-          file_name: typeof fileName === 'string' ? fileName : undefined,
-          uploaded_at: typeof uploadedAt === 'string' ? uploadedAt : undefined,
-          rejection_reason:
-            typeof rejectionReason === 'string' ? rejectionReason : undefined,
-        };
-      });
+      const completenessItems: DocumentCompletenessItem[] = rawItems.map(
+        (raw) => {
+          const item = (raw ?? {}) as Record<string, unknown>;
+          const documentId = item.document_id ?? item.documentId;
+          const fileName = item.file_name ?? item.fileName;
+          const uploadedAt = item.uploaded_at ?? item.uploadedAt;
+          const rejectionReason = item.rejection_reason ?? item.rejectionReason;
+          return {
+            document_type: String(
+              item.document_type ?? item.documentType ?? ''
+            ),
+            status: String(item.status ?? 'missing'),
+            document_id:
+              typeof documentId === 'string' ? documentId : undefined,
+            file_name: typeof fileName === 'string' ? fileName : undefined,
+            uploaded_at:
+              typeof uploadedAt === 'string' ? uploadedAt : undefined,
+            rejection_reason:
+              typeof rejectionReason === 'string' ? rejectionReason : undefined,
+          };
+        }
+      );
       const completenessByType = new Map<string, DocumentCompletenessItem>(
         completenessItems.map((item) => [item.document_type, item])
       );
       const documentsByType = new Map<
         string,
-        { id?: string; fileName?: string; uploadedAt?: string; status?: string; rejectionReason?: string }
+        {
+          id?: string;
+          fileName?: string;
+          uploadedAt?: string;
+          status?: string;
+          rejectionReason?: string;
+        }
       >();
 
       for (const raw of (data.documents ?? []) as unknown[]) {
@@ -276,7 +296,8 @@ export default function Teams() {
               ? String(doc.file_name ?? doc.fileName)
               : undefined,
           uploadedAt:
-            typeof (doc.uploaded_at ?? doc.uploadedAt ?? doc.created_at) === 'string'
+            typeof (doc.uploaded_at ?? doc.uploadedAt ?? doc.created_at) ===
+            'string'
               ? String(doc.uploaded_at ?? doc.uploadedAt ?? doc.created_at)
               : undefined,
           status: typeof doc.status === 'string' ? doc.status : undefined,
@@ -312,7 +333,9 @@ export default function Teams() {
       setDocumentsItems(mergedItems);
     } catch (error) {
       toast.error(
-        error instanceof Error ? error.message : 'Failed to load doula documents'
+        error instanceof Error
+          ? error.message
+          : 'Failed to load doula documents'
       );
     } finally {
       setDocumentsLoading(false);
@@ -575,19 +598,22 @@ export default function Teams() {
         throw new Error(errorMessage);
       }
 
-      const emailResponse = await fetchWithAuth(buildUrl('/email/team-invite'), {
-        //send the email invite after user is created
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          email: inviteForm.email,
-          firstname: inviteForm.firstname,
-          lastname: inviteForm.lastname,
-          role: inviteForm.role,
-        }),
-      });
+      const emailResponse = await fetchWithAuth(
+        buildUrl('/email/team-invite'),
+        {
+          //send the email invite after user is created
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            email: inviteForm.email,
+            firstname: inviteForm.firstname,
+            lastname: inviteForm.lastname,
+            role: inviteForm.role,
+          }),
+        }
+      );
 
       if (!emailResponse.ok) {
         const errorData = await emailResponse.json();
@@ -669,7 +695,9 @@ export default function Teams() {
               <select
                 className='h-10 rounded-md border border-gray-300 bg-white px-3 text-sm'
                 value={roleFilter}
-                onChange={(e) => setRoleFilter(e.target.value as 'doula' | 'admin')}
+                onChange={(e) =>
+                  setRoleFilter(e.target.value as 'doula' | 'admin')
+                }
               >
                 <option value='doula'>Doulas</option>
                 <option value='admin'>Admins</option>
@@ -839,7 +867,9 @@ export default function Teams() {
                           <UserAvatar
                             fullName={`${member?.firstname || ''} ${member?.lastname || ''}`}
                             className='h-14 w-14 ring-2 ring-gray-100 group-hover:ring-green-200 transition-all'
-                            profile_picture={member?.profile_picture ?? undefined}
+                            profile_picture={
+                              member?.profile_picture ?? undefined
+                            }
                           />
                           <div className='absolute -bottom-1 -right-1 h-5 w-5 bg-green-500 rounded-full border-2 border-white'></div>
                         </div>
@@ -873,25 +903,25 @@ export default function Teams() {
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align='end' className='w-40'>
-                          {user?.role === 'admin' && member.role === 'doula' && (
-                            <DropdownMenuItem
-                              onClick={() => void handleOpenDocuments(member)}
-                              className='cursor-pointer'
-                            >
-                              <FileText className='h-4 w-4 mr-2' />
-                              <span>Documents</span>
-                            </DropdownMenuItem>
-                          )}
                           {user?.role === 'admin' &&
-                            member.profile_picture && (
+                            member.role === 'doula' && (
                               <DropdownMenuItem
-                                onClick={() => handleDownloadHeadshot(member)}
+                                onClick={() => void handleOpenDocuments(member)}
                                 className='cursor-pointer'
                               >
-                                <Download className='h-4 w-4 mr-2' />
-                                <span>Download headshot</span>
+                                <FileText className='h-4 w-4 mr-2' />
+                                <span>Documents</span>
                               </DropdownMenuItem>
                             )}
+                          {user?.role === 'admin' && member.profile_picture && (
+                            <DropdownMenuItem
+                              onClick={() => handleDownloadHeadshot(member)}
+                              className='cursor-pointer'
+                            >
+                              <Download className='h-4 w-4 mr-2' />
+                              <span>Download headshot</span>
+                            </DropdownMenuItem>
+                          )}
                           <DropdownMenuItem
                             onClick={() => handleEditClick(member)}
                             className='cursor-pointer'
@@ -951,8 +981,11 @@ export default function Teams() {
               <div className='flex items-center justify-between rounded-xl border bg-white px-4 py-3'>
                 <p className='text-sm text-gray-600'>
                   Showing {(safeCurrentPage - 1) * PAGE_SIZE + 1}-
-                  {Math.min(safeCurrentPage * PAGE_SIZE, filteredMembers.length)} of{' '}
-                  {filteredMembers.length}
+                  {Math.min(
+                    safeCurrentPage * PAGE_SIZE,
+                    filteredMembers.length
+                  )}{' '}
+                  of {filteredMembers.length}
                 </p>
                 <div className='flex items-center gap-3'>
                   <span className='text-sm text-gray-500'>10 / page</span>
@@ -1265,7 +1298,9 @@ export default function Teams() {
             {documentsLoading ? (
               <p className='text-sm text-gray-500'>Loading documents...</p>
             ) : documentsItems.length === 0 ? (
-              <p className='text-sm text-gray-500'>No document status available.</p>
+              <p className='text-sm text-gray-500'>
+                No document status available.
+              </p>
             ) : (
               documentsItems.map((item) => {
                 const label =
@@ -1287,7 +1322,9 @@ export default function Teams() {
                   >
                     <div className='flex items-start justify-between gap-3'>
                       <div className='min-w-0'>
-                        <p className='text-sm font-medium text-gray-900'>{label}</p>
+                        <p className='text-sm font-medium text-gray-900'>
+                          {label}
+                        </p>
                         <p className='text-xs text-gray-500 capitalize'>
                           Status: {item.status}
                         </p>

--- a/src/features/teams/teams.tsx
+++ b/src/features/teams/teams.tsx
@@ -71,9 +71,7 @@ const normalizeTeamRole = (value: unknown): string =>
 const toTeamMember = (member: any): TeamMember => ({
   firstname: String(member?.firstname ?? member?.first_name ?? '').trim(),
   lastname: String(member?.lastname ?? member?.last_name ?? '').trim(),
-  role: normalizeTeamRole(
-    member?.role ?? member?.user_metadata?.role ?? member?.app_metadata?.role
-  ),
+  role: normalizeTeamRole(member?.role),
   email: String(member?.email ?? '').trim().toLowerCase(),
   id: String(member?.id ?? member?.user_id ?? member?.email ?? ''),
   bio: String(member?.bio ?? ''),
@@ -646,7 +644,7 @@ export default function Teams() {
   }, [currentPage, totalPages]);
 
   return (
-    <div className='flex flex-col h-screen bg-gradient-to-br from-gray-50 to-gray-100 overflow-hidden'>
+    <div className='flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-gradient-to-br from-gray-50 to-gray-100'>
       {/* Header Section */}
       <div className='bg-white border-b border-gray-200 shadow-sm flex-shrink-0'>
         <div className='max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6'>
@@ -716,7 +714,7 @@ export default function Teams() {
                           className='h-10'
                         />
                       </div>
-                      <div className='grid grid-cols-2 gap-3'>
+                      <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
                         <div className='space-y-2'>
                           <Label
                             htmlFor='firstname'
@@ -1036,7 +1034,7 @@ export default function Teams() {
                           className='h-10'
                         />
                       </div>
-                      <div className='grid grid-cols-2 gap-3'>
+                      <div className='grid grid-cols-1 gap-3 sm:grid-cols-2'>
                         <div className='space-y-2'>
                           <Label
                             htmlFor='firstname-empty'

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import 'tailwindcss';
 
 @layer base {
   html,

--- a/src/index.css
+++ b/src/index.css
@@ -3,6 +3,14 @@
 @tailwind utilities;
 
 @layer base {
+  html,
+  body,
+  #root {
+    min-height: 100dvh;
+    min-width: 0;
+    overflow-x: hidden;
+  }
+
   button, 
   [role="button"],
   [type="button"], 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,23 +4,6 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 
-// Force all fetch calls to include cookies (needed for HttpOnly auth)
-const originalFetch = window.fetch.bind(window);
-window.fetch = (input: RequestInfo | URL, init?: RequestInit) => {
-  const url =
-    typeof input === 'string'
-      ? input
-      : input instanceof URL
-        ? input.toString()
-        : input.url;
-  const isSupabaseRequest = url.includes('.supabase.co/');
-
-  return originalFetch(input, {
-    ...init,
-    credentials: init?.credentials ?? (isSupabaseRequest ? 'omit' : 'include'),
-  });
-};
-
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <HeroUIProvider>

--- a/src/services/signNowService.ts
+++ b/src/services/signNowService.ts
@@ -1,4 +1,5 @@
 // types/signnow.ts
+import { fetchWithAuth } from '@/api/http';
 export interface SignNowClient {
   email: string;
   name: string;
@@ -25,7 +26,7 @@ const BACKEND_URL = apiBaseUrl;
 export const signNowService = {
   async sendInvitation(client: SignNowClient): Promise<SignNowResponse> {
     try {
-      const response = await fetch(`${BACKEND_URL}/api/signnow/send-client-partner`, {
+      const response = await fetchWithAuth(`${BACKEND_URL}/api/signnow/send-client-partner`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/services/signNowService.ts
+++ b/src/services/signNowService.ts
@@ -26,24 +26,29 @@ const BACKEND_URL = apiBaseUrl;
 export const signNowService = {
   async sendInvitation(client: SignNowClient): Promise<SignNowResponse> {
     try {
-      const response = await fetchWithAuth(`${BACKEND_URL}/api/signnow/send-client-partner`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          client,
-          subject: "Contract Ready for Signature",
-          message: "Please review and sign this contract",
-          sequential: false,
-          clientRole: "Recipient 1"  // This matches the role in the template
-        }),
-      });
+      const response = await fetchWithAuth(
+        `${BACKEND_URL}/api/signnow/send-client-partner`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({
+            client,
+            subject: 'Contract Ready for Signature',
+            message: 'Please review and sign this contract',
+            sequential: false,
+            clientRole: 'Recipient 1', // This matches the role in the template
+          }),
+        }
+      );
 
       if (!response.ok) {
         const errorData = await response.json();
         if (response.status === 429) {
-          throw new Error('Daily invite limit exceeded. Please try again tomorrow.');
+          throw new Error(
+            'Daily invite limit exceeded. Please try again tomorrow.'
+          );
         }
         throw new Error(errorData.error || 'Failed to send invitation');
       }
@@ -53,5 +58,5 @@ export const signNowService = {
       console.error('SignNow service error:', error);
       throw error;
     }
-  }
+  },
 };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,31 +1,30 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_APP_BACKEND_URL: string
-  readonly VITE_APP_FRONTEND_URL?: string
+  readonly VITE_APP_BACKEND_URL: string;
+  readonly VITE_APP_FRONTEND_URL?: string;
   /** Prod Cloud Run URL; fallback: VITE_APP_BACKEND_URL */
-  readonly VITE_API_BASE_URL?: string
+  readonly VITE_API_BASE_URL?: string;
   /** Same as VITE_API_BASE_URL (alias for backend URL) */
-  readonly VITE_API_URL?: string
+  readonly VITE_API_URL?: string;
   /** Gradual cutover: when "true", use VITE_CLOUD_RUN_API_URL as API base */
-  readonly VITE_USE_CLOUD_RUN?: string
+  readonly VITE_USE_CLOUD_RUN?: string;
   /** Cloud Run private API URL used when VITE_USE_CLOUD_RUN=true */
-  readonly VITE_CLOUD_RUN_API_URL?: string
+  readonly VITE_CLOUD_RUN_API_URL?: string;
   /** "production" | "staging" | "development" */
-  readonly VITE_APP_ENV?: string
+  readonly VITE_APP_ENV?: string;
   /** "supabase" (Bearer token) | "cookie" (credentials: include) */
-  readonly VITE_AUTH_MODE?: 'supabase' | 'cookie'
+  readonly VITE_AUTH_MODE?: 'supabase' | 'cookie';
   /** Optional: client id for smoke test GET /clients/:id */
-  readonly VITE_SMOKE_CLIENT_ID?: string
+  readonly VITE_SMOKE_CLIENT_ID?: string;
   /** Optional: external URL for client portal "Service Outcomes" link */
-  readonly VITE_CLIENT_PORTAL_SERVICE_OUTCOMES_URL?: string
+  readonly VITE_CLIENT_PORTAL_SERVICE_OUTCOMES_URL?: string;
   /** Optional: URL to payment authorization form PDF (same-origin path or absolute URL) */
-  readonly VITE_PAYMENT_AUTHORIZATION_FORM_URL?: string
+  readonly VITE_PAYMENT_AUTHORIZATION_FORM_URL?: string;
   /** Optional: show public request "Fill with test data" in production builds */
-  readonly VITE_ENABLE_REQUEST_TEST_DATA?: string
+  readonly VITE_ENABLE_REQUEST_TEST_DATA?: string;
 }
 
 interface ImportMeta {
-  readonly env: ImportMetaEnv
+  readonly env: ImportMetaEnv;
 }
-

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -21,6 +21,8 @@ interface ImportMetaEnv {
   readonly VITE_CLIENT_PORTAL_SERVICE_OUTCOMES_URL?: string
   /** Optional: URL to payment authorization form PDF (same-origin path or absolute URL) */
   readonly VITE_PAYMENT_AUTHORIZATION_FORM_URL?: string
+  /** Optional: show public request "Fill with test data" in production builds */
+  readonly VITE_ENABLE_REQUEST_TEST_DATA?: string
 }
 
 interface ImportMeta {

--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,21 @@
   "framework": "vite",
   "rewrites": [
     { "source": "/(.*)", "destination": "/" }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "X-Frame-Options", "value": "DENY" },
+        { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
+        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains" },
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; font-src 'self' data:; connect-src 'self' https: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* wss://localhost:* wss://127.0.0.1:*; frame-src 'self' https:; frame-ancestors 'none'; base-uri 'self'; form-action 'self'; object-src 'none'; upgrade-insecure-requests"
+        }
+      ]
+    }
   ]
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -32,6 +32,8 @@ export default defineConfig({
   ],
   server: {
     port: 3001,
+    host: true,
+    allowedHosts: true,
     clearScreen: false,
     proxy: {
       '/api': {


### PR DESCRIPTION
## Summary
- Replace the leftover `w-64` sidebar gap with `SidebarProvider` + `SidebarInset`. Hamburger/Sheet below `lg` (1024px) so 375 and 768 get a full-width main.
- Fix Home calendar overlap (`S M T…` labels, `minmax(0,1fr)` cells) and stack CRM tables/dialogs so primary actions stay reachable on phones.
- Keep recent auth/session work in this branch (`fetchWithAuth`, login JSON token / `X-Session-Token`, role guards, intake honeypot). Production Cloud Run must be **redeployed** after merge.

## Test plan
- [ ] Chrome device mode at **375**, **768**, **1024**, **1280**
- [ ] At 375 and 768: no empty left gray column, hamburger nav, full-width Home, no overlapping calendar weekdays/dates, no document horizontal scroll
- [ ] Login → Home → Leads (or client `/profile`) without clipped primary actions
- [ ] Desktop 1280 still shows the icon/expanded sidebar
- [ ] After merge, redeploy Cloud Run before checking production


Made with [Cursor](https://cursor.com)