### PR TITLE
Fix clients.service Vitest mocks after @/api imports

### DIFF
--- a/src/api/services/__tests__/clients.service.quickbooks-nonblocking.test.ts
+++ b/src/api/services/__tests__/clients.service.quickbooks-nonblocking.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 
-vi.mock('../../http', () => {
+vi.mock('@/api/http', () => {
   return {
     put: vi.fn(),
     get: vi.fn(),
@@ -13,9 +13,9 @@ vi.mock('@/common/utils/syncQuickBooksCustomer', () => {
   };
 });
 
-import { put } from '../../http';
+import { put } from '@/api/http';
 import { syncQuickBooksCustomerFromClient } from '@/common/utils/syncQuickBooksCustomer';
-import { updateClientStatus } from '../clients.service';
+import { updateClientStatus } from '@/api/services/clients.service';
 
 describe('clients.service — QuickBooks sync is non-blocking', () => {
   beforeEach(() => {
@@ -55,11 +55,12 @@ describe('clients.service — QuickBooks sync is non-blocking', () => {
       status: 'lead',
     } as any);
 
-    vi.mocked(syncQuickBooksCustomerFromClient).mockResolvedValue({ success: false });
+    vi.mocked(syncQuickBooksCustomerFromClient).mockResolvedValue({
+      success: false,
+    });
 
     const result = await updateClientStatus('client-1', 'lead');
     expect(result.status).toBe('lead');
     expect(syncQuickBooksCustomerFromClient).toHaveBeenCalledTimes(0);
   });
 });
-

--- a/src/api/services/__tests__/clients.service.test.ts
+++ b/src/api/services/__tests__/clients.service.test.ts
@@ -4,12 +4,12 @@ const { mockPut } = vi.hoisted(() => ({
   mockPut: vi.fn(),
 }));
 
-vi.mock('../../http', () => ({
+vi.mock('@/api/http', () => ({
   get: vi.fn(),
   put: mockPut,
 }));
 
-vi.mock('../../config', () => ({
+vi.mock('@/api/config', () => ({
   API_CONFIG: {
     useLegacyApi: false,
     baseUrl: 'http://localhost:5050',
@@ -25,7 +25,9 @@ describe('updateClientPhi', () => {
   });
 
   it('normalizes numeric zip_code values to strings before sending', async () => {
-    mockPut.mockResolvedValueOnce({ message: 'PHI fields updated successfully' });
+    mockPut.mockResolvedValueOnce({
+      message: 'PHI fields updated successfully',
+    });
 
     const result = await updateClientPhi('client-1', {
       zip_code: 60601,
@@ -43,7 +45,9 @@ describe('updateClientPhi', () => {
   });
 
   it('preserves a trimmed ZIP string unchanged', async () => {
-    mockPut.mockResolvedValueOnce({ message: 'PHI fields updated successfully' });
+    mockPut.mockResolvedValueOnce({
+      message: 'PHI fields updated successfully',
+    });
 
     const result = await updateClientPhi('client-1', {
       zip_code: ' 01234 ',


### PR DESCRIPTION
## Summary
- Mock `@/api/http` and `@/api/config` in clients.service tests so they match the service imports.
- This is the failure from PR #82 (`updateClientPhi` ZIP tests: `expected false to be true`).

## Test plan
- [ ] `npm run test:run -- src/api/services/__tests__/clients.service.test.ts src/api/services/__tests__/clients.service.quickbooks-nonblocking.test.ts`
- [ ] GitHub Lint and Tests workflows go green on this PR.


Made with [Cursor](https://cursor.com)