### PR TITLE
Fix Home Type chips and Lead Profile save routing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,8 @@
   },
   "editor.formatOnSaveMode": "file",
   "vs-code-prettier-eslint.prettierLast": false,
+  "css.lint.unknownAtRules": "ignore",
+  "scss.lint.unknownAtRules": "ignore",
   "editor.tabSize": 2,
   "typescript.tsdk": "node_modules/typescript/lib",
   "[typescriptreact]": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,7 +16,13 @@ export default function App() {
           <AppRoutes />
         </BrowserRouter>
       </UserProvider>
-      <Toaster richColors position='bottom-right' />
+      <Toaster
+        richColors
+        position='bottom-right'
+        expand
+        visibleToasts={5}
+        closeButton
+      />
       <ToastContainer />
     </>
   );

--- a/src/api/dto/client.dto.ts
+++ b/src/api/dto/client.dto.ts
@@ -186,4 +186,13 @@ export interface ClientDetailDTO {
   referral_source_other?: string;
   referral_name?: string;
   referral_email?: string;
+
+  /** Intake — home / household (CRM profile + request form). */
+  home_type?: string[] | string;
+  home_types?: string[];
+  home_type_other?: string;
+  home_access?: string;
+  pets?: string;
+  home_adults_count?: string;
+  home_youth_count?: string;
 }

--- a/src/api/mappers/client.mapper.ts
+++ b/src/api/mappers/client.mapper.ts
@@ -221,5 +221,12 @@ export function mapClientDetail(dto: ClientDetailDTO): ClientDetail {
     secondaryInsuranceMemberId: dto.secondary_insurance_member_id,
     secondaryPolicyNumber: dto.secondary_policy_number,
     selfPayCardInfo: dto.self_pay_card_info,
+    homeType: dto.home_type ?? dto.home_types,
+    homeTypes: dto.home_types ?? (Array.isArray(dto.home_type) ? dto.home_type : undefined),
+    homeTypeOther: dto.home_type_other,
+    homeAccess: dto.home_access,
+    pets: dto.pets,
+    homeAdultsCount: dto.home_adults_count,
+    homeYouthCount: dto.home_youth_count,
   };
 }

--- a/src/api/services/__tests__/clients.service.test.ts
+++ b/src/api/services/__tests__/clients.service.test.ts
@@ -25,13 +25,14 @@ describe('updateClientPhi', () => {
   });
 
   it('normalizes numeric zip_code values to strings before sending', async () => {
-    mockPut.mockResolvedValueOnce({ success: true });
+    mockPut.mockResolvedValueOnce({ message: 'PHI fields updated successfully' });
 
-    await updateClientPhi('client-1', {
+    const result = await updateClientPhi('client-1', {
       zip_code: 60601,
       first_name: 'Jane',
     });
 
+    expect(result.success).toBe(true);
     expect(mockPut).toHaveBeenCalledWith(
       '/clients/client-1/phi',
       expect.objectContaining({
@@ -42,12 +43,13 @@ describe('updateClientPhi', () => {
   });
 
   it('preserves a trimmed ZIP string unchanged', async () => {
-    mockPut.mockResolvedValueOnce({ success: true });
+    mockPut.mockResolvedValueOnce({ message: 'PHI fields updated successfully' });
 
-    await updateClientPhi('client-1', {
+    const result = await updateClientPhi('client-1', {
       zip_code: ' 01234 ',
     });
 
+    expect(result.success).toBe(true);
     expect(mockPut).toHaveBeenCalledWith(
       '/clients/client-1/phi',
       expect.objectContaining({

--- a/src/api/services/clients.service.ts
+++ b/src/api/services/clients.service.ts
@@ -4,7 +4,7 @@ import { ApiError } from '../errors';
 import { extractClientList, mapClient, mapClientDetail } from '../mappers/client.mapper';
 import type { ClientListItemDTO, ClientDetailDTO } from '../dto/client.dto';
 import type { Client, ClientDetail } from '@/domain/client';
-import { normalizeZipCode } from '@/common/utils/zipCode';
+import { normalizeClientFieldKey } from '@/config/clientFieldRouting';
 import { syncQuickBooksCustomerFromClient } from '@/common/utils/syncQuickBooksCustomer';
 
 /**
@@ -243,12 +243,24 @@ export async function updateClientPhi(
   }
 
   try {
-    const normalizedPhiData =
-      Object.prototype.hasOwnProperty.call(phiData, 'zip_code')
-        ? { ...phiData, zip_code: normalizeZipCode(phiData.zip_code) }
-        : phiData;
-    const response = await put<PhiUpdateResponse>(`/clients/${clientId}/phi`, normalizedPhiData);
-    return response;
+    const normalizedPhiData: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(phiData)) {
+      if (value === undefined) continue;
+      normalizedPhiData[normalizeClientFieldKey(key)] = value;
+    }
+    if (Object.prototype.hasOwnProperty.call(normalizedPhiData, 'zip_code')) {
+      normalizedPhiData.zip_code = normalizeZipCode(
+        normalizedPhiData.zip_code as string | null | undefined
+      );
+    }
+    const data = await put<{ message: string }>(
+      `/clients/${clientId}/phi`,
+      normalizedPhiData
+    );
+    return {
+      success: true,
+      data,
+    };
   } catch (error: unknown) {
     let message = 'Failed to update PHI fields';
     if (error instanceof ApiError) {

--- a/src/common/utils/updateClient.ts
+++ b/src/common/utils/updateClient.ts
@@ -2,7 +2,7 @@ import {
   getSessionExpirationMessage,
   isSessionExpiredError,
 } from './sessionUtils';
-import { PHI_KEYS } from '@/config/phi';
+import { PHI_BROKER_FIELD_KEYS } from '@/config/clientFieldRouting';
 import { normalizeZipCode } from './zipCode';
 import { apiBaseUrl } from '@/config/env';
 import { fetchWithAuth } from '@/api/http';
@@ -18,11 +18,10 @@ import { fetchWithAuth } from '@/api/http';
  * Operational fields (status, firstname, lastname, service_needed, etc.) ARE in client_info.
  */
 const UNSUPPORTED_CLIENT_INFO_COLUMNS = new Set([
-  // PHI fields (stored in Google Cloud, not Supabase client_info) - imported from config/phi.ts
-  ...PHI_KEYS,
+  // PHI broker fields (PUT /clients/:id/phi) — not Supabase client_info
+  ...PHI_BROKER_FIELD_KEYS,
 
   // Additional form fields not yet in schema
-  'pronouns',
   'family_pronouns',
 ]);
 

--- a/src/config/clientFieldRouting.ts
+++ b/src/config/clientFieldRouting.ts
@@ -1,0 +1,162 @@
+/**
+ * Routes client profile update fields to the correct backend endpoint.
+ *
+ * Backend split (see backend/src/constants/phiFields.ts):
+ * - PUT /clients/:id/phi — PHI broker fields only (PHI_FIELDS)
+ * - PUT /clients/:id — operational profile fields (Cloud SQL)
+ * - PUT /api/clients/:id/billing — billing / insurance fields
+ *
+ * PHI_KEYS in phi.ts is broader (used for list redaction). Do not use it for save routing.
+ */
+
+/** Canonical snake_case keys accepted by PUT /clients/:id/phi */
+export const PHI_BROKER_FIELD_KEYS = new Set([
+  'first_name',
+  'last_name',
+  'email',
+  'phone_number',
+  'date_of_birth',
+  'due_date',
+  'address_line1',
+  'address',
+  'city',
+  'state',
+  'zip_code',
+  'country',
+  'birth_location',
+  'birth_hospital',
+  'provider_type',
+  'pronouns',
+  'pronouns_other',
+  'preferred_contact_method',
+  'preferred_name',
+  'pets',
+  'service_support_details',
+  'services_interested',
+  'intake_age_years',
+  'health_history',
+  'health_notes',
+  'allergies',
+  'medications',
+]);
+
+/** Canonical snake_case keys routed to PUT /api/clients/:id/billing */
+export const BILLING_FIELD_KEYS = new Set([
+  'payment_method',
+  'insurance',
+  'insurance_policy_holder_name',
+  'insurance_policy_holder_dob',
+  'insurance_policy_holder_relationship',
+  'insurance_plan_type',
+  'insurance_provider',
+  'insurance_member_id',
+  'policy_number',
+  'insurance_phone_number',
+  'has_secondary_insurance',
+  'secondary_insurance_provider',
+  'secondary_insurance_member_id',
+  'secondary_policy_number',
+  'self_pay_card_info',
+  'self_pay_sliding_tier',
+  'self_pay_sliding_support_type',
+]);
+
+const FIELD_ALIAS_MAP: Record<string, string> = {
+  firstname: 'first_name',
+  firstName: 'first_name',
+  lastname: 'last_name',
+  lastName: 'last_name',
+  phoneNumber: 'phone_number',
+  phonenumber: 'phone_number',
+  dateOfBirth: 'date_of_birth',
+  dateofbirth: 'date_of_birth',
+  dueDate: 'due_date',
+  duedate: 'due_date',
+  addressLine1: 'address_line1',
+  addressline1: 'address_line1',
+  zipCode: 'zip_code',
+  zipcode: 'zip_code',
+  healthHistory: 'health_history',
+  healthhistory: 'health_history',
+  healthNotes: 'health_notes',
+  healthnotes: 'health_notes',
+  birthOutcomes: 'birth_outcomes',
+  birthoutcomes: 'birth_outcomes',
+  serviceNeeded: 'service_needed',
+  serviceneeded: 'service_needed',
+  childrenExpected: 'children_expected',
+  childrenexpected: 'children_expected',
+  portalStatus: 'portal_status',
+  portalstatus: 'portal_status',
+  referralSourceOther: 'referral_source_other',
+  pregnancyNumber: 'pregnancy_number',
+  pregnancynumber: 'pregnancy_number',
+  babyName: 'baby_name',
+  babyname: 'baby_name',
+  raceEthnicity: 'race_ethnicity',
+  raceethnicity: 'race_ethnicity',
+  clientAgeRange: 'client_age_range',
+  clientagerange: 'client_age_range',
+  annualIncome: 'annual_income',
+  annualincome: 'annual_income',
+  paymentMethod: 'payment_method',
+  paymentmethod: 'payment_method',
+  insuranceProvider: 'insurance_provider',
+  insuranceprovider: 'insurance_provider',
+  insuranceMemberId: 'insurance_member_id',
+  insurancememberid: 'insurance_member_id',
+  insurancePolicyHolderName: 'insurance_policy_holder_name',
+  insurancepolicyholdername: 'insurance_policy_holder_name',
+  insurancePolicyHolderDob: 'insurance_policy_holder_dob',
+  insurancepolicyholderdob: 'insurance_policy_holder_dob',
+  insurancePolicyHolderRelationship: 'insurance_policy_holder_relationship',
+  insurancepolicyholderrelationship: 'insurance_policy_holder_relationship',
+  insurancePlanType: 'insurance_plan_type',
+  insuranceplantype: 'insurance_plan_type',
+  policyNumber: 'policy_number',
+  policynumber: 'policy_number',
+  insurancePhoneNumber: 'insurance_phone_number',
+  insurancephonenumber: 'insurance_phone_number',
+  hasSecondaryInsurance: 'has_secondary_insurance',
+  hassecondaryinsurance: 'has_secondary_insurance',
+  secondaryInsuranceProvider: 'secondary_insurance_provider',
+  secondaryinsuranceprovider: 'secondary_insurance_provider',
+  secondaryInsuranceMemberId: 'secondary_insurance_member_id',
+  secondaryinsurancememberid: 'secondary_insurance_member_id',
+  secondaryPolicyNumber: 'secondary_policy_number',
+  secondarypolicynumber: 'secondary_policy_number',
+  selfPayCardInfo: 'self_pay_card_info',
+  selfpaycardinfo: 'self_pay_card_info',
+};
+
+/** Normalize a frontend field key to canonical snake_case (backend column name). */
+export function normalizeClientFieldKey(key: string): string {
+  return FIELD_ALIAS_MAP[key] ?? key;
+}
+
+export function splitClientUpdatePayload(
+  updateData: Record<string, unknown>
+): {
+  phi: Record<string, unknown>;
+  operational: Record<string, unknown>;
+  billing: Record<string, unknown>;
+} {
+  const phi: Record<string, unknown> = {};
+  const operational: Record<string, unknown> = {};
+  const billing: Record<string, unknown> = {};
+
+  for (const [rawKey, value] of Object.entries(updateData)) {
+    if (value === undefined) continue;
+    const key = normalizeClientFieldKey(rawKey);
+
+    if (BILLING_FIELD_KEYS.has(key)) {
+      billing[key] = value;
+    } else if (PHI_BROKER_FIELD_KEYS.has(key)) {
+      phi[key] = value;
+    } else {
+      operational[key] = value;
+    }
+  }
+
+  return { phi, operational, billing };
+}

--- a/src/domain/client.ts
+++ b/src/domain/client.ts
@@ -175,4 +175,12 @@ export interface ClientDetail {
   secondaryInsuranceMemberId?: string;
   secondaryPolicyNumber?: string;
   selfPayCardInfo?: string;
+  /** Intake — home / household */
+  homeType?: string[] | string;
+  homeTypes?: string[];
+  homeTypeOther?: string;
+  homeAccess?: string;
+  pets?: string;
+  homeAdultsCount?: string;
+  homeYouthCount?: string;
 }

--- a/src/features/clients/components/dialog/LeadProfileModal.tsx
+++ b/src/features/clients/components/dialog/LeadProfileModal.tsx
@@ -47,7 +47,7 @@ import {
   type CardOnFileStatus,
 } from '@/api/services/clients.service';
 import { buildUrl, fetchWithAuth } from '@/api/http';
-import { PHI_KEYS } from '@/config/phi';
+import { splitClientUpdatePayload } from '@/config/clientFieldRouting';
 import { Client } from '@/features/clients/data/schema';
 import type { ClientDetail } from '@/domain/client';
 import { cn } from '@/lib/utils';
@@ -92,6 +92,7 @@ import {
   getPaymentMethodMessage,
   derivePaymentAuthorizationStatus,
   normalizeBillingPaymentMethod,
+  toBillingApiPaymentMethod,
   PAYMENT_AUTHORIZATION_STATUS_LABELS,
   requiresPaymentMethodOnFile,
   requiresInsuranceDetails,
@@ -116,7 +117,8 @@ import { HOME_PEOPLE_COUNT_OPTIONS } from '@/features/request/homePeopleCountOpt
 import {
   HOME_TYPE_OPTIONS,
   HOME_TYPE_OTHER_VALUE,
-  normalizeHomeTypeFromApi,
+  selectSingleHomeType,
+  singleHomeTypeFromApi,
   toggleHomeTypeSelection,
 } from '@/features/request/homeTypeOptions';
 
@@ -661,7 +663,10 @@ export function LeadProfileModal({
     const phone = ((d.phone_number ?? d.phoneNumber) || '') as string;
     const service = ((d.service_needed ?? d.serviceNeeded) || '') as string;
     const dueDate = ((d.due_date ?? d.dueDate) || '') as string;
-    return `${clientId}|${phone}|${service}|${dueDate}`;
+    const homeType = JSON.stringify(
+      d.home_types ?? d.homeTypes ?? d.home_type ?? d.homeType ?? ''
+    );
+    return `${clientId}|${phone}|${service}|${dueDate}|${homeType}`;
   }, [detailSource, client?.id]);
 
   const hasInsuranceDetails = hasAnyInsuranceDetails(
@@ -785,19 +790,46 @@ export function LeadProfileModal({
       initializedData.referral_source =
         normalizeReferralSourceStoredValue(rawReferral);
     }
-    const rawHomeType = get('home_type', 'homeType');
+    const rawHomeType =
+      d.home_types ??
+      d.homeTypes ??
+      d.home_type ??
+      d.homeType;
     if (
       rawHomeType !== undefined &&
       rawHomeType !== null &&
-      rawHomeType !== ''
+      rawHomeType !== '' &&
+      !(Array.isArray(rawHomeType) && rawHomeType.length === 0)
     ) {
-      initializedData.home_type = normalizeHomeTypeFromApi(rawHomeType);
+      initializedData.home_type = singleHomeTypeFromApi(rawHomeType);
     }
     const rawHomeTypeOther = stripRedacted(
-      get('home_type_other', 'homeTypeOther')
+      (d.home_type_other ?? d.homeTypeOther) as string | undefined
     );
     if (rawHomeTypeOther !== undefined) {
       initializedData.home_type_other = rawHomeTypeOther;
+    }
+    const rawHomeAccess = stripRedacted(
+      (d.home_access ?? d.homeAccess) as string | undefined
+    );
+    if (rawHomeAccess !== undefined) {
+      initializedData.home_access = rawHomeAccess;
+    }
+    const rawPets = stripRedacted((d.pets as string | undefined) ?? undefined);
+    if (rawPets !== undefined) {
+      initializedData.pets = rawPets;
+    }
+    const rawHomeAdults = stripRedacted(
+      (d.home_adults_count ?? d.homeAdultsCount) as string | undefined
+    );
+    if (rawHomeAdults !== undefined) {
+      initializedData.home_adults_count = rawHomeAdults;
+    }
+    const rawHomeYouth = stripRedacted(
+      (d.home_youth_count ?? d.homeYouthCount) as string | undefined
+    );
+    if (rawHomeYouth !== undefined) {
+      initializedData.home_youth_count = rawHomeYouth;
     }
     console.log('🔍 [Init] Final initializedData:', {
       phoneNumber: initializedData.phoneNumber,
@@ -1007,6 +1039,21 @@ export function LeadProfileModal({
         }
       }
 
+      if (updateData.home_type !== undefined) {
+        const singleHomeType = singleHomeTypeFromApi(updateData.home_type);
+        if (singleHomeType.length === 0) {
+          updateData.home_type = [];
+        } else {
+          updateData.home_type = singleHomeType;
+        }
+        if (!singleHomeType.includes(HOME_TYPE_OTHER_VALUE)) {
+          updateData.home_type_other = '';
+          if (!changedFields.includes('home_type_other')) {
+            changedFields.push('home_type_other');
+          }
+        }
+      }
+
       console.log('Saving changes:', updateData);
       console.log('Changed fields:', changedFields);
 
@@ -1058,48 +1105,18 @@ export function LeadProfileModal({
         return;
       }
 
-      // Split update data into PHI fields and operational fields
-      const phiSet = new Set<string>(PHI_KEYS);
-      const phiData: Record<string, unknown> = {};
-      const operationalData: Record<string, unknown> = {};
-
-      Object.entries(updateData).forEach(([key, value]) => {
-        if (phiSet.has(key)) {
-          phiData[key] = value;
-        } else {
-          operationalData[key] = value;
-        }
-      });
+      const {
+        phi: phiData,
+        operational: operationalData,
+        billing: billingData,
+      } = splitClientUpdatePayload(updateData);
 
       console.log('PHI fields to update:', Object.keys(phiData));
       console.log(
         'Operational fields to update:',
         Object.keys(operationalData)
       );
-
-      const billingFieldKeys = new Set([
-        'payment_method',
-        'insurance',
-        'insurance_policy_holder_name',
-        'insurance_policy_holder_dob',
-        'insurance_policy_holder_relationship',
-        'insurance_plan_type',
-        'insurance_provider',
-        'insurance_member_id',
-        'policy_number',
-        'insurance_phone_number',
-        'has_secondary_insurance',
-        'secondary_insurance_provider',
-        'secondary_insurance_member_id',
-        'secondary_policy_number',
-      ]);
-      const billingData: Record<string, unknown> = {};
-      Object.keys(phiData).forEach((key) => {
-        if (billingFieldKeys.has(key)) {
-          billingData[key] = phiData[key];
-          delete phiData[key];
-        }
-      });
+      console.log('Billing fields to update:', Object.keys(billingData));
 
       // Track update results
       let operationalSuccess = true;
@@ -1144,11 +1161,24 @@ export function LeadProfileModal({
       // Update billing fields via dedicated endpoint when available;
       // fallback to PHI endpoint for backwards compatibility.
       if (Object.keys(billingData).length > 0) {
+        const resolvedPaymentMethod = toBillingApiPaymentMethod(
+          billingData.payment_method ?? effectivePaymentMethod
+        );
+
+        if (!resolvedPaymentMethod) {
+          const fallbackResult = await updateClient(client.id, billingData);
+          if (!fallbackResult.success) {
+            billingSuccess = false;
+            errors.push(
+              fallbackResult.error || 'Failed to update billing fields'
+            );
+          } else if (fallbackResult.client && typeof fallbackResult.client === 'object') {
+            setEditedData((prev) => ({ ...prev, ...billingData }));
+          }
+        } else {
         const normalizedBillingData = {
           ...billingData,
-          payment_method: normalizeBillingPaymentMethod(
-            billingData.payment_method
-          ),
+          payment_method: resolvedPaymentMethod,
         };
         const billingResponse = await fetchWithAuth(
           buildUrl(`/api/clients/${encodeURIComponent(client.id)}/billing`),
@@ -1200,10 +1230,18 @@ export function LeadProfileModal({
             ),
           }));
         }
+        }
       }
 
       // Show appropriate success/error message
       if (operationalSuccess && phiSuccess && billingSuccess) {
+        const profilePatch = { ...operationalData, ...phiData };
+        if (Object.keys(profilePatch).length > 0) {
+          setFetchedDetail((prev) =>
+            prev ? ({ ...prev, ...profilePatch } as ClientDetail) : prev
+          );
+          setEditedData((prev) => ({ ...prev, ...profilePatch }));
+        }
         toast.success('Client profile updated successfully!');
         setIsEditing(false);
         if (refreshClients) {
@@ -1211,21 +1249,15 @@ export function LeadProfileModal({
         }
       } else if (!operationalSuccess && !phiSuccess && !billingSuccess) {
         toast.error(`Update failed: ${errors.join('; ')}`);
-      } else if (!operationalSuccess) {
-        toast.error(`Operational fields update failed: ${errors.join('; ')}`);
-        if (phiSuccess || billingSuccess) {
-          toast.success('Some fields updated successfully');
-        }
-      } else if (!phiSuccess) {
-        toast.error(`PHI fields update failed: ${errors.join('; ')}`);
-        if (operationalSuccess || billingSuccess) {
-          toast.success('Some fields updated successfully');
-        }
-      } else if (!billingSuccess) {
-        toast.error(`Billing fields update failed: ${errors.join('; ')}`);
-        if (operationalSuccess || phiSuccess) {
-          toast.success('Other profile fields updated successfully');
-        }
+      } else {
+        const failedParts: string[] = [];
+        if (!operationalSuccess) failedParts.push('operational fields');
+        if (!phiSuccess) failedParts.push('PHI fields');
+        if (!billingSuccess) failedParts.push('billing fields');
+        toast.warning('Some fields updated successfully', {
+          description: `Failed to update ${failedParts.join(', ')}: ${errors.join('; ')}`,
+          duration: 8000,
+        });
       }
     } catch (error) {
       console.error('Error saving changes:', error);
@@ -1779,6 +1811,7 @@ export function LeadProfileModal({
       | 'textarea'
       | 'select'
       | 'multiselect'
+      | 'singleselect'
       | 'date'
       | 'number' = 'text',
     options?: string[],
@@ -1815,10 +1848,19 @@ export function LeadProfileModal({
                                 : fieldKey === 'insurance_plan_type'
                                   ? 'insurancePlanType'
                                   : null;
-    let value: string | Date =
+    let value: string | Date | unknown =
       altKey !== null || fieldKey === 'referral_source'
         ? getDisplayValue(fieldKey, altKey)
         : (editedData[fieldKey] ?? '');
+    if (fieldKey === 'home_type') {
+      value =
+        editedData.home_type !== undefined
+          ? editedData.home_type
+          : ((detailSource?.home_types ??
+              detailSource?.homeTypes ??
+              detailSource?.home_type ??
+              detailSource?.homeType) as unknown);
+    }
     if (fieldKey === 'payment_method') {
       value = normalizeBillingPaymentMethod(value);
     }
@@ -1889,13 +1931,13 @@ export function LeadProfileModal({
                 {String(value || 'Not provided')}
               </div>
             )
-          ) : type === 'multiselect' && options ? (
+          ) : (type === 'multiselect' || type === 'singleselect') && options ? (
             <div className='mt-1'>
               <div className='flex flex-wrap gap-2'>
                 {options.map((option) => {
                   const multiValue =
                     fieldKey === 'home_type'
-                      ? normalizeHomeTypeFromApi(value)
+                      ? singleHomeTypeFromApi(value)
                       : Array.isArray(value)
                         ? value
                         : [];
@@ -1906,17 +1948,20 @@ export function LeadProfileModal({
                       type='button'
                       variant={isSelected ? 'default' : 'outline'}
                       size='sm'
+                      aria-pressed={isSelected}
                       onClick={() => {
                         if (!isEditing) return;
                         const currentArray =
                           fieldKey === 'home_type'
-                            ? normalizeHomeTypeFromApi(value)
+                            ? singleHomeTypeFromApi(value)
                             : Array.isArray(value)
                               ? value
                               : [];
                         const newArray =
                           fieldKey === 'home_type'
-                            ? toggleHomeTypeSelection(currentArray, option)
+                            ? type === 'singleselect'
+                              ? selectSingleHomeType(currentArray, option)
+                              : toggleHomeTypeSelection(currentArray, option)
                             : isSelected
                               ? currentArray.filter((item) => item !== option)
                               : [...currentArray, option];
@@ -1937,8 +1982,10 @@ export function LeadProfileModal({
                           [fieldKey]: newArray,
                         }));
                       }}
-                      disabled={!isEditing}
-                      className={`text-xs ${!isEditing ? 'cursor-default' : ''}`}
+                      className={cn(
+                        'text-xs transition-none',
+                        !isEditing && 'pointer-events-none cursor-default'
+                      )}
                     >
                       {option}
                     </Button>
@@ -1947,7 +1994,7 @@ export function LeadProfileModal({
               </div>
               {!isEditing &&
                 (fieldKey === 'home_type'
-                  ? normalizeHomeTypeFromApi(value).length === 0
+                  ? singleHomeTypeFromApi(value).length === 0
                   : !value || (Array.isArray(value) && value.length === 0)) && (
                   <div className='text-sm text-muted-foreground mt-2'>
                     No options selected
@@ -2244,10 +2291,10 @@ export function LeadProfileModal({
                   'Home Type',
                   'home_type',
                   undefined,
-                  'multiselect',
+                  'singleselect',
                   [...HOME_TYPE_OPTIONS]
                 )}
-                {normalizeHomeTypeFromApi(editedData.home_type).includes(
+                {singleHomeTypeFromApi(editedData.home_type).includes(
                   HOME_TYPE_OTHER_VALUE
                 ) &&
                   renderEditableField('Home Type (Other)', 'home_type_other')}

--- a/src/features/request/__tests__/homeTypeOptions.test.ts
+++ b/src/features/request/__tests__/homeTypeOptions.test.ts
@@ -3,6 +3,8 @@ import {
   HOME_TYPE_OTHER_VALUE,
   HOME_TYPE_PREFER_NOT_VALUE,
   normalizeHomeTypeFromApi,
+  selectSingleHomeType,
+  singleHomeTypeFromApi,
   toggleHomeTypeSelection,
 } from '../homeTypeOptions';
 
@@ -28,6 +30,31 @@ describe('homeTypeOptions', () => {
       expect(normalizeHomeTypeFromApi(['Shelter or emergency housing'])).toEqual([
         'Shelter or emergency housing',
       ]);
+    });
+  });
+
+  describe('selectSingleHomeType', () => {
+    it('replaces the current selection with the new option', () => {
+      expect(
+        selectSingleHomeType(['Rent, apartment or house'], 'Transitional housing')
+      ).toEqual(['Transitional housing']);
+    });
+
+    it('deselects when the same option is clicked again', () => {
+      expect(
+        selectSingleHomeType(['Rent, apartment or house'], 'Rent, apartment or house')
+      ).toEqual([]);
+    });
+  });
+
+  describe('singleHomeTypeFromApi', () => {
+    it('returns only the first stored value for legacy multi-select rows', () => {
+      expect(
+        singleHomeTypeFromApi([
+          'Rent, apartment or house',
+          'Own, apartment, condo, or house',
+        ])
+      ).toEqual(['Rent, apartment or house']);
     });
   });
 

--- a/src/features/request/homeTypeOptions.ts
+++ b/src/features/request/homeTypeOptions.ts
@@ -1,4 +1,4 @@
-/** Request form — Home Type (check all that apply). */
+/** Request form — Home Type (multi-select on intake; staff CRM profile is single-select). */
 
 export const HOME_TYPE_OPTIONS = [
   'Rent, apartment or house',
@@ -41,6 +41,25 @@ export function normalizeHomeTypeFromApi(raw: unknown): string[] {
     return [trimmed];
   }
   return [];
+}
+
+/** Staff CRM profile: at most one home type (first stored value if legacy multi-select). */
+export function singleHomeTypeFromApi(raw: unknown): string[] {
+  const items = normalizeHomeTypeFromApi(raw);
+  if (items.length === 0) return [];
+  if (items.includes(HOME_TYPE_PREFER_NOT_VALUE)) {
+    return [HOME_TYPE_PREFER_NOT_VALUE];
+  }
+  return [items[0]];
+}
+
+/** Single-select for staff CRM — clicking an option replaces the current selection. */
+export function selectSingleHomeType(current: string[], option: string): string[] {
+  const selected = singleHomeTypeFromApi(current);
+  if (selected.includes(option)) {
+    return [];
+  }
+  return [option];
 }
 
 /** Toggle one home type; "Prefer not to answer" is mutually exclusive with other options. */

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,3 @@
-@import 'tailwindcss';
-@custom-variant dark (&:where(.dark, .dark *));
-
 @layer base {
   html,
   body,
@@ -10,11 +7,11 @@
     overflow-x: hidden;
   }
 
-  button, 
-  [role="button"],
-  [type="button"], 
-  [type="submit"], 
-  [type="reset"] {
+  button,
+  [role='button'],
+  [type='button'],
+  [type='submit'],
+  [type='reset'] {
     cursor: pointer;
   }
 }

--- a/src/lib/paymentRules.ts
+++ b/src/lib/paymentRules.ts
@@ -289,6 +289,41 @@ export function normalizeBillingPaymentMethod(method: unknown): string {
   return raw;
 }
 
+const BILLING_API_PAYMENT_METHODS = new Set([
+  'Self-Pay',
+  'Commercial Insurance',
+  'Private Insurance',
+  'Medicaid',
+]);
+
+/**
+ * Maps CRM/profile payment labels to values accepted by PUT /clients/:id/billing.
+ */
+export function toBillingApiPaymentMethod(method: unknown): string {
+  const normalized = normalizeBillingPaymentMethod(method);
+  if (!normalized) return '';
+
+  if (BILLING_API_PAYMENT_METHODS.has(normalized)) {
+    return normalized;
+  }
+
+  if (normalized === 'Private/Commercial Insurance') {
+    return 'Commercial Insurance';
+  }
+
+  const lower = normalized.toLowerCase();
+  if (
+    lower.startsWith('self-pay') ||
+    lower.includes('unable to pay') ||
+    lower.includes('full support') ||
+    lower.includes('not sure')
+  ) {
+    return 'Self-Pay';
+  }
+
+  return normalized;
+}
+
 // ---------------------------------------------------------------------------
 // Admin clients table — at-a-glance card-on-file expectation
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Show the Home Type chip from loaded client detail immediately, without the faded-then-green flash.
- Keep a single home-type selection and map profile/home fields through the client DTO and update payload.
- Split PHI vs billing updates so Lead Profile saves hit the correct APIs.

## Test plan
- [ ] Open a lead with a Home Type on phone and desktop: chip is the selected green style on first paint.
- [ ] Change Home Type (including Other) and save; reload the profile and confirm it stuck.
- [ ] Confirm billing/payment fields still save without wiping home/PHI fields.
- [ ] After merge, confirm Cloud Build deploys `sokana-front-end`.


Made with [Cursor](https://cursor.com)