### PR TITLE
Fix mobile login session verification

### DIFF
--- a/src/common/contexts/UserContext.tsx
+++ b/src/common/contexts/UserContext.tsx
@@ -43,10 +43,10 @@ export function UserProvider({
         credentials: 'include',
       });
       if (!response.ok) throw new Error('Logout failed');
-      setUser(null);
-      window.location.href = '/login';
     } catch (error) {
       console.error('Logout error:', error);
+    } finally {
+      clearSessionAccessToken();
       setUser(null);
       window.location.href = '/login';
     }
@@ -92,6 +92,7 @@ export function UserProvider({
         });
         if (error) throw new Error(error.message);
         if (!data.session) throw new Error('No session after sign in');
+        setSessionAccessToken(data.session.access_token);
         await checkAuth();
         return true;
       }
@@ -102,12 +103,22 @@ export function UserProvider({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email, password }),
       });
+      const data = await response.json().catch(() => ({}));
       if (!response.ok) {
-        const data = await response.json().catch(() => ({}));
         throw new Error((data as { error?: string })?.error || 'Login failed');
+      }
+      // Phones often block the cross-site session cookie. The JSON token is the
+      // fallback: fetchWithAuth sends it as Bearer + X-Session-Token.
+      const token =
+        typeof (data as { token?: unknown }).token === 'string'
+          ? (data as { token: string }).token.trim()
+          : '';
+      if (token) {
+        setSessionAccessToken(token);
       }
       const sessionOk = await checkAuth();
       if (!sessionOk) {
+        clearSessionAccessToken();
         throw new Error(
           'Signed in, but the session could not be verified. If you are on a phone, confirm the API URL is reachable (not localhost) and that cookies are allowed.'
         );

--- a/src/features/auth/AuthCallback.tsx
+++ b/src/features/auth/AuthCallback.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { LoadingOverlay } from '@/common/components/loading/LoadingOverlay';
 import { useUser } from '@/common/hooks/user/useUser';
 import { fetchWithAuth, buildUrl } from '@/api/http';
+import { setSessionAccessToken } from '@/api/sessionAccessToken';
 import { consumeSensitiveHash } from './consumeSensitiveHash';
 
 const Container = styled.div`
@@ -28,6 +29,8 @@ export default function AuthCallback() {
         if (!access_token) {
           throw new Error('No access token received');
         }
+
+        setSessionAccessToken(access_token);
 
         const response = await fetchWithAuth(
           buildUrl('/auth/callback'),


### PR DESCRIPTION
## Summary
- Store the login JSON token and send it as `Authorization` / `X-Session-Token` so `/auth/me` works when phones block the cross-site session cookie.
- Clear the stored token on logout.

## Test plan
- [ ] Cloud Build deploy of `sokana-front-end` succeeds
- [ ] Email/password login on a phone no longer shows "session could not be verified"
- [ ] Desktop login still works
- [ ] Logout still returns to `/login`


Made with [Cursor](https://cursor.com)