### PR TITLE
Fix Playwright smoke stub for birth-outcomes save

### DIFF
--- a/e2e/ticket6-birth-outcomes-required.spec.ts
+++ b/e2e/ticket6-birth-outcomes-required.spec.ts
@@ -163,9 +163,9 @@ test.describe('Ticket 6 — Birth Outcomes mandatory reminder (E2E)', () => {
       return route.continue();
     });
 
-    // ---- Client update endpoint used to save structured birth outcomes
+    // ---- Dedicated birth-outcomes endpoint used by updateClientBirthOutcomes
     await page.route(
-      `http://localhost:5050/clients/${clientId}`,
+      `**/clients/${clientId}/birth-outcomes**`,
       async (route) => {
         const req = route.request();
         if (req.method() !== 'PUT') return route.continue();


### PR DESCRIPTION
## Summary
- Playwright smoke failed on `main` after PR #92 because `e2e/ticket6-birth-outcomes-required.spec.ts` still stubbed `PUT /clients/:id`.
- The app now saves via `PUT /clients/:id/birth-outcomes`, so the stub never recorded the save and `Induction: Yes` never appeared.
- This updates the stub to the dedicated endpoint. Local run of the spec passed.

## Test plan
- [x] `npx playwright test e2e/ticket6-birth-outcomes-required.spec.ts --project=chromium`
- [ ] Confirm GitHub Actions Playwright smoke is green on this PR


Made with [Cursor](https://cursor.com)