### PR TITLE
Quiet CRM deep-link misses for intake email links

### DIFF
--- a/e2e/ticket6-birth-outcomes-required.spec.ts
+++ b/e2e/ticket6-birth-outcomes-required.spec.ts
@@ -163,9 +163,9 @@ test.describe('Ticket 6 — Birth Outcomes mandatory reminder (E2E)', () => {
       return route.continue();
     });
 
-    // ---- Client update endpoint used to save structured birth outcomes
+    // ---- Dedicated birth-outcomes endpoint used by updateClientBirthOutcomes
     await page.route(
-      `http://localhost:5050/clients/${clientId}`,
+      `**/clients/${clientId}/birth-outcomes**`,
       async (route) => {
         const req = route.request();
         if (req.method() !== 'PUT') return route.continue();

--- a/src/common/hooks/clients/useClients.ts
+++ b/src/common/hooks/clients/useClients.ts
@@ -68,7 +68,8 @@ export function useClients() {
         !normalizedOptions?.force && !!getCachedClientDetail(id);
       if (!hasCached) {
         setIsLoading(true);
-        setError(null);
+        // Do not clear list-level error here — a detail miss must not wipe or
+        // replace the clients-list error banner.
       }
 
       try {
@@ -77,13 +78,9 @@ export function useClients() {
         if (err instanceof ApiError) {
           if (isSessionExpiredError(err.status, err.message)) {
             setError(getSessionExpirationMessage());
-          } else {
-            setError(err.message);
           }
-        } else if (err instanceof Error) {
-          setError(err.message);
-        } else {
-          setError('An unknown error occurred');
+          // 404 / other detail failures: return null for the caller. Do not set
+          // list-level `error` (that banner is for getClients failures only).
         }
         return null;
       } finally {

--- a/src/features/clients/Clients.tsx
+++ b/src/features/clients/Clients.tsx
@@ -198,7 +198,6 @@ export default function Users() {
   }, [selectedLeadForPortal]);
 
   const handleResendInvite = useCallback(async (lead: UserSummary) => {
-
     try {
       // Get the frontend URL (production or current origin)
       const frontendUrl =
@@ -255,7 +254,6 @@ export default function Users() {
   }, []);
 
   const handleDisablePortal = useCallback(async (lead: UserSummary) => {
-
     try {
       const response = await fetchWithAuth(
         buildUrl(`/api/admin/clients/${lead.id}/portal/disable`),
@@ -481,11 +479,14 @@ function RouteAwareLeadProfileLoader({
         if (isCancelled) return;
 
         if (!fetchedClient) {
-          toast.error('Client profile not found.');
-          setMissingClientId(normalizedId);
+          // Missing / unauthorized deep-link: return to list quietly (no banner, no modal).
+          setMissingClientId(null);
           setCurrentRow(null);
-          setOpen('lead-profile');
+          setOpen(null);
           lastRequestedIdRef.current = normalizedId;
+          if (location.pathname !== navigateToOnClose) {
+            navigate(navigateToOnClose, { replace: true });
+          }
           return;
         }
 
@@ -495,11 +496,13 @@ function RouteAwareLeadProfileLoader({
         );
 
         if (!parsedClient) {
-          toast.error('Unable to load client profile.');
-          setMissingClientId(normalizedId);
+          setMissingClientId(null);
           setCurrentRow(null);
-          setOpen('lead-profile');
+          setOpen(null);
           lastRequestedIdRef.current = normalizedId;
+          if (location.pathname !== navigateToOnClose) {
+            navigate(navigateToOnClose, { replace: true });
+          }
           return;
         }
 
@@ -509,13 +512,16 @@ function RouteAwareLeadProfileLoader({
         setOpen('lead-profile');
         lastRequestedIdRef.current = normalizedId;
         setMissingClientId(null);
-      } catch (error) {
+      } catch {
         logFailure('clients', 'error_loading_client_from_deep_link');
-        toast.error('Failed to load client profile.');
-        setMissingClientId(normalizedId);
+        // Quiet fallback — do not surface list banner or not-found modal.
+        setMissingClientId(null);
         setCurrentRow(null);
-        setOpen('lead-profile');
+        setOpen(null);
         lastRequestedIdRef.current = normalizedId;
+        if (location.pathname !== navigateToOnClose) {
+          navigate(navigateToOnClose, { replace: true });
+        }
       } finally {
         if (!isCancelled) {
           setIsFetchingFromRoute(false);
@@ -539,6 +545,9 @@ function RouteAwareLeadProfileLoader({
     attemptedRouteIdsRef,
     setMissingClientId,
     manualCloseRef,
+    navigate,
+    navigateToOnClose,
+    location.pathname,
   ]);
 
   useEffect(() => {

--- a/src/features/clients/__tests__/useClients.test.tsx
+++ b/src/features/clients/__tests__/useClients.test.tsx
@@ -179,7 +179,7 @@ describe('useClients', () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    it('should handle client not found', async () => {
+    it('should handle client not found without setting list error', async () => {
       (global.fetch as any).mockResolvedValueOnce({
         ok: false,
         status: 404,
@@ -193,19 +193,25 @@ describe('useClients', () => {
       });
 
       expect(client).toBeNull();
-      expect(result.current.error).toBe('Client not found');
+      // Deep-link / detail 404 must not poison the clients list banner
+      expect(result.current.error).toBeNull();
     });
   });
 
   describe('Loading States', () => {
     it('should set loading state during fetch', async () => {
-      (global.fetch as any).mockImplementationOnce(() =>
-        new Promise(resolve =>
-          setTimeout(() => resolve({
-            ok: true,
-            text: async () => JSON.stringify({ success: true, data: [] }),
-          }), 100)
-        )
+      (global.fetch as any).mockImplementationOnce(
+        () =>
+          new Promise((resolve) =>
+            setTimeout(
+              () =>
+                resolve({
+                  ok: true,
+                  text: async () => JSON.stringify({ success: true, data: [] }),
+                }),
+              100
+            )
+          )
       );
 
       const { result } = renderHook(() => useClients());
@@ -240,7 +246,6 @@ describe('useClients', () => {
       });
 
       expect(result.current.error).toBe('Server error');
-      
 
       // Then, make a successful request
       (global.fetch as any).mockResolvedValueOnce({
@@ -257,4 +262,4 @@ describe('useClients', () => {
       });
     });
   });
-}); 
+});


### PR DESCRIPTION
## Summary
- When an email CRM deep-link targets a missing client, do not show the list error banner or Client Not Found modal.
- Quietly return to the clients list (supports HIPAA-13F email deep-links).

## Test plan
- [ ] `/admin/clients/<nonexistent-uuid>` → clients list, no banner/modal
- [ ] `/admin/clients/<real-lead-id>` → lead profile modal still opens


Made with [Cursor](https://cursor.com)