### PR TITLE
Fix Vercel production build (getClientById types)

### DIFF
--- a/src/common/hooks/clients/useClients.ts
+++ b/src/common/hooks/clients/useClients.ts
@@ -60,16 +60,19 @@ export function useClients() {
   const getClientById = useCallback(
     async (
       id: string,
-      options?: { force?: boolean }
+      options?: { force?: boolean } | boolean
     ): Promise<ClientDetail | null> => {
-      const hasCached = !options?.force && !!getCachedClientDetail(id);
+      const normalizedOptions =
+        typeof options === 'boolean' ? { force: options } : options;
+      const hasCached =
+        !normalizedOptions?.force && !!getCachedClientDetail(id);
       if (!hasCached) {
         setIsLoading(true);
         setError(null);
       }
 
       try {
-        return await loadClientDetail(id, options);
+        return await loadClientDetail(id, normalizedOptions);
       } catch (err: unknown) {
         if (err instanceof ApiError) {
           if (isSessionExpiredError(err.status, err.message)) {

--- a/src/features/clients/Clients.tsx
+++ b/src/features/clients/Clients.tsx
@@ -36,6 +36,7 @@ import {
 } from '@/common/components/ui/tabs';
 import { fetchWithAuth, buildUrl } from '@/api/http';
 import { prefetchClientDetail } from '@/api/services/clientDetailCache';
+import type { ClientDetail } from '@/domain/client';
 
 type RouteParams = {
   clientId?: string;
@@ -495,7 +496,10 @@ function RouteAwareLeadProfileLoader({
   requestedClientId?: string;
   knownClients: UserSummary[];
   navigateToOnClose: string;
-  getClientById: (id: string, detailed?: boolean) => Promise<any>;
+  getClientById: (
+    id: string,
+    options?: { force?: boolean } | boolean
+  ) => Promise<ClientDetail | null>;
   attemptedRouteIdsRef: MutableRefObject<Set<string>>;
   setMissingClientId: React.Dispatch<React.SetStateAction<string | null>>;
   manualCloseRef: MutableRefObject<boolean>;


### PR DESCRIPTION
## Summary
- Fixes TypeScript build failure that blocked Vercel production deploy after #86
- `getClientById` accepts legacy `boolean` second arg and `{ force?: boolean }` options object
- Updates `RouteAwareLeadProfileLoader` prop typing to match

## Test plan
- [x] `npm run build` passes locally
- [ ] Vercel production deploy succeeds on merge


Made with [Cursor](https://cursor.com)