### PR TITLE
Fix production Home calendar dark mode

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -4,7 +4,7 @@
 
 @plugin 'tailwind-scrollbar-hide';
 
-@custom-variant dark (&:is(.dark *));
+@custom-variant dark (&:where(.dark, .dark *));
 
 :root {
   --background: oklch(1 0 0);

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 @import 'tailwindcss';
+@custom-variant dark (&:where(.dark, .dark *));
 
 @layer base {
   html,


### PR DESCRIPTION
## Summary
- Tailwind v4 was applying `dark:` from the OS color scheme, so production Home showed a navy calendar on light dashboards.
- Scope `dark:` to a `.dark` ancestor so the CRM stays light unless we opt in.

## Test plan
- [ ] macOS Dark Mode on: Home calendar is white, not navy
- [ ] Cloud Run redeploys after merge


Made with [Cursor](https://cursor.com)