### PR TITLE
Harden Payment Schedule errors and admin-only CSV Export

### DIFF
--- a/src/api/http.ts
+++ b/src/api/http.ts
@@ -79,12 +79,23 @@ function normalizeError(
   parsed: unknown,
   response: Response
 ): { ok: false; status: number; message: string; code?: string } {
-  const message =
+  let message =
     typeof parsed === 'string'
       ? parsed
       : ((parsed as Record<string, unknown>)?.error ??
         (parsed as Record<string, unknown>)?.message ??
         response.statusText);
+  // Express default HTML 404 bodies must not surface in CRM UI.
+  const raw = String(message ?? '');
+  if (/<!DOCTYPE\s+html/i.test(raw) || /<html[\s>]/i.test(raw)) {
+    const preMatch = raw.match(/<pre>([\s\S]*?)<\/pre>/i);
+    message =
+      preMatch?.[1]?.trim() ||
+      response.statusText ||
+      `Request failed (${response.status})`;
+  } else {
+    message = raw;
+  }
   const code =
     typeof parsed === 'object' && parsed !== null
       ? (parsed as Record<string, unknown>)?.code

--- a/src/features/clients/components/data-table-toolbar.tsx
+++ b/src/features/clients/components/data-table-toolbar.tsx
@@ -9,15 +9,15 @@ import { UsersPrimaryButtons } from './users-primary-buttons';
 
 interface DataTableToolbarProps<TData> {
   table: Table<TData>;
+  /** @deprecated Unused; kept for call-site compatibility. */
   draggedTemplate?: Template | null;
+  /** @deprecated Unused; kept for call-site compatibility. */
   clients?: any[];
   viewMode?: 'leads' | 'customers';
 }
 
 export function DataTableToolbar<TData>({
   table,
-  draggedTemplate,
-  clients,
   viewMode = 'leads',
 }: DataTableToolbarProps<TData>) {
   const isFiltered = table.getState().columnFilters.length > 0;
@@ -57,7 +57,7 @@ export function DataTableToolbar<TData>({
           </Button>
         )}
       </div>
-      <UsersPrimaryButtons draggedTemplate={draggedTemplate ?? null} clients={clients} />
+      <UsersPrimaryButtons />
     </div>
   );
 }

--- a/src/features/clients/components/dialog/LeadProfileModal.tsx
+++ b/src/features/clients/components/dialog/LeadProfileModal.tsx
@@ -525,17 +525,36 @@ export function LeadProfileModal({
     setBillingLoading(true);
     setBillingError(null);
     try {
-      const [schedule, card] = await Promise.all([
-        fetchClientPaymentSchedule(String(client.id)),
-        fetchCardOnFileStatus(String(client.id)),
+      const clientId = String(client.id);
+      const [scheduleResult, cardResult] = await Promise.allSettled([
+        fetchClientPaymentSchedule(clientId),
+        fetchCardOnFileStatus(clientId),
       ]);
-      setInstallments(Array.isArray(schedule) ? schedule : []);
-      setCardStatus(card);
-    } catch (error) {
+
+      if (scheduleResult.status === 'fulfilled') {
+        setInstallments(
+          Array.isArray(scheduleResult.value) ? scheduleResult.value : []
+        );
+        setBillingError(null);
+      } else {
+        setInstallments([]);
+        // Never surface raw API/HTML bodies in this panel.
+        setBillingError(
+          'Payment schedule is temporarily unavailable. Try again later.'
+        );
+      }
+
+      // Card-on-file is informational; failures must not paint Payment Schedule red.
+      if (cardResult.status === 'fulfilled') {
+        setCardStatus(cardResult.value);
+      } else {
+        setCardStatus(null);
+      }
+    } catch {
+      setInstallments([]);
+      setCardStatus(null);
       setBillingError(
-        error instanceof Error
-          ? error.message
-          : 'Unable to load billing information.'
+        'Payment schedule is temporarily unavailable. Try again later.'
       );
     } finally {
       setBillingLoading(false);

--- a/src/features/clients/components/users-primary-buttons.tsx
+++ b/src/features/clients/components/users-primary-buttons.tsx
@@ -1,30 +1,19 @@
 import { Button } from '@/common/components/ui/button';
-import { Template } from '@/common/types/template';
 import { UserContext } from '@/common/contexts/UserContext';
 import { Send, SquarePlus } from 'lucide-react';
 import { useContext, useState } from 'react';
 import { EnhancedContractDialog } from './dialog/EnhancedContractDialog';
 import { fetchWithAuth, buildUrl } from '@/api/http';
 
-interface Props {
-  draggedTemplate: Template | null;
-  clients?: any[]; // Simple clients prop
-}
-
-export function UsersPrimaryButtons({
-  draggedTemplate,
-  clients = [],
-}: Props) {
-  const [isEnhancedContractDialogOpen, setIsEnhancedContractDialogOpen] = useState(false);
+export function UsersPrimaryButtons() {
+  const [isEnhancedContractDialogOpen, setIsEnhancedContractDialogOpen] =
+    useState(false);
   const { user } = useContext(UserContext);
   const canExportCsv = user?.role === 'admin';
 
   const fetchCSV = async () => {
     try {
-      const data = await fetchWithAuth(buildUrl('/clients/fetchCSV'), {
-        headers: {
-        },
-      });
+      const data = await fetchWithAuth(buildUrl('/clients/fetchCSV'));
 
       const csvData = await data.text();
       const blob = new Blob([csvData], { type: 'text/csv' });

--- a/src/features/clients/components/users-primary-buttons.tsx
+++ b/src/features/clients/components/users-primary-buttons.tsx
@@ -1,7 +1,8 @@
 import { Button } from '@/common/components/ui/button';
 import { Template } from '@/common/types/template';
+import { UserContext } from '@/common/contexts/UserContext';
 import { Send, SquarePlus } from 'lucide-react';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import { EnhancedContractDialog } from './dialog/EnhancedContractDialog';
 import { fetchWithAuth, buildUrl } from '@/api/http';
 
@@ -15,6 +16,8 @@ export function UsersPrimaryButtons({
   clients = [],
 }: Props) {
   const [isEnhancedContractDialogOpen, setIsEnhancedContractDialogOpen] = useState(false);
+  const { user } = useContext(UserContext);
+  const canExportCsv = user?.role === 'admin';
 
   const fetchCSV = async () => {
     try {
@@ -38,10 +41,12 @@ export function UsersPrimaryButtons({
   };
   return (
     <div className='ml-auto flex shrink-0 flex-wrap justify-end gap-2'>
-      <Button variant='outline' className='space-x-1' onClick={fetchCSV}>
-        <span>Export</span>
-        <SquarePlus size={18} />
-      </Button>
+      {canExportCsv ? (
+        <Button variant='outline' className='space-x-1' onClick={fetchCSV}>
+          <span>Export</span>
+          <SquarePlus size={18} />
+        </Button>
+      ) : null}
       <Button
         className='space-x-1'
         onClick={() => setIsEnhancedContractDialogOpen(true)}


### PR DESCRIPTION
## Summary
- Never surface Express HTML 404 bodies as red text in Lead Profile billing.
- Load payment schedule and card-on-file independently; card failures show `—` without breaking Payment Schedule.
- Show Clients **Export** only for `admin` (matches backend HIPAA-13A admin-only CSV).

Pairs with backend PR: always mount `/api/payment-methods` + admin-only CSV export.

## Test plan
- [ ] Open Lead Profile with `FEATURE_QUICKBOOKS=false` backend: no red HTML in Payment Schedule
- [ ] Card API failure → Card on file shows `—`; schedule still loads if available
- [ ] Schedule API failure → generic “temporarily unavailable” message only
- [ ] Non-admin users do not see Export button; admin still can


Made with [Cursor](https://cursor.com)