### PR TITLE
Improve profile photo upload UI and loading state

### DIFF
--- a/src/common/components/form/ProfileImageInput.tsx
+++ b/src/common/components/form/ProfileImageInput.tsx
@@ -1,0 +1,155 @@
+import UserAvatar from '@/common/components/user/UserAvatar';
+import { cn } from '@/lib/utils';
+import { Camera, ImagePlus, Loader2 } from 'lucide-react';
+import * as React from 'react';
+
+const DEFAULT_ACCEPT = 'image/jpeg,image/jpg,image/png,image/webp';
+
+export type ProfileImageInputProps = Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  'type' | 'onChange'
+> & {
+  selectedFile?: File | null;
+  currentImageUrl?: string | null;
+  fullName?: string;
+  isUploading?: boolean;
+  showAvatar?: boolean;
+  onFileChange: (file: File | undefined) => void;
+};
+
+export const ProfileImageInput = React.forwardRef<
+  HTMLInputElement,
+  ProfileImageInputProps
+>(function ProfileImageInput(
+  {
+    id,
+    accept = DEFAULT_ACCEPT,
+    disabled,
+    selectedFile,
+    currentImageUrl,
+    fullName = '',
+    isUploading = false,
+    showAvatar = false,
+    onFileChange,
+    className,
+    ...inputProps
+  },
+  ref
+) {
+  const generatedId = React.useId();
+  const inputId = id ?? generatedId;
+  const inputRef = React.useRef<HTMLInputElement | null>(null);
+  const isDisabled = Boolean(disabled || isUploading);
+  const hasExistingPhoto = Boolean(currentImageUrl);
+  const actionLabel = isUploading
+    ? 'Uploading...'
+    : hasExistingPhoto || selectedFile
+      ? 'Change photo'
+      : 'Click to upload photo';
+
+  const setInputRef = (node: HTMLInputElement | null) => {
+    inputRef.current = node;
+    if (typeof ref === 'function') {
+      ref(node);
+    } else if (ref) {
+      ref.current = node;
+    }
+  };
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    onFileChange(file || undefined);
+    event.target.value = '';
+  };
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-3',
+        showAvatar ? 'w-fit' : 'w-full',
+        className
+      )}
+    >
+      {showAvatar ? (
+        <label
+          htmlFor={inputId}
+          className={cn(
+            'relative flex w-fit flex-col items-center gap-2 group',
+            isDisabled ? 'pointer-events-none opacity-50' : 'cursor-pointer'
+          )}
+        >
+          <div className='relative rounded-full ring-2 ring-border group-hover:ring-primary transition-all'>
+            <UserAvatar
+              fullName={fullName}
+              className='h-24 w-24'
+              profile_picture={currentImageUrl || undefined}
+            />
+            <div
+              className={cn(
+                'absolute inset-0 flex items-center justify-center rounded-full transition-colors',
+                isUploading
+                  ? 'bg-black/50'
+                  : hasExistingPhoto || selectedFile
+                    ? 'bg-transparent group-hover:bg-black/50'
+                    : 'bg-black/30 group-hover:bg-black/40'
+              )}
+            >
+              {isUploading ? (
+                <Loader2 className='h-8 w-8 animate-spin text-white' />
+              ) : (
+                <Camera
+                  className={cn(
+                    'h-8 w-8 text-white',
+                    hasExistingPhoto || selectedFile
+                      ? 'opacity-0 group-hover:opacity-100'
+                      : 'opacity-100'
+                  )}
+                />
+              )}
+            </div>
+          </div>
+          <span className='text-sm font-medium text-primary group-hover:underline'>
+            {actionLabel}
+          </span>
+        </label>
+      ) : null}
+
+      <label
+        htmlFor={inputId}
+        className={cn(
+          'flex min-h-12 cursor-pointer items-center gap-3 rounded-lg border border-dashed border-input bg-background px-3 py-2 text-left shadow-xs transition-colors',
+          showAvatar ? 'w-fit max-w-xs' : 'w-full',
+          'hover:border-primary hover:bg-accent/50',
+          'has-[:focus-visible]:border-ring has-[:focus-visible]:ring-ring/50 has-[:focus-visible]:ring-[3px]',
+          isDisabled && 'pointer-events-none cursor-not-allowed opacity-50'
+        )}
+      >
+        <span className='inline-flex h-9 shrink-0 items-center justify-center gap-2 rounded-md bg-primary px-3 text-sm font-medium text-primary-foreground shadow-xs'>
+          {isUploading ? (
+            <Loader2 className='h-4 w-4 animate-spin' />
+          ) : (
+            <ImagePlus className='h-4 w-4' />
+          )}
+          {isUploading ? 'Uploading...' : 'Choose photo'}
+        </span>
+        <span className='min-w-0 text-sm text-muted-foreground'>
+          {isUploading
+            ? 'Uploading photo...'
+            : selectedFile
+              ? selectedFile.name
+              : 'No file chosen — JPEG, PNG, or WebP'}
+        </span>
+        <input
+          {...inputProps}
+          ref={setInputRef}
+          id={inputId}
+          type='file'
+          accept={accept}
+          disabled={isDisabled}
+          onChange={handleChange}
+          className='sr-only'
+        />
+      </label>
+    </div>
+  );
+});

--- a/src/common/components/user/UserAvatar.tsx
+++ b/src/common/components/user/UserAvatar.tsx
@@ -10,6 +10,18 @@ interface UserAvatarProps {
   fullName: string;
   className?: string;
   large?: boolean;
+  onLoadingStatusChange?: (
+    status: 'idle' | 'loading' | 'loaded' | 'error'
+  ) => void;
+}
+
+export function preloadProfileImage(src: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const image = new window.Image();
+    image.onload = () => resolve();
+    image.onerror = () => reject(new Error('Failed to load profile picture'));
+    image.src = src;
+  });
 }
 
 export default function UserAvatar({
@@ -17,6 +29,7 @@ export default function UserAvatar({
   fullName,
   className,
   large = false,
+  onLoadingStatusChange,
 }: UserAvatarProps) {
   // Handle undefined/null fullName
   const safeFullName = fullName || '';
@@ -39,6 +52,7 @@ export default function UserAvatar({
           src={profile_picture || ''}
           alt={`${fullName}'s profile`}
           className='size-full object-cover object-center'
+          onLoadingStatusChange={onLoadingStatusChange}
         />
         <AvatarFallback
           className={cn(

--- a/src/common/components/user/UserAvatar.tsx
+++ b/src/common/components/user/UserAvatar.tsx
@@ -33,12 +33,12 @@ export default function UserAvatar({
 }: UserAvatarProps) {
   // Handle undefined/null fullName
   const safeFullName = fullName || '';
-  const initials = safeFullName
-    .split(' ')
-    .filter((word) => word.length > 0)
-    .map((word) => word[0]?.toUpperCase())
-    .join('')
-    || '?';
+  const initials =
+    safeFullName
+      .split(' ')
+      .filter((word) => word.length > 0)
+      .map((word) => word[0]?.toUpperCase())
+      .join('') || '?';
 
   return (
     <div className={cn('flex items-center justify-center', className)}>

--- a/src/common/utils/saveUser.tsx
+++ b/src/common/utils/saveUser.tsx
@@ -11,7 +11,13 @@ export default async function saveUser(userData: FormData) {
       });
 
     if (!response.ok) {
-      throw new Error('Failed to save user');
+      const errorBody = (await response.json().catch(() => null)) as {
+        error?: string;
+        message?: string;
+      } | null;
+      throw new Error(
+        errorBody?.error || errorBody?.message || 'Failed to save user'
+      );
     }
     return await response.json();
   } catch (error) {

--- a/src/common/utils/saveUser.tsx
+++ b/src/common/utils/saveUser.tsx
@@ -4,11 +4,10 @@ import { logFailure } from '@/utils/safeLog';
 export default async function saveUser(userData: FormData) {
   try {
     const response = await fetchWithAuth(buildUrl('/users/update'), {
-        method: 'PUT',
-        headers: {
-        },
-        body: userData,
-      });
+      method: 'PUT',
+      headers: {},
+      body: userData,
+    });
 
     if (!response.ok) {
       const errorBody = (await response.json().catch(() => null)) as {

--- a/src/features/doula-dashboard/components/ProfileTab.tsx
+++ b/src/features/doula-dashboard/components/ProfileTab.tsx
@@ -25,8 +25,9 @@ import {
   type UpdateProfileData,
 } from '@/api/doulas/doulaService';
 import { toast } from 'sonner';
-import UserAvatar from '@/common/components/user/UserAvatar';
-import { Camera, X } from 'lucide-react';
+import { preloadProfileImage } from '@/common/components/user/UserAvatar';
+import { ProfileImageInput } from '@/common/components/form/ProfileImageInput';
+import { X } from 'lucide-react';
 import {
   ANOTHER_RACE_ETHNICITY,
   DOULA_RACE_ETHNICITY_OPTIONS,
@@ -291,15 +292,14 @@ export default function ProfileTab({ onProfileStatusChange }: ProfileTabProps) {
     });
   };
 
-  const handleProfilePictureChange = async (
-    e: React.ChangeEvent<HTMLInputElement>
-  ) => {
-    const file = e.target.files?.[0];
+  const handleProfilePictureChange = async (file?: File) => {
     if (!file) return;
     setIsUploadingPicture(true);
-    e.target.value = '';
     try {
       const updated = await uploadDoulaProfilePicture(file);
+      if (updated.profile_picture) {
+        await preloadProfileImage(updated.profile_picture);
+      }
       setProfile(updated);
       cachedProfile = updated;
       toast.success('Profile picture updated');
@@ -431,52 +431,15 @@ export default function ProfileTab({ onProfileStatusChange }: ProfileTabProps) {
       <Card>
         <CardHeader>
           <div className='flex items-center gap-4'>
-            <label
-              htmlFor='profile-picture-upload'
-              className='relative flex flex-col items-center gap-2 cursor-pointer group'
-            >
-              <div className='relative rounded-full ring-2 ring-border group-hover:ring-primary transition-all'>
-                <UserAvatar
-                  fullName={`${profile.firstname} ${profile.lastname}`}
-                  className='h-24 w-24'
-                  profile_picture={profile.profile_picture || undefined}
-                />
-                <div
-                  className={`absolute inset-0 flex items-center justify-center rounded-full transition-colors ${
-                    profile.profile_picture
-                      ? 'bg-transparent group-hover:bg-black/50'
-                      : 'bg-black/30 group-hover:bg-black/40'
-                  }`}
-                >
-                  {isUploadingPicture ? (
-                    <span className='text-white text-xs font-medium'>
-                      Uploading...
-                    </span>
-                  ) : (
-                    <Camera
-                      className={`h-8 w-8 text-white ${
-                        profile.profile_picture
-                          ? 'opacity-0 group-hover:opacity-100'
-                          : 'opacity-100'
-                      }`}
-                    />
-                  )}
-                </div>
-              </div>
-              <span className='text-sm font-medium text-primary group-hover:underline'>
-                {profile.profile_picture
-                  ? 'Change photo'
-                  : 'Click to upload photo'}
-              </span>
-              <input
-                id='profile-picture-upload'
-                type='file'
-                accept='image/jpeg,image/jpg,image/png,image/webp'
-                className='sr-only'
-                onChange={handleProfilePictureChange}
-                disabled={isUploadingPicture}
-              />
-            </label>
+            <ProfileImageInput
+              id='profile-picture-upload'
+              accept='image/jpeg,image/jpg,image/png,image/webp'
+              showAvatar
+              currentImageUrl={profile.profile_picture || undefined}
+              fullName={`${profile.firstname} ${profile.lastname}`}
+              isUploading={isUploadingPicture}
+              onFileChange={handleProfilePictureChange}
+            />
             <div>
               <CardTitle className='text-2xl'>
                 {profile.firstname} {profile.lastname}

--- a/src/features/doula-dashboard/components/ProfileTab.tsx
+++ b/src/features/doula-dashboard/components/ProfileTab.tsx
@@ -35,8 +35,8 @@ import {
   normalizeRaceEthnicityFromApi,
   RACE_ETHNICITY_FIELD_LABEL,
   toggleRaceEthnicitySelection,
-} from '../doulaDemographics';
-import type { ProfileCompletionStatus } from '../doulaDashboardTypes';
+} from '@/features/doula-dashboard/doulaDemographics';
+import type { ProfileCompletionStatus } from '@/features/doula-dashboard/doulaDashboardTypes';
 import { getDoulaSchedulingInfo } from '@/common/utils/doulaScheduling';
 
 interface ProfileTabProps {

--- a/src/features/my-account/components/UpdateProfile.tsx
+++ b/src/features/my-account/components/UpdateProfile.tsx
@@ -47,8 +47,7 @@ export const Profile = () => {
   });
   const selectedPicture = profileForm.watch('profile_picture');
   const isUploadingPicture =
-    isWaitingForRemoteImage ||
-    (isSaving && selectedPicture instanceof File);
+    isWaitingForRemoteImage || (isSaving && selectedPicture instanceof File);
   const displayPicture = heldPreviewUrl || user?.profile_picture;
 
   useEffect(() => {

--- a/src/features/my-account/components/UpdateProfile.tsx
+++ b/src/features/my-account/components/UpdateProfile.tsx
@@ -16,14 +16,16 @@ import {
   FormLabel,
   FormMessage,
 } from '@/common/components/ui/form';
-import { Input } from '@/common/components/ui/input';
 import { Separator } from '@/common/components/ui/separator';
 import { Textarea } from '@/common/components/ui/textarea';
-import UserAvatar from '@/common/components/user/UserAvatar';
+import UserAvatar, {
+  preloadProfileImage,
+} from '@/common/components/user/UserAvatar';
 import { useUser } from '@/common/hooks/user/useUser';
 import saveUser from '@/common/utils/saveUser';
+import { ProfileImageInput } from '@/common/components/form/ProfileImageInput';
 import { Loader2 } from 'lucide-react';
-import { ChangeEvent, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 
@@ -34,20 +36,37 @@ interface ProfileFormValues {
 
 export const Profile = () => {
   const { user, isLoading, checkAuth, setUser } = useUser();
+  const [isSaving, setIsSaving] = useState(false);
+  const [heldPreviewUrl, setHeldPreviewUrl] = useState<string | null>(null);
+  const [isWaitingForRemoteImage, setIsWaitingForRemoteImage] = useState(false);
 
   const profileForm = useForm<ProfileFormValues>({
     defaultValues: {
       bio: '',
     },
   });
+  const selectedPicture = profileForm.watch('profile_picture');
+  const isUploadingPicture =
+    isWaitingForRemoteImage ||
+    (isSaving && selectedPicture instanceof File);
+  const displayPicture = heldPreviewUrl || user?.profile_picture;
 
   useEffect(() => {
-    if (!user) return;
+    if (!(selectedPicture instanceof File)) return;
+    const previewUrl = URL.createObjectURL(selectedPicture);
+    setHeldPreviewUrl(previewUrl);
+    return () => {
+      URL.revokeObjectURL(previewUrl);
+    };
+  }, [selectedPicture]);
+
+  useEffect(() => {
+    if (!user || isSaving || isWaitingForRemoteImage) return;
     profileForm.reset({
       bio: user.bio || '',
       profile_picture: undefined,
     });
-  }, [user, profileForm]);
+  }, [user, profileForm, isSaving, isWaitingForRemoteImage]);
 
   const submitProfileForm = async (values: ProfileFormValues) => {
     if (!user?.id) return;
@@ -55,13 +74,34 @@ export const Profile = () => {
     const formData = new FormData();
     formData.append('id', user.id);
     formData.append('bio', values.bio ?? '');
-    formData.append('profile_picture', values.profile_picture ?? '');
+    if (values.profile_picture instanceof File) {
+      formData.append('profile_picture', values.profile_picture);
+    }
 
+    setIsSaving(true);
     try {
       const savedUser = await saveUser(formData);
-      toast.success('Changes saved.');
+      const uploadedPictureUrl =
+        typeof savedUser?.profile_picture === 'string' &&
+        savedUser.profile_picture.trim().length > 0
+          ? savedUser.profile_picture
+          : null;
+
       setUser((prev) => (prev ? { ...prev, ...savedUser } : savedUser));
+
+      if (values.profile_picture instanceof File && uploadedPictureUrl) {
+        setIsWaitingForRemoteImage(true);
+        await preloadProfileImage(uploadedPictureUrl);
+      }
+
+      toast.success('Changes saved.');
       await checkAuth({ silent: true });
+      if (uploadedPictureUrl) {
+        setUser((prev) =>
+          prev ? { ...prev, profile_picture: uploadedPictureUrl } : prev
+        );
+        setHeldPreviewUrl(null);
+      }
       profileForm.reset({
         bio: values.bio ?? '',
         profile_picture: undefined,
@@ -71,6 +111,9 @@ export const Profile = () => {
       toast.error(
         err instanceof Error ? err.message : 'Could not save changes.'
       );
+    } finally {
+      setIsSaving(false);
+      setIsWaitingForRemoteImage(false);
     }
   };
 
@@ -85,11 +128,18 @@ export const Profile = () => {
         <CardContent className='flex flex-col flex-1'>
           <Card>
             <CardContent>
-              <UserAvatar
-                profile_picture={user?.profile_picture}
-                fullName={`${user?.firstname || ''} ${user?.lastname || ''}`}
-                className={'h-35 w-35'}
-              />
+              <div className='relative w-fit'>
+                <UserAvatar
+                  profile_picture={displayPicture}
+                  fullName={`${user?.firstname || ''} ${user?.lastname || ''}`}
+                  className={'h-35 w-35'}
+                />
+                {isUploadingPicture ? (
+                  <div className='absolute inset-0 flex items-center justify-center rounded-full bg-black/50'>
+                    <Loader2 className='h-8 w-8 animate-spin text-white' />
+                  </div>
+                ) : null}
+              </div>
             </CardContent>
             <CardHeader>
               <CardTitle>{`${user?.firstname || ''} ${user?.lastname || ''}`}</CardTitle>
@@ -110,14 +160,12 @@ export const Profile = () => {
                   <FormItem>
                     <FormLabel>Profile Picture</FormLabel>
                     <FormControl>
-                      <Input
-                        type='file'
+                      <ProfileImageInput
                         accept='image/jpeg,image/png,image/webp'
-                        onChange={(e: ChangeEvent<HTMLInputElement>) => {
-                          const file = e.target.files?.[0];
-                          field.onChange(file || undefined);
-                        }}
-                        className='cursor-pointer'
+                        selectedFile={field.value}
+                        currentImageUrl={user?.profile_picture}
+                        isUploading={isUploadingPicture}
+                        onFileChange={(file) => field.onChange(file)}
                       />
                     </FormControl>
                     <FormMessage />
@@ -142,8 +190,12 @@ export const Profile = () => {
                 )}
               />
 
-              <Button type='submit' className='cursor-pointer mt-10'>
-                {isLoading ? (
+              <Button
+                type='submit'
+                className='cursor-pointer mt-10'
+                disabled={isUploadingPicture}
+              >
+                {isSaving ? (
                   <Loader2 className='h-4 w-4 animate-spin mx-auto' />
                 ) : (
                   'Save Changes'


### PR DESCRIPTION
## Summary
- Replace the native profile picture file input with a clickable Choose photo control on My Account and the doula profile tab.
- Show a loading overlay while a photo is saving, and keep the local preview until the uploaded image has loaded so the default avatar does not flash.
- Surface the API error message when `/users/update` fails.

## Test plan
- [ ] On My Account → Profile, confirm Choose photo looks like a button and accepts JPEG/PNG/WebP.
- [ ] Select a photo and save; confirm a spinner appears on the avatar and picker.
- [ ] After save, confirm the new photo appears without briefly showing initials/default avatar.
- [ ] On the doula dashboard profile tab, confirm the same picker and loading behavior.
- [ ] Confirm a failed save shows the server error instead of a generic message.


Made with [Cursor](https://cursor.com)