### PR TITLE
Fix production build TypeScript errors in profile save flow

### DIFF
--- a/src/api/services/clients.service.ts
+++ b/src/api/services/clients.service.ts
@@ -1,8 +1,12 @@
-import { get, post, put } from '../http';
-import { API_CONFIG } from '../config';
-import { ApiError } from '../errors';
-import { extractClientList, mapClient, mapClientDetail } from '../mappers/client.mapper';
-import type { ClientListItemDTO, ClientDetailDTO } from '../dto/client.dto';
+import { get, post, put } from '@/api/http';
+import { API_CONFIG } from '@/api/config';
+import { ApiError } from '@/api/errors';
+import {
+  extractClientList,
+  mapClient,
+  mapClientDetail,
+} from '@/api/mappers/client.mapper';
+import type { ClientListItemDTO, ClientDetailDTO } from '@/api/dto/client.dto';
 import type { Client, ClientDetail } from '@/domain/client';
 import { normalizeClientFieldKey } from '@/config/clientFieldRouting';
 import { syncQuickBooksCustomerFromClient } from '@/common/utils/syncQuickBooksCustomer';

--- a/src/api/services/clients.service.ts
+++ b/src/api/services/clients.service.ts
@@ -6,6 +6,7 @@ import type { ClientListItemDTO, ClientDetailDTO } from '../dto/client.dto';
 import type { Client, ClientDetail } from '@/domain/client';
 import { normalizeClientFieldKey } from '@/config/clientFieldRouting';
 import { syncQuickBooksCustomerFromClient } from '@/common/utils/syncQuickBooksCustomer';
+import { normalizeZipCode } from '@/common/utils/zipCode';
 
 /**
  * Normalize API response to an array of client list DTOs.

--- a/src/api/services/clients.service.ts
+++ b/src/api/services/clients.service.ts
@@ -1,12 +1,8 @@
-import { get, post, put } from 'api/http';
-import { API_CONFIG } from 'api/config';
-import { ApiError } from 'api/errors';
-import {
-  extractClientList,
-  mapClient,
-  mapClientDetail,
-} from 'api/mappers/client.mapper';
-import type { ClientListItemDTO, ClientDetailDTO } from 'api/dto/client.dto';
+import { get, post, put } from '../http';
+import { API_CONFIG } from '../config';
+import { ApiError } from '../errors';
+import { extractClientList, mapClient, mapClientDetail } from '../mappers/client.mapper';
+import type { ClientListItemDTO, ClientDetailDTO } from '../dto/client.dto';
 import type { Client, ClientDetail } from '@/domain/client';
 import { normalizeClientFieldKey } from '@/config/clientFieldRouting';
 import { syncQuickBooksCustomerFromClient } from '@/common/utils/syncQuickBooksCustomer';

--- a/src/api/services/clients.service.ts
+++ b/src/api/services/clients.service.ts
@@ -1,8 +1,12 @@
-import { get, post, put } from '../http';
-import { API_CONFIG } from '../config';
-import { ApiError } from '../errors';
-import { extractClientList, mapClient, mapClientDetail } from '../mappers/client.mapper';
-import type { ClientListItemDTO, ClientDetailDTO } from '../dto/client.dto';
+import { get, post, put } from 'api/http';
+import { API_CONFIG } from 'api/config';
+import { ApiError } from 'api/errors';
+import {
+  extractClientList,
+  mapClient,
+  mapClientDetail,
+} from 'api/mappers/client.mapper';
+import type { ClientListItemDTO, ClientDetailDTO } from 'api/dto/client.dto';
 import type { Client, ClientDetail } from '@/domain/client';
 import { normalizeClientFieldKey } from '@/config/clientFieldRouting';
 import { syncQuickBooksCustomerFromClient } from '@/common/utils/syncQuickBooksCustomer';
@@ -36,7 +40,9 @@ export async function fetchClients(): Promise<Client[]> {
     return dtos.map(mapClient);
   } else {
     // Canonical: unwrap may return array or object; normalize so .map never throws
-    const raw = await get<ClientListItemDTO[] | Record<string, unknown>>('/clients');
+    const raw = await get<ClientListItemDTO[] | Record<string, unknown>>(
+      '/clients'
+    );
     const dtos = normalizeClientListResponse(raw);
     return dtos.map(mapClient);
   }
@@ -54,7 +60,9 @@ export async function fetchClientById(id: string): Promise<ClientDetail> {
     throw new Error('Legacy mode disabled. Set VITE_USE_LEGACY_API=false.');
   }
 
-  const response = await get<ClientDetailDTO | { data?: ClientDetailDTO }>(`/clients/${id}`);
+  const response = await get<ClientDetailDTO | { data?: ClientDetailDTO }>(
+    `/clients/${id}`
+  );
 
   const dto: ClientDetailDTO =
     response &&
@@ -73,7 +81,10 @@ export async function fetchClientById(id: string): Promise<ClientDetail> {
  *
  * Canonical mode only - throws if legacy mode is enabled.
  */
-export async function updateClientStatus(clientId: string, status: string): Promise<ClientDetail> {
+export async function updateClientStatus(
+  clientId: string,
+  status: string
+): Promise<ClientDetail> {
   if (API_CONFIG.useLegacyApi) {
     throw new Error('Legacy mode disabled. Set VITE_USE_LEGACY_API=false.');
   }
@@ -94,7 +105,10 @@ export async function updateClientStatus(clientId: string, status: string): Prom
     });
 
     if (!syncResult.success && syncResult.error) {
-      console.warn('QuickBooks customer sync skipped or failed:', syncResult.error);
+      console.warn(
+        'QuickBooks customer sync skipped or failed:',
+        syncResult.error
+      );
     }
   }
 
@@ -168,21 +182,51 @@ export interface PhiUpdateResponse {
  * @throws ApiError if update fails or non-PHI fields are included
  */
 export interface PaymentInstallment {
-  id: string; installment_number: number; payment_type: string; amount: number; due_date: string | null;
-  payment_status: 'upcoming' | 'pending' | 'invoiced' | 'paid' | 'overdue' | 'failed' | 'cancelled';
-  qbo_invoice_status: string | null; qbo_invoice_id: string | null; payment_link: string | null;
-  paid_date: string | null; is_overdue: boolean; available_action: { enabled: boolean; reason: string | null };
+  id: string;
+  installment_number: number;
+  payment_type: string;
+  amount: number;
+  due_date: string | null;
+  payment_status:
+    | 'upcoming'
+    | 'pending'
+    | 'invoiced'
+    | 'paid'
+    | 'overdue'
+    | 'failed'
+    | 'cancelled';
+  qbo_invoice_status: string | null;
+  qbo_invoice_id: string | null;
+  payment_link: string | null;
+  paid_date: string | null;
+  is_overdue: boolean;
+  available_action: { enabled: boolean; reason: string | null };
 }
 
 export interface CardOnFileStatus {
-  required: boolean; on_file: boolean; status: 'active' | 'missing' | 'expired' | 'inactive' | 'not_required';
-  quickbooks_customer_id: string | null; payment_method_reference: string | null; card_brand: string | null;
-  last4: string | null; exp_month: number | null; exp_year: number | null; last_verified_at: string | null;
+  required: boolean;
+  on_file: boolean;
+  status: 'active' | 'missing' | 'expired' | 'inactive' | 'not_required';
+  quickbooks_customer_id: string | null;
+  payment_method_reference: string | null;
+  card_brand: string | null;
+  last4: string | null;
+  exp_month: number | null;
+  exp_year: number | null;
+  last_verified_at: string | null;
 }
 
 export interface GenerateInstallmentInvoiceResponse {
-  installment_id: string; installment_number: number; payment_type: string; amount: number; due_date: string | null;
-  qbo_invoice_id: string; payment_link: string | null; card_on_file: boolean; card_warning_included: boolean; invoice_status: string;
+  installment_id: string;
+  installment_number: number;
+  payment_type: string;
+  amount: number;
+  due_date: string | null;
+  qbo_invoice_id: string;
+  payment_link: string | null;
+  card_on_file: boolean;
+  card_warning_included: boolean;
+  invoice_status: string;
 }
 
 const LOCAL_BILLING_FIXTURE_CLIENT_ID = '1d981375-beeb-46e7-bf22-5d7a750eb391';
@@ -193,46 +237,126 @@ const useLocalBillingFixture = (clientId: string) =>
 
 let localFixtureInstallments: PaymentInstallment[] = [
   {
-    id: '10000000-0000-4000-8000-000000000001', installment_number: 1, payment_type: 'deposit',
-    amount: 100, due_date: '2026-07-01', payment_status: 'paid', qbo_invoice_status: 'paid',
-    qbo_invoice_id: 'LOCAL-DEPOSIT-001', payment_link: null, paid_date: '2026-07-01T12:00:00.000Z',
-    is_overdue: false, available_action: { enabled: false, reason: 'Installment is already paid' },
+    id: '10000000-0000-4000-8000-000000000001',
+    installment_number: 1,
+    payment_type: 'deposit',
+    amount: 100,
+    due_date: '2026-07-01',
+    payment_status: 'paid',
+    qbo_invoice_status: 'paid',
+    qbo_invoice_id: 'LOCAL-DEPOSIT-001',
+    payment_link: null,
+    paid_date: '2026-07-01T12:00:00.000Z',
+    is_overdue: false,
+    available_action: { enabled: false, reason: 'Installment is already paid' },
   },
   {
-    id: '10000000-0000-4000-8000-000000000002', installment_number: 2, payment_type: 'installment',
-    amount: 450, due_date: '2026-08-15', payment_status: 'pending', qbo_invoice_status: null,
-    qbo_invoice_id: null, payment_link: null, paid_date: null, is_overdue: false,
+    id: '10000000-0000-4000-8000-000000000002',
+    installment_number: 2,
+    payment_type: 'installment',
+    amount: 450,
+    due_date: '2026-08-15',
+    payment_status: 'pending',
+    qbo_invoice_status: null,
+    qbo_invoice_id: null,
+    payment_link: null,
+    paid_date: null,
+    is_overdue: false,
     available_action: { enabled: true, reason: null },
   },
   {
-    id: '10000000-0000-4000-8000-000000000003', installment_number: 3, payment_type: 'installment',
-    amount: 450, due_date: '2026-09-15', payment_status: 'upcoming', qbo_invoice_status: null,
-    qbo_invoice_id: null, payment_link: null, paid_date: null, is_overdue: false,
-    available_action: { enabled: false, reason: 'A prior required installment remains unpaid' },
+    id: '10000000-0000-4000-8000-000000000003',
+    installment_number: 3,
+    payment_type: 'installment',
+    amount: 450,
+    due_date: '2026-09-15',
+    payment_status: 'upcoming',
+    qbo_invoice_status: null,
+    qbo_invoice_id: null,
+    payment_link: null,
+    paid_date: null,
+    is_overdue: false,
+    available_action: {
+      enabled: false,
+      reason: 'A prior required installment remains unpaid',
+    },
   },
 ];
 
 export const fetchClientPaymentSchedule = (clientId: string) =>
   useLocalBillingFixture(clientId)
-    ? Promise.resolve(localFixtureInstallments.map((item) => ({ ...item, available_action: { ...item.available_action } })))
-    : get<PaymentInstallment[]>(`/clients/${clientId}/billing/payment-schedule`);
+    ? Promise.resolve(
+        localFixtureInstallments.map((item) => ({
+          ...item,
+          available_action: { ...item.available_action },
+        }))
+      )
+    : get<PaymentInstallment[]>(
+        `/clients/${clientId}/billing/payment-schedule`
+      );
 
 export const fetchCardOnFileStatus = (clientId: string) =>
   useLocalBillingFixture(clientId)
-    ? Promise.resolve<CardOnFileStatus>({ required: true, on_file: false, status: 'missing', quickbooks_customer_id: 'LOCAL-QBO-CUSTOMER', payment_method_reference: null, card_brand: null, last4: null, exp_month: null, exp_year: null, last_verified_at: null })
+    ? Promise.resolve<CardOnFileStatus>({
+        required: true,
+        on_file: false,
+        status: 'missing',
+        quickbooks_customer_id: 'LOCAL-QBO-CUSTOMER',
+        payment_method_reference: null,
+        card_brand: null,
+        last4: null,
+        exp_month: null,
+        exp_year: null,
+        last_verified_at: null,
+      })
     : get<CardOnFileStatus>(`/api/payment-methods/${clientId}`);
 
-export const generateInstallmentInvoice = (clientId: string, installmentId: string) => {
+export const generateInstallmentInvoice = (
+  clientId: string,
+  installmentId: string
+) => {
   if (useLocalBillingFixture(clientId)) {
-    const installment = localFixtureInstallments.find((item) => item.id === installmentId);
-    if (!installment || !installment.available_action.enabled) return Promise.reject(new Error(installment?.available_action.reason || 'Installment is not eligible'));
+    const installment = localFixtureInstallments.find(
+      (item) => item.id === installmentId
+    );
+    if (!installment || !installment.available_action.enabled)
+      return Promise.reject(
+        new Error(
+          installment?.available_action.reason || 'Installment is not eligible'
+        )
+      );
     const paymentLink = 'https://app.qbo.intuit.com/app/invoice';
-    localFixtureInstallments = localFixtureInstallments.map((item) => item.id === installmentId
-      ? { ...item, payment_status: 'invoiced', qbo_invoice_status: 'sent', qbo_invoice_id: 'LOCAL-INVOICE-002', payment_link: paymentLink, available_action: { enabled: false, reason: 'Installment is already invoiced' } }
-      : item);
-    return Promise.resolve({ installment_id: installment.id, installment_number: installment.installment_number, payment_type: installment.payment_type, amount: installment.amount, due_date: installment.due_date, qbo_invoice_id: 'LOCAL-INVOICE-002', payment_link: paymentLink, card_on_file: false, card_warning_included: true, invoice_status: 'sent' });
+    localFixtureInstallments = localFixtureInstallments.map((item) =>
+      item.id === installmentId
+        ? {
+            ...item,
+            payment_status: 'invoiced',
+            qbo_invoice_status: 'sent',
+            qbo_invoice_id: 'LOCAL-INVOICE-002',
+            payment_link: paymentLink,
+            available_action: {
+              enabled: false,
+              reason: 'Installment is already invoiced',
+            },
+          }
+        : item
+    );
+    return Promise.resolve({
+      installment_id: installment.id,
+      installment_number: installment.installment_number,
+      payment_type: installment.payment_type,
+      amount: installment.amount,
+      due_date: installment.due_date,
+      qbo_invoice_id: 'LOCAL-INVOICE-002',
+      payment_link: paymentLink,
+      card_on_file: false,
+      card_warning_included: true,
+      invoice_status: 'sent',
+    });
   }
-  return post<GenerateInstallmentInvoiceResponse>(`/clients/${clientId}/billing/installments/${installmentId}/invoice`);
+  return post<GenerateInstallmentInvoiceResponse>(
+    `/clients/${clientId}/billing/installments/${installmentId}/invoice`
+  );
 };
 
 export async function updateClientPhi(

--- a/src/features/clients/components/dialog/LeadProfileModal.tsx
+++ b/src/features/clients/components/dialog/LeadProfileModal.tsx
@@ -791,10 +791,7 @@ export function LeadProfileModal({
         normalizeReferralSourceStoredValue(rawReferral);
     }
     const rawHomeType =
-      d.home_types ??
-      d.homeTypes ??
-      d.home_type ??
-      d.homeType;
+      d.home_types ?? d.homeTypes ?? d.home_type ?? d.homeType;
     if (
       rawHomeType !== undefined &&
       rawHomeType !== null &&
@@ -1172,64 +1169,69 @@ export function LeadProfileModal({
             errors.push(
               fallbackResult.error || 'Failed to update billing fields'
             );
-          } else if (fallbackResult.client && typeof fallbackResult.client === 'object') {
+          } else if (
+            fallbackResult.client &&
+            typeof fallbackResult.client === 'object'
+          ) {
             setEditedData((prev) => ({ ...prev, ...billingData }));
           }
         } else {
-        const normalizedBillingData = {
-          ...billingData,
-          payment_method: resolvedPaymentMethod,
-        };
-        const billingResponse = await fetchWithAuth(
-          buildUrl(`/api/clients/${encodeURIComponent(client.id)}/billing`),
-          {
-            method: 'PUT',
-            headers: {
-              'Content-Type': 'application/json',
-            },
-            body: JSON.stringify(normalizedBillingData),
-          }
-        );
+          const normalizedBillingData = {
+            ...billingData,
+            payment_method: resolvedPaymentMethod,
+          };
+          const billingResponse = await fetchWithAuth(
+            buildUrl(`/api/clients/${encodeURIComponent(client.id)}/billing`),
+            {
+              method: 'PUT',
+              headers: {
+                'Content-Type': 'application/json',
+              },
+              body: JSON.stringify(normalizedBillingData),
+            }
+          );
 
-        if (!billingResponse.ok) {
-          if (isEndpointUnavailableStatus(billingResponse.status)) {
-            const fallbackResult = await updateClientPhi(
-              client.id,
-              normalizedBillingData
-            );
-            if (!fallbackResult.success) {
-              billingSuccess = false;
-              errors.push(
-                fallbackResult.error || 'Failed to update billing fields'
+          if (!billingResponse.ok) {
+            if (isEndpointUnavailableStatus(billingResponse.status)) {
+              const fallbackResult = await updateClientPhi(
+                client.id,
+                normalizedBillingData
               );
+              if (!fallbackResult.success) {
+                billingSuccess = false;
+                errors.push(
+                  fallbackResult.error || 'Failed to update billing fields'
+                );
+              } else {
+                setEditedData((prev) => ({
+                  ...prev,
+                  ...normalizedBillingData,
+                  payment_method: normalizeBillingPaymentMethod(
+                    normalizedBillingData.payment_method ??
+                      prev.payment_method ??
+                      ''
+                  ),
+                }));
+              }
             } else {
-              setEditedData((prev) => ({
-                ...prev,
-                ...normalizedBillingData,
-                payment_method: normalizeBillingPaymentMethod(
-                  normalizedBillingData.payment_method ??
-                    prev.payment_method ??
-                    ''
-                ),
-              }));
+              billingSuccess = false;
+              const billingError = await billingResponse.text().catch(() => '');
+              errors.push(
+                billingError ||
+                  `Failed to update billing fields (${billingResponse.status})`
+              );
             }
           } else {
-            billingSuccess = false;
-            const billingError = await billingResponse.text().catch(() => '');
-            errors.push(
-              billingError ||
-                `Failed to update billing fields (${billingResponse.status})`
-            );
+            setEditedData((prev) => ({
+              ...prev,
+              ...normalizedBillingData,
+              payment_method: normalizeBillingPaymentMethod(
+                normalizedBillingData.payment_method ??
+                  prev.payment_method ??
+                  ''
+              ),
+            }));
           }
-        } else {
-          setEditedData((prev) => ({
-            ...prev,
-            ...normalizedBillingData,
-            payment_method: normalizeBillingPaymentMethod(
-              normalizedBillingData.payment_method ?? prev.payment_method ?? ''
-            ),
-          }));
-        }
         }
       }
 

--- a/src/features/clients/components/dialog/LeadProfileModal.tsx
+++ b/src/features/clients/components/dialog/LeadProfileModal.tsx
@@ -1876,6 +1876,13 @@ export function LeadProfileModal({
       value = value.toISOString().split('T')[0];
     }
 
+    const dateValue =
+      typeof value === 'string' ||
+      typeof value === 'number' ||
+      value instanceof Date
+        ? value
+        : undefined;
+
     return (
       <div className='flex items-start gap-2 py-2'>
         {icon && <div className='mt-2 text-muted-foreground'>{icon}</div>}
@@ -2010,17 +2017,19 @@ export function LeadProfileModal({
                       variant='outline'
                       className={cn(
                         'flex-1 justify-start text-left font-normal',
-                        !value && 'text-muted-foreground'
+                        !dateValue && 'text-muted-foreground'
                       )}
                     >
                       <CalendarIcon className='mr-2 h-4 w-4' />
-                      {value ? format(new Date(value), 'PPP') : 'Pick a date'}
+                      {dateValue
+                        ? format(new Date(dateValue), 'PPP')
+                        : 'Pick a date'}
                     </Button>
                   </PopoverTrigger>
                   <PopoverContent className='w-auto p-0' align='start'>
                     <Calendar
                       mode='single'
-                      selected={value ? new Date(value) : undefined}
+                      selected={dateValue ? new Date(dateValue) : undefined}
                       onSelect={(date) => {
                         if (date) {
                           setEditedData((prev) => ({
@@ -2039,7 +2048,7 @@ export function LeadProfileModal({
                     />
                   </PopoverContent>
                 </Popover>
-                {value && (
+                {dateValue ? (
                   <Button
                     variant='outline'
                     size='sm'
@@ -2050,11 +2059,13 @@ export function LeadProfileModal({
                   >
                     Clear
                   </Button>
-                )}
+                ) : null}
               </div>
             ) : (
               <div className='mt-1 px-3 py-2 border rounded-md bg-muted/50 text-sm'>
-                {value ? format(new Date(value), 'PPP') : 'Not provided'}
+                {dateValue
+                  ? format(new Date(dateValue), 'PPP')
+                  : 'Not provided'}
               </div>
             )
           ) : (fieldKey === 'phoneNumber' && type === 'tel') || isEditing ? (


### PR DESCRIPTION
## Summary
- Adds missing `normalizeZipCode` import in `clients.service.ts`
- Narrows date field values in `LeadProfileModal` so `tsc` passes in Cloud Build

Fixes failed frontend deploy from #82 (`996c0f15`).

## Test plan
- [x] `npx tsc -p tsconfig.build.json` passes locally
- [ ] Cloud Build frontend deploy succeeds on merge


Made with [Cursor](https://cursor.com)