### PR TITLE
Fix Lead Profile read and save for services and intake fields

### DIFF
--- a/src/api/dto/client.dto.ts
+++ b/src/api/dto/client.dto.ts
@@ -195,4 +195,28 @@ export interface ClientDetailDTO {
   pets?: string;
   home_adults_count?: string;
   home_youth_count?: string;
+
+  /** Intake — services requested */
+  services_interested?: string[];
+  service_support_details?: string;
+  service_specifics?: string;
+  demographics_multi?: string[];
+  preferred_contact_method?: string;
+  preferred_name?: string;
+  pronouns?: string;
+  pronouns_other?: string;
+  children_expected?: string;
+  intake_age_years?: number;
+  birth_location?: string;
+  birth_hospital?: string;
+  provider_type?: string;
+  primary_language?: string;
+  relationship_status?: string;
+  middle_name?: string;
+  mobile_phone?: string;
+  work_phone?: string;
+  city?: string;
+  state?: string;
+  zip_code?: string;
+  address?: string;
 }

--- a/src/api/mappers/client.mapper.ts
+++ b/src/api/mappers/client.mapper.ts
@@ -1,9 +1,18 @@
-import { API_CONFIG } from '../config';
-import type { ClientListItemDTO, ClientDetailDTO } from '../dto/client.dto';
-import type { Client, ClientDetail, ClientStatus, PortalBlocker, BillingPath } from '@/domain/client';
+import { API_CONFIG } from '@/api/config';
+import type { ClientListItemDTO, ClientDetailDTO } from '@/api/dto/client.dto';
+import type {
+  Client,
+  ClientDetail,
+  ClientStatus,
+  PortalBlocker,
+  BillingPath,
+} from '@/domain/client';
 import type { PortalAllowedActions } from '@/lib/portalEligibility';
+import { normalizeStringArrayFromApi } from '@/features/clients/utils/profileArrayFields';
 
-function mapPortalBlockers(raw: string[] | undefined): PortalBlocker[] | undefined {
+function mapPortalBlockers(
+  raw: string[] | undefined
+): PortalBlocker[] | undefined {
   if (!raw?.length) return undefined;
   const valid: PortalBlocker[] = [
     'contract_unsigned',
@@ -12,7 +21,9 @@ function mapPortalBlockers(raw: string[] | undefined): PortalBlocker[] | undefin
     'payment_authorization_required',
     'billing_path_unknown',
   ];
-  return raw.filter((item): item is PortalBlocker => valid.includes(item as PortalBlocker));
+  return raw.filter((item): item is PortalBlocker =>
+    valid.includes(item as PortalBlocker)
+  );
 }
 
 function mapEligibilityFromDto(
@@ -32,14 +43,22 @@ function mapEligibilityFromDto(
     portalBlockers: mapPortalBlockers(pick<string[]>('portal_blockers')),
     primaryPortalBlocker: primaryBlocker as PortalBlocker | null | undefined,
     billingPath: billingPath as BillingPath | undefined,
-    paymentAuthorizationRequired: pick<boolean>('payment_authorization_required'),
-    paymentAuthorizationSatisfied: pick<boolean>('payment_authorization_satisfied'),
+    paymentAuthorizationRequired: pick<boolean>(
+      'payment_authorization_required'
+    ),
+    paymentAuthorizationSatisfied: pick<boolean>(
+      'payment_authorization_satisfied'
+    ),
     cardOnFile: pick<boolean>('card_on_file'),
     qbCustomerId: pick<string | null>('qb_customer_id'),
     qbStoredPaymentMethodId: pick<string | null>('qb_stored_payment_method_id'),
     verificationInvoiceId: pick<string | null>('verification_invoice_id'),
-    verificationInvoiceSentAt: pick<string | null>('verification_invoice_sent_at'),
-    verificationInvoicePaidAt: pick<string | null>('verification_invoice_paid_at'),
+    verificationInvoiceSentAt: pick<string | null>(
+      'verification_invoice_sent_at'
+    ),
+    verificationInvoicePaidAt: pick<string | null>(
+      'verification_invoice_paid_at'
+    ),
     allowedActions: pick<PortalAllowedActions>('allowed_actions'),
     paymentMethod: pick<string>('payment_method'),
     paymentAuthorizationStatus: pick<string>('payment_authorization_status'),
@@ -95,45 +114,31 @@ export function mapClient(dto: ClientListItemDTO): Client {
 
   // Extract fields from nested user or flat DTO
   const firstname =
-    user?.firstname ||
-    user?.firstName ||
-    dto.firstname ||
-    dto.first_name ||
-    '';
+    user?.firstname || user?.firstName || dto.firstname || dto.first_name || '';
 
   const lastname =
-    user?.lastname ||
-    user?.lastName ||
-    dto.lastname ||
-    dto.last_name ||
-    '';
+    user?.lastname || user?.lastName || dto.lastname || dto.last_name || '';
 
   const email = user?.email || dto.email || '';
 
   const phoneNumber =
-    user?.phone_number ||
-    user?.phoneNumber ||
-    dto.phone_number ||
-    '';
+    user?.phone_number || user?.phoneNumber || dto.phone_number || '';
 
   const rawStatus = dto.status || user?.status || 'lead';
-  const status = (rawStatus === 'matching' ? 'matched' : rawStatus) as ClientStatus;
+  const status = (
+    rawStatus === 'matching' ? 'matched' : rawStatus
+  ) as ClientStatus;
 
   const serviceNeeded =
-    dto.serviceNeeded ||
-    dto.service_needed ||
-    user?.service_needed ||
-    '';
+    dto.serviceNeeded || dto.service_needed || user?.service_needed || '';
 
-  const requestedAtRaw =
-    dto.requestedAt || dto.requested_at;
+  const requestedAtRaw = dto.requestedAt || dto.requested_at;
   const requestedAt = requestedAtRaw ? new Date(requestedAtRaw) : new Date();
 
   const updatedAtRaw = dto.updatedAt || dto.updated_at;
   const updatedAt = updatedAtRaw ? new Date(updatedAtRaw) : new Date();
 
-  const profilePicture =
-    user?.profile_picture ?? dto.profile_picture ?? null;
+  const profilePicture = user?.profile_picture ?? dto.profile_picture ?? null;
 
   return {
     id: dto.id,
@@ -153,7 +158,8 @@ export function mapClient(dto: ClientListItemDTO): Client {
     contractStatus: dto.contract_status || user?.contract_status,
     hasSignedContract: dto.has_signed_contract ?? user?.has_signed_contract,
     paymentStatus: dto.payment_status || user?.payment_status,
-    hasCompletedPayment: dto.has_completed_payment ?? user?.has_completed_payment,
+    hasCompletedPayment:
+      dto.has_completed_payment ?? user?.has_completed_payment,
     ...mapEligibilityFromDto(dto, user),
   };
 }
@@ -171,7 +177,9 @@ export function mapClientDetail(dto: ClientDetailDTO): ClientDetail {
     lastName: dto.last_name,
     email: dto.email,
     phoneNumber: dto.phone_number,
-    status: ((dto.status || 'lead') === 'matching' ? 'matched' : (dto.status || 'lead')) as ClientStatus,
+    status: ((dto.status || 'lead') === 'matching'
+      ? 'matched'
+      : dto.status || 'lead') as ClientStatus,
     serviceNeeded: dto.service_needed,
     portalStatus: dto.portal_status,
     invitedAt: dto.invited_at,
@@ -222,11 +230,40 @@ export function mapClientDetail(dto: ClientDetailDTO): ClientDetail {
     secondaryPolicyNumber: dto.secondary_policy_number,
     selfPayCardInfo: dto.self_pay_card_info,
     homeType: dto.home_type ?? dto.home_types,
-    homeTypes: dto.home_types ?? (Array.isArray(dto.home_type) ? dto.home_type : undefined),
+    homeTypes:
+      dto.home_types ??
+      (Array.isArray(dto.home_type) ? dto.home_type : undefined),
     homeTypeOther: dto.home_type_other,
     homeAccess: dto.home_access,
     pets: dto.pets,
     homeAdultsCount: dto.home_adults_count,
     homeYouthCount: dto.home_youth_count,
+    servicesInterested: normalizeStringArrayFromApi(dto.services_interested),
+    serviceSupportDetails: dto.service_support_details,
+    serviceSpecifics: dto.service_specifics,
+    demographicsMulti: normalizeStringArrayFromApi(dto.demographics_multi),
+    preferredContactMethod: dto.preferred_contact_method,
+    preferredName: dto.preferred_name,
+    pronouns: dto.pronouns,
+    pronounsOther: dto.pronouns_other,
+    childrenExpected: dto.children_expected,
+    intakeAgeYears: dto.intake_age_years,
+    age: dto.age ?? dto.intake_age_years,
+    birthLocation: dto.birth_location,
+    birthHospital: dto.birth_hospital,
+    providerType: dto.provider_type,
+    primaryLanguage: dto.primary_language,
+    relationshipStatus: dto.relationship_status,
+    middleName: dto.middle_name,
+    mobilePhone: dto.mobile_phone,
+    workPhone: dto.work_phone,
+    city: dto.city,
+    state: dto.state,
+    zipCode: dto.zip_code,
+    address: dto.address ?? dto.address_line1,
+    referralSource: dto.referral_source,
+    referralSourceOther: dto.referral_source_other,
+    referralName: dto.referral_name,
+    referralEmail: dto.referral_email,
   };
 }

--- a/src/config/clientFieldRouting.ts
+++ b/src/config/clientFieldRouting.ts
@@ -84,6 +84,25 @@ const FIELD_ALIAS_MAP: Record<string, string> = {
   birthoutcomes: 'birth_outcomes',
   serviceNeeded: 'service_needed',
   serviceneeded: 'service_needed',
+  servicesInterested: 'services_interested',
+  serviceSupportDetails: 'service_support_details',
+  serviceSpecifics: 'service_specifics',
+  demographicsMulti: 'demographics_multi',
+  age: 'intake_age_years',
+  preferredContactMethod: 'preferred_contact_method',
+  preferredName: 'preferred_name',
+  pronounsOther: 'pronouns_other',
+  birthLocation: 'birth_location',
+  birthHospital: 'birth_hospital',
+  providerType: 'provider_type',
+  primaryLanguage: 'primary_language',
+  relationshipStatus: 'relationship_status',
+  middleName: 'middle_name',
+  mobilePhone: 'mobile_phone',
+  workPhone: 'work_phone',
+  referralSource: 'referral_source',
+  referralName: 'referral_name',
+  referralEmail: 'referral_email',
   childrenExpected: 'children_expected',
   childrenexpected: 'children_expected',
   portalStatus: 'portal_status',
@@ -134,9 +153,7 @@ export function normalizeClientFieldKey(key: string): string {
   return FIELD_ALIAS_MAP[key] ?? key;
 }
 
-export function splitClientUpdatePayload(
-  updateData: Record<string, unknown>
-): {
+export function splitClientUpdatePayload(updateData: Record<string, unknown>): {
   phi: Record<string, unknown>;
   operational: Record<string, unknown>;
   billing: Record<string, unknown>;

--- a/src/domain/client.ts
+++ b/src/domain/client.ts
@@ -10,7 +10,12 @@ import type {
   PortalBlocker,
 } from '@/lib/portalEligibility';
 
-export type { BillingPath, ClientEligibilityFields, PortalAllowedActions, PortalBlocker };
+export type {
+  BillingPath,
+  ClientEligibilityFields,
+  PortalAllowedActions,
+  PortalBlocker,
+};
 
 export type ClientStatus =
   | 'lead'
@@ -183,4 +188,32 @@ export interface ClientDetail {
   pets?: string;
   homeAdultsCount?: string;
   homeYouthCount?: string;
+  /** Intake — services requested */
+  servicesInterested?: string[];
+  serviceSupportDetails?: string;
+  serviceSpecifics?: string;
+  demographicsMulti?: string[];
+  preferredContactMethod?: string;
+  preferredName?: string;
+  pronouns?: string;
+  pronounsOther?: string;
+  childrenExpected?: string;
+  intakeAgeYears?: number;
+  age?: number;
+  birthLocation?: string;
+  birthHospital?: string;
+  providerType?: string;
+  primaryLanguage?: string;
+  relationshipStatus?: string;
+  middleName?: string;
+  mobilePhone?: string;
+  workPhone?: string;
+  city?: string;
+  state?: string;
+  zipCode?: string;
+  address?: string;
+  referralSource?: string;
+  referralSourceOther?: string;
+  referralName?: string;
+  referralEmail?: string;
 }

--- a/src/features/clients/components/dialog/LeadProfileModal.tsx
+++ b/src/features/clients/components/dialog/LeadProfileModal.tsx
@@ -121,6 +121,11 @@ import {
   singleHomeTypeFromApi,
   toggleHomeTypeSelection,
 } from '@/features/request/homeTypeOptions';
+import {
+  normalizeStringArrayFromApi,
+  readProfileFieldFromRecord,
+  PROFILE_FIELD_CAMEL_ALIASES,
+} from '@/features/clients/utils/profileArrayFields';
 
 interface LeadProfileModalProps {
   open: boolean;
@@ -666,7 +671,10 @@ export function LeadProfileModal({
     const homeType = JSON.stringify(
       d.home_types ?? d.homeTypes ?? d.home_type ?? d.homeType ?? ''
     );
-    return `${clientId}|${phone}|${service}|${dueDate}|${homeType}`;
+    const servicesInterested = JSON.stringify(
+      d.services_interested ?? d.servicesInterested ?? ''
+    );
+    return `${clientId}|${phone}|${service}|${dueDate}|${homeType}|${servicesInterested}`;
   }, [detailSource, client?.id]);
 
   const hasInsuranceDetails = hasAnyInsuranceDetails(
@@ -828,6 +836,54 @@ export function LeadProfileModal({
     if (rawHomeYouth !== undefined) {
       initializedData.home_youth_count = rawHomeYouth;
     }
+    const rawServicesInterested = d.services_interested ?? d.servicesInterested;
+    if (
+      rawServicesInterested !== undefined &&
+      rawServicesInterested !== null &&
+      !(
+        Array.isArray(rawServicesInterested) &&
+        rawServicesInterested.length === 0
+      )
+    ) {
+      initializedData.services_interested = normalizeStringArrayFromApi(
+        rawServicesInterested
+      );
+    }
+    const rawServiceSupport = stripRedacted(
+      (d.service_support_details ?? d.serviceSupportDetails) as
+        | string
+        | undefined
+    );
+    if (rawServiceSupport !== undefined) {
+      initializedData.service_support_details = rawServiceSupport;
+    }
+    const rawServiceSpecifics = stripRedacted(
+      (d.service_specifics ?? d.serviceSpecifics) as string | undefined
+    );
+    if (rawServiceSpecifics !== undefined) {
+      initializedData.service_specifics = rawServiceSpecifics;
+    }
+    const rawDemographicsMulti = d.demographics_multi ?? d.demographicsMulti;
+    if (
+      rawDemographicsMulti !== undefined &&
+      rawDemographicsMulti !== null &&
+      !(
+        Array.isArray(rawDemographicsMulti) && rawDemographicsMulti.length === 0
+      )
+    ) {
+      initializedData.demographics_multi =
+        normalizeStringArrayFromApi(rawDemographicsMulti);
+    }
+    const rawAge = d.age ?? d.intake_age_years ?? d.intakeAgeYears;
+    if (rawAge !== undefined && rawAge !== null && rawAge !== '') {
+      initializedData.age = Number(rawAge);
+    }
+    const rawChildrenExpected = stripRedacted(
+      (d.children_expected ?? d.childrenExpected) as string | undefined
+    );
+    if (rawChildrenExpected !== undefined) {
+      initializedData.children_expected = rawChildrenExpected;
+    }
     console.log('🔍 [Init] Final initializedData:', {
       phoneNumber: initializedData.phoneNumber,
       phone_number: (initializedData as any).phone_number,
@@ -901,9 +957,17 @@ export function LeadProfileModal({
       const updateData: any = {};
       const changedFields: string[] = [];
 
-      // Check which fields have changed by comparing with original client data
+      // Check which fields have changed by comparing with loaded profile baseline
+      const originalSource: Record<string, unknown> = {
+        ...(client as Record<string, unknown>),
+        ...(detailSource ?? {}),
+      };
       Object.keys(editedData).forEach((key) => {
-        const originalValue = client[key as keyof Client];
+        const alias = PROFILE_FIELD_CAMEL_ALIASES[key];
+        const originalValue =
+          originalSource[key] ??
+          (alias ? originalSource[alias] : undefined) ??
+          client[key as keyof Client];
         const newValue = editedData[key as keyof Client];
 
         // Skip fields that are in editedData but not meaningful for updates
@@ -921,10 +985,8 @@ export function LeadProfileModal({
 
         // Handle array comparisons
         if (Array.isArray(newValue)) {
-          const originalArray = Array.isArray(originalValue)
-            ? originalValue
-            : [];
-          const originalSorted = originalArray.sort().join(',');
+          const originalArray = normalizeStringArrayFromApi(originalValue);
+          const originalSorted = [...originalArray].sort().join(',');
           const newSorted = [...newValue].sort().join(',');
           if (originalSorted !== newSorted) {
             updateData[key] = newValue;
@@ -1047,6 +1109,20 @@ export function LeadProfileModal({
           updateData.home_type_other = '';
           if (!changedFields.includes('home_type_other')) {
             changedFields.push('home_type_other');
+          }
+        }
+      }
+
+      if (
+        updateData.age !== undefined &&
+        updateData.age !== null &&
+        updateData.age !== ''
+      ) {
+        const parsedAge = Number(updateData.age);
+        if (!Number.isNaN(parsedAge)) {
+          updateData.intake_age_years = parsedAge;
+          if (!changedFields.includes('intake_age_years')) {
+            changedFields.push('intake_age_years');
           }
         }
       }
@@ -1802,6 +1878,61 @@ export function LeadProfileModal({
     [eligibilitySource]
   );
 
+  const resolveProfileFieldValue = (
+    fieldKey: string,
+    altKey: string | null,
+    inputType:
+      | 'text'
+      | 'email'
+      | 'tel'
+      | 'textarea'
+      | 'select'
+      | 'multiselect'
+      | 'singleselect'
+      | 'date'
+      | 'number'
+  ): unknown => {
+    const isEmptyScalar = (v: unknown) =>
+      v === null || v === undefined || v === '';
+    const isEmptyArray = (v: unknown) => Array.isArray(v) && v.length === 0;
+    const isMultiselect =
+      inputType === 'multiselect' ||
+      fieldKey === 'services_interested' ||
+      fieldKey === 'demographics_multi';
+
+    const fromEdited =
+      (altKey ? editedData[altKey as keyof Client] : undefined) ??
+      editedData[fieldKey as keyof Client];
+    if (!isEmptyScalar(fromEdited) && !isEmptyArray(fromEdited)) {
+      return isMultiselect
+        ? normalizeStringArrayFromApi(fromEdited)
+        : fromEdited;
+    }
+
+    const fromDetail = readProfileFieldFromRecord(detailSource, fieldKey);
+    if (!isEmptyScalar(fromDetail) && !isEmptyArray(fromDetail)) {
+      return isMultiselect
+        ? normalizeStringArrayFromApi(fromDetail)
+        : fromDetail;
+    }
+
+    const fromClient = readProfileFieldFromRecord(
+      client as Record<string, unknown> | null,
+      fieldKey
+    );
+    if (!isEmptyScalar(fromClient) && !isEmptyArray(fromClient)) {
+      return isMultiselect
+        ? normalizeStringArrayFromApi(fromClient)
+        : fromClient;
+    }
+
+    if (altKey !== null || fieldKey === 'referral_source') {
+      return getDisplayValue(fieldKey, altKey);
+    }
+
+    return isMultiselect ? [] : '';
+  };
+
   const renderEditableField = (
     label: string,
     fieldKey: string,
@@ -1850,10 +1981,11 @@ export function LeadProfileModal({
                                 : fieldKey === 'insurance_plan_type'
                                   ? 'insurancePlanType'
                                   : null;
-    let value: string | Date | unknown =
-      altKey !== null || fieldKey === 'referral_source'
-        ? getDisplayValue(fieldKey, altKey)
-        : (editedData[fieldKey] ?? '');
+    let value: string | Date | unknown = resolveProfileFieldValue(
+      fieldKey,
+      altKey,
+      type
+    );
     if (fieldKey === 'home_type') {
       value =
         editedData.home_type !== undefined
@@ -1947,9 +2079,7 @@ export function LeadProfileModal({
                   const multiValue =
                     fieldKey === 'home_type'
                       ? singleHomeTypeFromApi(value)
-                      : Array.isArray(value)
-                        ? value
-                        : [];
+                      : normalizeStringArrayFromApi(value);
                   const isSelected = multiValue.includes(option);
                   return (
                     <Button
@@ -1963,9 +2093,7 @@ export function LeadProfileModal({
                         const currentArray =
                           fieldKey === 'home_type'
                             ? singleHomeTypeFromApi(value)
-                            : Array.isArray(value)
-                              ? value
-                              : [];
+                            : normalizeStringArrayFromApi(value);
                         const newArray =
                           fieldKey === 'home_type'
                             ? type === 'singleselect'
@@ -2004,7 +2132,7 @@ export function LeadProfileModal({
               {!isEditing &&
                 (fieldKey === 'home_type'
                   ? singleHomeTypeFromApi(value).length === 0
-                  : !value || (Array.isArray(value) && value.length === 0)) && (
+                  : normalizeStringArrayFromApi(value).length === 0) && (
                   <div className='text-sm text-muted-foreground mt-2'>
                     No options selected
                   </div>

--- a/src/features/clients/utils/profileArrayFields.ts
+++ b/src/features/clients/utils/profileArrayFields.ts
@@ -1,0 +1,92 @@
+/** Normalize API / legacy values to a string array for profile multiselect fields. */
+export function normalizeStringArrayFromApi(raw: unknown): string[] {
+  if (Array.isArray(raw)) {
+    return raw.filter(
+      (item): item is string => typeof item === 'string' && item.trim() !== ''
+    );
+  }
+  if (typeof raw === 'string') {
+    const trimmed = raw.trim();
+    if (!trimmed) return [];
+    if (trimmed.startsWith('[')) {
+      try {
+        const parsed = JSON.parse(trimmed) as unknown;
+        if (Array.isArray(parsed)) {
+          return normalizeStringArrayFromApi(parsed);
+        }
+      } catch {
+        /* fall through */
+      }
+    }
+    if (trimmed.includes(',')) {
+      return trimmed
+        .split(',')
+        .map((part) => part.trim())
+        .filter(Boolean);
+    }
+    return [trimmed];
+  }
+  return [];
+}
+
+/** snake_case form field → camelCase key on ClientDetail / fetched detail. */
+export const PROFILE_FIELD_CAMEL_ALIASES: Record<string, string> = {
+  preferred_contact_method: 'preferredContactMethod',
+  preferred_name: 'preferredName',
+  pronouns_other: 'pronounsOther',
+  children_expected: 'childrenExpected',
+  intake_age_years: 'intakeAgeYears',
+  home_type: 'homeType',
+  home_types: 'homeTypes',
+  home_type_other: 'homeTypeOther',
+  home_access: 'homeAccess',
+  home_adults_count: 'homeAdultsCount',
+  home_youth_count: 'homeYouthCount',
+  services_interested: 'servicesInterested',
+  service_support_details: 'serviceSupportDetails',
+  service_specifics: 'serviceSpecifics',
+  service_needed: 'serviceNeeded',
+  demographics_multi: 'demographicsMulti',
+  annual_income: 'annualIncome',
+  relationship_status: 'relationshipStatus',
+  middle_name: 'middleName',
+  mobile_phone: 'mobilePhone',
+  work_phone: 'workPhone',
+  referral_source: 'referralSource',
+  referral_source_other: 'referralSourceOther',
+  referral_name: 'referralName',
+  referral_email: 'referralEmail',
+  due_date: 'dueDate',
+  birth_location: 'birthLocation',
+  birth_hospital: 'birthHospital',
+  number_of_babies: 'numberOfBabies',
+  baby_name: 'babyName',
+  provider_type: 'providerType',
+  pregnancy_number: 'pregnancyNumber',
+  health_history: 'healthHistory',
+  health_notes: 'healthNotes',
+  had_previous_pregnancies: 'hadPreviousPregnancies',
+  previous_pregnancies_count: 'previousPregnanciesCount',
+  living_children_count: 'livingChildrenCount',
+  past_pregnancy_experience: 'pastPregnancyExperience',
+  race_ethnicity: 'raceEthnicity',
+  primary_language: 'primaryLanguage',
+  client_age_range: 'clientAgeRange',
+  zip_code: 'zipCode',
+  address_line1: 'addressLine1',
+};
+
+export function readProfileFieldFromRecord(
+  source: Record<string, unknown> | null | undefined,
+  fieldKey: string
+): unknown {
+  if (!source) return undefined;
+  if (fieldKey === 'age') {
+    return source.age ?? source.intake_age_years ?? source.intakeAgeYears;
+  }
+  if (fieldKey === 'address') {
+    return source.address ?? source.address_line1 ?? source.addressLine1;
+  }
+  const camelKey = PROFILE_FIELD_CAMEL_ALIASES[fieldKey];
+  return source[fieldKey] ?? (camelKey ? source[camelKey] : undefined);
+}


### PR DESCRIPTION
## Summary
- Add `resolveProfileFieldValue` so multiselect/scalar fields read from fetched client detail (fixes Services Interested showing empty)
- Map intake fields through DTO/mapper (`services_interested`, `birth_location`, `preferred_contact_method`, etc.)
- Route form `age` to `intake_age_years` on save; expand field routing aliases

Depends on backend PR #77 for GET response fields.

## Test plan
- [x] `npx tsc -p tsconfig.build.json`
- [ ] Lead Profile: Services Interested selections visible on open and after refresh
- [ ] Save birth location / preferred contact method and confirm after reload


Made with [Cursor](https://cursor.com)