### PR TITLE
Fix lint on mobile login session verification

### DIFF
--- a/src/common/contexts/UserContext.tsx
+++ b/src/common/contexts/UserContext.tsx
@@ -205,6 +205,9 @@ export function UserProvider({
     accessToken: string
   ): Promise<boolean> => {
     try {
+      if (accessToken) {
+        setSessionAccessToken(accessToken);
+      }
       const response = await fetchWithAuth(buildUrl('/auth/reset-password'), {
         method: 'PUT',
         headers: {

--- a/src/features/auth/AuthCallback.tsx
+++ b/src/features/auth/AuthCallback.tsx
@@ -32,16 +32,13 @@ export default function AuthCallback() {
 
         setSessionAccessToken(access_token);
 
-        const response = await fetchWithAuth(
-          buildUrl('/auth/callback'),
-          {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({ access_token }),
-          }
-        );
+        const response = await fetchWithAuth(buildUrl('/auth/callback'), {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ access_token }),
+        });
 
         if (!response.ok) {
           const error = await response.json();


### PR DESCRIPTION
## Summary
- Format `AuthCallback.tsx` to satisfy Prettier.
- Store the reset-password `accessToken` so it is used (and so phones can complete reset without the session cookie).

## Test plan
- [ ] Lint and Style Check is green
- [ ] Phone email/password login still works after this lands on `main`


Made with [Cursor](https://cursor.com)